### PR TITLE
Mobile updates

### DIFF
--- a/src/pages/components/header/Header.tsx
+++ b/src/pages/components/header/Header.tsx
@@ -5,9 +5,9 @@ import cn from 'classnames'
 export default function Header({ pages }: { pages: MenuPage[] }) {
   const [open, setOpen] = useState(false)
 
-  function dismiss() {
+  useCallback(function dismiss() {
     setOpen(false)
-  }
+  }, [])
   return (
     <header className={cn('header', { open })}>
       <div className="header-menu" onClick={() => setOpen(!open)}>

--- a/src/pages/components/header/Header.tsx
+++ b/src/pages/components/header/Header.tsx
@@ -5,6 +5,9 @@ import cn from 'classnames'
 export default function Header({ pages }: { pages: MenuPage[] }) {
   const [open, setOpen] = useState(false)
 
+  function dismiss() {
+    setOpen(false)
+  }
   return (
     <header className={cn('header', { open })}>
       <div className="header-menu" onClick={() => setOpen(!open)}>
@@ -13,7 +16,7 @@ export default function Header({ pages }: { pages: MenuPage[] }) {
         <div className="header-menu-line" />
       </div>
       <h1>דאטאבוס</h1>
-      <Menu pages={pages} />
+      <Menu pages={pages} shouldDismiss={dismiss} />
     </header>
   )
 }

--- a/src/pages/components/header/menu/Menu.tsx
+++ b/src/pages/components/header/menu/Menu.tsx
@@ -13,7 +13,7 @@ export type MenuPage = {
 function Menu({ pages, shouldDismiss }: { pages: MenuPage[]; shouldDismiss: () => void }) {
   const navigate = useNavigate()
   const { pathname: currpage } = useLocation()
-  const [isMobile, setIsMobile] = useState(window.innerWidth <= 768)
+  const isMobile= window.innerWidth <= 768
 
   console.log({ currpage, active: pages.map((p) => p.key === currpage) })
 

--- a/src/pages/components/header/menu/Menu.tsx
+++ b/src/pages/components/header/menu/Menu.tsx
@@ -3,15 +3,38 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import cn from 'classnames'
 import './menu.scss'
 
+import { useEffect, useState } from 'react'
+
 export type MenuPage = {
   label: string
   key: string
 }
 
-function Menu({ pages }: { pages: MenuPage[] }) {
+function Menu({ pages, shouldDismiss }: { pages: MenuPage[]; shouldDismiss: () => void }) {
   const navigate = useNavigate()
   const { pathname: currpage } = useLocation()
+  const [isMobile, setIsMobile] = useState(window.innerWidth <= 768)
+
   console.log({ currpage, active: pages.map((p) => p.key === currpage) })
+
+  function navigateTo(page: MenuPage, dismiss: boolean) {
+    page.key[0] === '/' ? navigate(page.key) : window.open(page.key, '_blank')
+    if (dismiss) {
+      shouldDismiss()
+    }
+  }
+
+  useEffect(() => {
+    function handleResize() {
+      setIsMobile(window.innerWidth <= 768)
+    }
+
+    window.addEventListener('resize', handleResize)
+
+    return () => {
+      window.removeEventListener('resize', handleResize)
+    }
+  }, [])
 
   return (
     <ul className="menu">
@@ -19,9 +42,7 @@ function Menu({ pages }: { pages: MenuPage[] }) {
         <li
           className={cn('menu-item', { active: currpage === page.key })}
           key={page.key}
-          onClick={() =>
-            page.key[0] === '/' ? navigate(page.key) : window.open(page.key, '_blank')
-          }>
+          onClick={() => navigateTo(page, isMobile)}>
           {page.label}
         </li>
       ))}

--- a/src/pages/dashboard/DashboardPage.scss
+++ b/src/pages/dashboard/DashboardPage.scss
@@ -61,3 +61,14 @@
         }
     }
 }
+
+@media (max-width: 768px) {
+  .date-picker-container {
+    flex-direction: column;
+  }
+  .widgets-container {
+    flex-direction: column;
+  }
+}
+
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -4221,10 +4221,10 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
-typescript@^4.7.4:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
 
 uglify-js@^3.1.4:
   version "3.17.4"


### PR DESCRIPTION
# Description

Some  simple layout changes so  both dashboard charts and nav bar will be visible on mobile
Dismiss the side menu on mobile when clicking

#16 

<img width="574" alt="Screenshot 2023-10-12 at 17 04 17" src="https://github.com/hasadna/open-bus-map-search/assets/1727247/00cb6fb3-3b70-43cd-a678-f693e1ae86e2">


<img width="574" alt="Screenshot 2023-10-12 at 17 04 26" src="https://github.com/hasadna/open-bus-map-search/assets/1727247/5ce0c792-2d1c-46c2-8a31-f1050a6e71cd">



* still has some issues with the historical schedule results.

* I think the side menu should be a popup and not part of the page layout
