### PR TITLE
feat: add explanation at the top of dashboard page

### DIFF
--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -9,7 +9,7 @@ import moment from 'moment'
 import './DashboardPage.scss'
 import { PageContainer } from '../components/PageContainer'
 import { TEXTS } from 'src/resources/texts'
-import { Typography } from 'antd'
+import { Alert, Typography } from 'antd'
 import Grid from '@mui/material/Unstable_Grid2' // Grid version 2
 
 // Components
@@ -30,6 +30,7 @@ const DashboardPage = () => {
   return (
     <PageContainer>
       <Title level={3}>ביצועי תחבורה ציבורית</Title>
+      <Alert message="תפקוד תחבורה ציבורית לפי פרמטרים שונים" type="info" />
       <Grid
         container
         spacing={2}


### PR DESCRIPTION
# Description
explanation for users added at the top of dashboard page
related to #109 

## screenshots
![image](https://github.com/hasadna/open-bus-map-search/assets/1336862/55dbb976-6676-46fd-9e42-ccfcb2963d9d)