### PR TITLE
refactor: import pages directly to menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,7 +107,7 @@ const App = () => {
           <LocalizationProvider dateAdapter={AdapterMoment} adapterLocale="he">
             <ConfigProvider direction="rtl" locale={heIL}>
               <StyledLayout className="main">
-                <SideBar pages={PAGES} />
+                <SideBar />
                 <Layout>
                   <StyledContent>
                     <StyledBody>

--- a/src/pages/components/header/sidebar/SideBar.tsx
+++ b/src/pages/components/header/sidebar/SideBar.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import Menu, { MenuPage } from '../menu/Menu'
+import Menu from './menu/Menu'
 import { MenuOutlined } from '@ant-design/icons'
 import './sidebar.scss'
 import cn from 'classnames'
@@ -12,13 +12,13 @@ const SidebarToggle = ({ open, setOpen }: { open: boolean; setOpen: (open: boole
 
 const Logo = () => <h1 className={'sidebar-logo'}>דאטאבוס</h1>
 
-export default function SideBar({ pages }: { pages: MenuPage[] }) {
+export default function SideBar() {
   const [open, setOpen] = useState(false)
   return (
     <aside className={cn('sidebar', { open })}>
       <Logo />
       <SidebarToggle open={open} setOpen={setOpen} />
-      <Menu pages={pages} />
+      <Menu />
     </aside>
   )
 }

--- a/src/pages/components/header/sidebar/menu/Menu.tsx
+++ b/src/pages/components/header/sidebar/menu/Menu.tsx
@@ -3,16 +3,9 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import cn from 'classnames'
 import './menu.scss'
 import { useTranslation } from 'react-i18next'
-import { IconBaseProps } from '@ant-design/icons/lib/components/Icon'
+import { PAGES as pages } from 'src/routes'
 
-export type MenuPage = {
-  label: string
-  key: string
-  searchParamsRequired?: boolean
-  icon: string | React.FunctionComponent<IconBaseProps>
-}
-
-function Menu({ pages }: { pages: MenuPage[] }) {
+const Menu: React.FC = () => {
   const { t, i18n } = useTranslation()
 
   const [currentLanguage, setCurrentLanguage] = useState('en')

--- a/src/pages/components/header/sidebar/menu/Menu.tsx
+++ b/src/pages/components/header/sidebar/menu/Menu.tsx
@@ -5,7 +5,7 @@ import './menu.scss'
 import { useTranslation } from 'react-i18next'
 import { PAGES as pages } from 'src/routes'
 
-const Menu: React.FC = () => {
+const Menu = () => {
   const { t, i18n } = useTranslation()
 
   const [currentLanguage, setCurrentLanguage] = useState('en')

--- a/src/pages/components/header/sidebar/menu/menu.scss
+++ b/src/pages/components/header/sidebar/menu/menu.scss
@@ -1,4 +1,4 @@
-@import '../../../../resources/variables';
+@import '../../../../../resources/variables';
 
 .menu {
     flex-direction: column;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -21,7 +21,14 @@ import {
   LineChartOutlined,
 } from '@ant-design/icons'
 
-import { MenuPage } from '../pages/components/header/menu/Menu'
+import { IconBaseProps } from '@ant-design/icons/lib/components/Icon'
+
+export type MenuPage = {
+  label: string
+  key: string
+  searchParamsRequired?: boolean
+  icon: string | React.FC<IconBaseProps>
+}
 
 export const PAGES = [
   {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -21,15 +21,6 @@ import {
   LineChartOutlined,
 } from '@ant-design/icons'
 
-import { IconBaseProps } from '@ant-design/icons/lib/components/Icon'
-
-export type MenuPage = {
-  label: string
-  key: string
-  searchParamsRequired?: boolean
-  icon: string | React.FC<IconBaseProps>
-}
-
 export const PAGES = [
   {
     label: TEXT_KEYS.dashboard_page_title,
@@ -79,7 +70,7 @@ export const PAGES = [
     key: 'https://www.jgive.com/new/he/ils/donation-targets/3268#donation-modal',
     icon: DollarOutlined,
   },
-] as MenuPage[]
+]
 
 const RoutesList = () => {
   const RedirectToDashboard = () => <Navigate to={PAGES[0].key} replace />


### PR DESCRIPTION
# Description
currently menus (pages) list passed from App to Sidebar and then to Menu component
this can be simplified
by importing the pages constant directly from router file
closes #182 
## screenshots
<paste here>