### PR TITLE
refactor: avoid toSorted

### DIFF
--- a/src/pages/components/utils/index.ts
+++ b/src/pages/components/utils/index.ts
@@ -23,7 +23,7 @@ export const bySeverityHandler = (a: HourlyData, b: HourlyData) => {
 }
 
 export const sortByMode = (hourlyData: HourlyData[] = [], sortingMode: string) => {
-  return hourlyData.toSorted(sortingMode === 'hour' ? byHourHandler : bySeverityHandler)
+  return [...hourlyData].sort(sortingMode === 'hour' ? byHourHandler : bySeverityHandler)
 }
 
 export const mapColorByExecution = (planned: number, actual: number) => {


### PR DESCRIPTION
# Description
`toSorted` browser support isn't wide enough
not to mention node.js support
let's use `sort` for now

