### PR TITLE
ci: disable preview attempts on fork

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,10 +4,22 @@ on:
 
 env:
   ASSET_URL: https://s3.amazonaws.com/noam-gaash.co.il/${{ github.run_id }}/open-bus/${{ github.sha }}
-
+  should_run: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
 jobs:
+  should_run:
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.set_should_run.outputs.should_run }}
+    steps:
+      - name: Set should_run
+        id: set_should_run
+        if: env.should_run
+        run: echo "::set-output name=should_run::true"
+
   build:
     runs-on: ubuntu-latest
+    needs: [should_run]
+    if: ${{ needs.should_run.outputs.should_run == 'true' }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -27,6 +39,8 @@ jobs:
           path: dist
   build-storybook:
     runs-on: ubuntu-latest
+    needs: [should_run]
+    if: ${{ needs.should_run.outputs.should_run == 'true' }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
# Description
when `secrets.AWS_SECRET_ACCESS_KEY` isn't accessible (on forks), the preview job shouldn't be running.
## screenshots
irrelevant