### PR TITLE
issue #205: GitHub repo link

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -68,5 +68,6 @@
   "mr_meir": "Mr. Asher Meir",
   "innovation_authority": "Innovation Authority",
   "migdal_company": "\"A tower in the community\"",
-  "and_smaller_donors": "And other small contributions from my friends and fans of the workshop."
+  "and_smaller_donors": "And other small contributions from my friends and fans of the workshop.",
+  "github_link": "Go to GitHub"
 }

--- a/src/locale/he.json
+++ b/src/locale/he.json
@@ -68,5 +68,7 @@
   "innovation_authority": "רשות החדשנות",
   "migdal_company": "“מגדל בקהילה“",
   "and_smaller_donors": "ותרומות קטנות נוספות של ידידי ואוהדי הסדנא.",
-  "gaps_patterns_page_title": "דפוסי נסיעות שלא יצאו"
+  "gaps_patterns_page_title": "דפוסי נסיעות שלא יצאו",
+  "github_link": "למעבר אל GitHub"
+
 }

--- a/src/pages/components/header/sidebar/GitHubLink/GitHubLink.scss
+++ b/src/pages/components/header/sidebar/GitHubLink/GitHubLink.scss
@@ -1,0 +1,12 @@
+.github-link {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 2em; 
+  cursor: pointer;
+
+
+  &:hover {
+    transform: scale(1.1); 
+  }
+}

--- a/src/pages/components/header/sidebar/GitHubLink/GitHubLink.tsx
+++ b/src/pages/components/header/sidebar/GitHubLink/GitHubLink.tsx
@@ -1,11 +1,14 @@
 import React from 'react'
 import { GithubOutlined } from '@ant-design/icons'
 import { TEXT_KEYS } from 'src/resources/texts'
+import { useTranslation } from 'react-i18next'
 import './GitHubLink.scss'
 
 export default function GitHubLink() {
+  const { t } = useTranslation()
+
   const data = {
-    label: TEXT_KEYS.github_link,
+    label: t(TEXT_KEYS.github_link),
     path: 'https://github.com/hasadna/open-bus-map-search',
     icon: <GithubOutlined />,
     element: null,

--- a/src/pages/components/header/sidebar/GitHubLink/GitHubLink.tsx
+++ b/src/pages/components/header/sidebar/GitHubLink/GitHubLink.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { GithubOutlined } from '@ant-design/icons'
+import { TEXT_KEYS } from 'src/resources/texts'
+import './GitHubLink.scss'
+
+export default function GitHubLink() {
+  const data = {
+    label: TEXT_KEYS.github_link,
+    path: 'https://github.com/hasadna/open-bus-map-search',
+    icon: <GithubOutlined />,
+    element: null,
+  }
+
+  const handleClick = () => {
+    window.open(data.path, '_blank')
+  }
+
+  return (
+    <div className="github-link" onClick={handleClick}>
+      {data.icon}
+    </div>
+  )
+}

--- a/src/pages/components/header/sidebar/SideBar.tsx
+++ b/src/pages/components/header/sidebar/SideBar.tsx
@@ -3,6 +3,7 @@ import './sidebar.scss'
 import { Drawer } from 'antd'
 import { useContext } from 'react'
 import { LayoutContextInterface, LayoutCtx } from 'src/layout/LayoutContext'
+import GitHubLink from './GitHubLink/GitHubLink'
 
 const Logo = () => (
   <div style={{ overflow: 'hidden' }}>
@@ -22,11 +23,18 @@ export default function SideBar() {
         onClose={() => setDrawerOpen(false)}
         open={drawerOpen}
         className="hideOnDesktop">
+        <Logo />
+        <div className="sidebar-divider"></div>
         <Menu />
+        <div className="sidebar-divider"></div>
+        <GitHubLink />
       </Drawer>
       <aside className={'sidebar hideOnMobile'}>
         <Logo />
+        <div className="sidebar-divider"></div>
         <Menu />
+        <div className="sidebar-divider"></div>
+        <GitHubLink />
       </aside>
     </>
   )

--- a/src/pages/components/header/sidebar/sidebar.scss
+++ b/src/pages/components/header/sidebar/sidebar.scss
@@ -96,3 +96,14 @@
     padding-bottom: 0;
     line-height: 25px;
 }
+
+.sidebar-section {
+  display: flex;
+  flex-direction: column;
+}
+
+.sidebar-divider {
+  height: 1px;
+  background-color: #ccc; 
+  margin: 8px 0; 
+}

--- a/src/resources/texts.tsx
+++ b/src/resources/texts.tsx
@@ -74,6 +74,7 @@ export const TEXT_KEYS = {
   migdal_company: 'migdal_company',
   and_smaller_donors: 'and_smaller_donors',
   gaps_patterns_page_title: 'gaps_patterns_page_title',
+  github_link: 'github_link',
 }
 
 export const TEXTS = {
@@ -179,6 +180,7 @@ export const TEXTS = {
   show_document: 'הצג מידע לגיקים',
   bearing: 'מעלות',
   kmh: 'קמ״ש',
+  github_link: 'github_link',
 }
 
 export const formatted = (text: string, value: string) => text.replace(PLACEHOLDER, value)


### PR DESCRIPTION
Resolving #205 

# Description

Mobile:
- Add a logo to the sidebar menu.

Mobile & Desktop:
- Add a GitHub icon that navigates to the repo link.
- Add dividers to the sidebar menu.

## screenshots
Desktop:

![image](https://github.com/hasadna/open-bus-map-search/assets/107395990/9f1a583d-601f-4ea3-b6d4-5ff2c1359f49)

Mobile:
![image](https://github.com/hasadna/open-bus-map-search/assets/107395990/c88fe891-0d34-4f93-bfcb-91b56d0c6287)
