### PR TITLE
Fix 'yarn' and 'eslintrc' configuration files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,12 @@
   },
   "plugins": ["react", "@typescript-eslint"],
   "rules": {
-    "@typescript-eslint/no-non-null-assertion": "off"
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -69,5 +69,6 @@
     "eslint-plugin-react": "^7.31.1",
     "openapi-typescript-codegen": "^0.23.0",
     "prettier": "^2.7.1"
-  }
+  },
+  "packageManager": "yarn@1.22.19"
 }


### PR DESCRIPTION
1)
I understand you use `yarn` v1.
you not define it in `package.json`.
so if I run `yarn install` yarn automatically upgrade to v3.

so I define  the yarn version in `package.json`.

2)
in windows when I run the project, I get the error ` delete 'CR' prettier/prettier` in every file.
this happen because the git default settings in `core.autocrlf` is automatically convert them when we check out files.

to fix it I define  the `eslintrc` automatically choose the `endOfLine`.