### PR TITLE
Reverse the timeline graph XAxis to be with  'ltr' orientation

### DIFF
--- a/src/pages/dashboard/ArrivalByTimeChart/ArrivalByTimeChart.tsx
+++ b/src/pages/dashboard/ArrivalByTimeChart/ArrivalByTimeChart.tsx
@@ -57,7 +57,7 @@ export default function ArrivalByTimeChart({
                   bottom: 5,
                 }}>
                 <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="gtfs_route_date" />
+                <XAxis dataKey="gtfs_route_date" reversed={true}/>
                 <YAxis />
                 <Tooltip
                   content={({ payload }) =>

--- a/src/pages/dashboard/ArrivalByTimeChart/ArrivalByTimeChart.tsx
+++ b/src/pages/dashboard/ArrivalByTimeChart/ArrivalByTimeChart.tsx
@@ -57,7 +57,7 @@ export default function ArrivalByTimeChart({
                   bottom: 5,
                 }}>
                 <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="gtfs_route_date" reversed={true}/>
+                <XAxis dataKey="gtfs_route_date" reversed={true} />
                 <YAxis />
                 <Tooltip
                   content={({ payload }) =>


### PR DESCRIPTION
# Description

The timeline graph at the dashboard (אחוזי יציאה מסך הנסיעות לפי זמן) was changed to be **ltr** even though the application is in Hebrew (basically with **rtl** orientation.

See the screenshot below.

This one closes the issue #139 


## screenshots

![image](https://github.com/hasadna/open-bus-map-search/assets/52656401/81db9ce9-26d9-477c-bd65-fb8e73809372)


