### PR TITLE
fix: restore dayTimeCahrt operator filtering

### DIFF
--- a/src/pages/dashboard/ArrivalByTimeChart/DayTimeChart.tsx
+++ b/src/pages/dashboard/ArrivalByTimeChart/DayTimeChart.tsx
@@ -20,9 +20,10 @@ const convertToGraphCompatibleStruct = (arr: GroupByRes[]) => {
 interface DayTimeChartProps {
   startDate: Moment
   endDate: Moment
+  operatorId: string
 }
 
-const DayTimeChart: FC<DayTimeChartProps> = ({ startDate, endDate }) => {
+const DayTimeChart: FC<DayTimeChartProps> = ({ startDate, endDate, operatorId }) => {
   const [groupByHour, setGroupByHour] = React.useState<boolean>(false)
 
   const [graphData, loadingGraph] = useGroupBy({
@@ -46,7 +47,10 @@ const DayTimeChart: FC<DayTimeChartProps> = ({ startDate, endDate }) => {
       {loadingGraph ? (
         <Skeleton active />
       ) : (
-        <ArrivalByTimeChart data={convertToGraphCompatibleStruct(graphData)} operatorId={''} />
+        <ArrivalByTimeChart
+          data={convertToGraphCompatibleStruct(graphData)}
+          operatorId={operatorId}
+        />
       )}
     </div>
   )

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -76,7 +76,7 @@ const DashboardPage = () => {
           <WorstLinesChart startDate={startDate} endDate={endDate} operatorId={operatorId} />
         </Grid>
         <Grid xs={12}>
-          <DayTimeChart startDate={startDate} endDate={endDate} />
+          <DayTimeChart startDate={startDate} endDate={endDate} operatorId={operatorId} />
         </Grid>
       </Grid>
     </PageContainer>


### PR DESCRIPTION
# Description
i fixing here disabled by my mistake `filter by operator` functionality at day time chart

## screenshots
not relevant in this  PR