### PR TITLE
fix: dockerfile to vite build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,5 @@
 node_modules
-build
+dist
 .dockerignore
 .gitignore
 Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 /coverage
 
 # production
-/build
+/dist
 
 # misc
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN yarn run build
 # Pulled March 21, 2023
 FROM nginx@sha256:aa0afebbb3cfa473099a62c4b32e9b3fb73ed23f2a75a65ce1d4b4f55a5c2ef2
 COPY nginx-default.conf /etc/nginx/conf.d/default.conf
-COPY --from=0 /app/build /usr/share/nginx/html
+COPY --from=0 /app/dist /usr/share/nginx/html


### PR DESCRIPTION
Vite build goes to a different directory - `/dist` instead of `/build`
@knightcube your approval will be appriciated
