### PR TITLE
fix: Use Only Relevant Routes

### DIFF
--- a/src/api/gtfsService.ts
+++ b/src/api/gtfsService.ts
@@ -24,6 +24,7 @@ export async function getRoutesAsync(
   })
   const routes = Object.values(
     gtfsRoutes
+      .filter((route) => route.date.getDate() === toTimestamp.date())
       .map((route) => fromGtfsRoute(route))
       .reduce((agg, line) => {
         const groupByKey = line.key


### PR DESCRIPTION

# Description
<Please describe the suggested changes>
How: filter the routes date when we get them from back-end

Why: it fixes stop duplication and don't use yesterday routes

Solves issue #134 from front. You still should change the back-end or not, up to you.

* I read that you discussed about changing the back-end so it will not send the routes of yesterday but as I see it, we should have a "protection in the front" in case the back-end sends not relevant routes like it happens now :) 

## screenshots
<paste here>
Before:

https://github.com/hasadna/open-bus-map-search/assets/76536506/169d8e59-3e0a-4b48-9c50-83fe4403c7c9


After:


https://github.com/hasadna/open-bus-map-search/assets/76536506/0cb0da60-9b44-4d1b-8d8a-182446021eb8

