### PR TITLE
refactor: move widget util to shared folder

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,6 +1,7 @@
 // import hebbo:
 @import 'https://fonts.googleapis.com/css?family=Heebo:400,500,700&display=swap';
 @import './resources/variables.scss';
+@import './shared/shared.css';
 
 .main {
     flex-direction: row;

--- a/src/pages/components/Widget.stories.tsx
+++ b/src/pages/components/Widget.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { BusToolTip } from './MapLayers/BusToolTip'
-import '../dashboard/DashboardPage.scss'
+import '../../shared/shared.css'
 const meta = {
   title: 'Components/Widget',
   component: () => (

--- a/src/pages/dashboard/DashboardPage.scss
+++ b/src/pages/dashboard/DashboardPage.scss
@@ -8,12 +8,6 @@
 }
 
 .widget {
-  border: 1px solid #e0e0e0;
-  border-radius: 4px;
-  padding: 20px;
-  box-sizing: border-box;
-  margin-bottom: 20px;
-  background-color: white;
 
   .chart {
     height: 400px;

--- a/src/shared/shared.css
+++ b/src/shared/shared.css
@@ -1,0 +1,8 @@
+.widget {
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+  padding: 20px;
+  box-sizing: border-box;
+  margin-bottom: 20px;
+  background-color: white;
+}


### PR DESCRIPTION
# Description
snice widget util (it also can be called `card`) used in multiple places
i think - it can be better to moved it to `shared` folder

## screenshots
not relevant here