### PR TITLE
hotfix: operatorRefField

### DIFF
--- a/src/api/useVehicleLocations.ts
+++ b/src/api/useVehicleLocations.ts
@@ -15,6 +15,7 @@ const config = {
   fromField: 'recorded_at_time_from',
   toField: 'recorded_at_time_to',
   lineRefField: 'siri_routes__line_ref',
+  operatorRefField: 'siri_routes__operator_ref',
 } as const
 
 type Dateable = Date | number | string | Moment
@@ -72,7 +73,8 @@ class LocationObservable {
       let url = config.apiUrl
       url += `&${config.fromField}=${formatTime(from)}&${config.toField}=${formatTime(to)}&limit=${
         config.limit * i
-      }&offset=${offset}&siri_routes__operator_ref=${operatorRef}`
+      }&offset=${offset}`
+      if (operatorRef) url += `&${config.operatorRefField}=${operatorRef}`
       if (lineRef) url += `&${config.lineRefField}=${lineRef}`
 
       const response = await fetchWithQueue(url)


### PR DESCRIPTION
# Description
we have an error - we send "operatorRefField=undefined" in our requests and it makes them fail on the backend side
## screenshots
![image](https://github.com/hasadna/open-bus-map-search/assets/11145132/b046419c-a441-482c-b45a-1ac29cb9a628)

