### PR TITLE
chore: change page preloader to circular

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -10,7 +10,6 @@ const SingleLineMapPage = lazy(() => import('../pages/singleLineMap'))
 const About = lazy(() => import('../pages/About'))
 const Profile = lazy(() => import('../pages/Profile'))
 const BugReportForm = lazy(() => import('../pages/BugReportForm '))
-import CircularProgress from '@mui/material/CircularProgress'
 
 import {
   RadarChartOutlined,
@@ -23,6 +22,7 @@ import {
   BarChartOutlined,
   LineChartOutlined,
 } from '@ant-design/icons'
+import Preloader from 'src/shared/Preloader'
 
 export const usePages = () => {
   const { t } = useTranslation()
@@ -92,7 +92,7 @@ const RoutesList = () => {
   const RedirectToDashboard = () => <Navigate to={pages[0].path} replace />
   const routes = pages.filter((r) => r.element)
   return (
-    <Suspense fallback={<CircularProgress />}>
+    <Suspense fallback={<Preloader />}>
       <Routes>
         {routes.map(({ path, element }) => (
           <Route key={path} path={path} element={element} />

--- a/src/shared/Preloader.tsx
+++ b/src/shared/Preloader.tsx
@@ -1,0 +1,8 @@
+const Preloader = () => (
+  <>
+    <div className="preloader-bus">🚌</div>
+    <div className="preloader"></div>
+  </>
+)
+
+export default Preloader


### PR DESCRIPTION
# Description
it can be better to us same preloader also at lazy loaded pages

## screenshots
![image](https://github.com/hasadna/open-bus-map-search/assets/1336862/ba0e1d20-9449-41d1-b091-e21bbe5b5e3b)