### PR TITLE
ci: prevent workflow from failing on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-    - if: secrets.GITHUB_TOKEN
+      if: secrets.GITHUB_TOKEN
     - env:
         DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-map-search/open-bus-map-search"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+    - if: secrets.GITHUB_TOKEN
     - env:
         DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-map-search/open-bus-map-search"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,16 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
-      if: secrets.GITHUB_TOKEN
     - env:
         DOCKER_APP_IMAGE_NAME: "ghcr.io/hasadna/open-bus-map-search/open-bus-map-search"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         HASADNA_K8S_DEPLOY_KEY: ${{ secrets.HASADNA_K8S_DEPLOY_KEY }}
       run: |
+        # verify github token is set
+        if [ -z "${GITHUB_TOKEN}" ]; then
+          echo "GITHUB_TOKEN is not set"
+          exit 0
+        fi
         echo "${GITHUB_TOKEN}" | docker login ghcr.io -u hasadna --password-stdin &&\
         if docker pull "${DOCKER_APP_IMAGE_NAME}:latest"; then
           CACHE_FROM_ARG="--cache-from ${DOCKER_APP_IMAGE_NAME}:latest"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
+  timeout: 15 * 60 * 1000,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
# Description
when running on forks, secrets.GITHUB_TOKEN is not available. I don't want the contributors to see a giant red `x` next to their pull request. That's a bad developer experience. let's solve it

## Screenshots
irrelevant 
