### PR TITLE
feat: Disable mobile-only media query

### DIFF
--- a/src/pages/Map.scss
+++ b/src/pages/Map.scss
@@ -57,9 +57,3 @@ pre {
   top: 0;
   left: 0;
 }
-
-@media screen and (min-width: 430px) {
-  .expand-button {
-    display: none;
-  }
-}


### PR DESCRIPTION
# Description
Hey there, sorry for the delay with delivering this feature, I had tons of work lately.
I thought it would be nice to implement it for the /map page, as it has pretty much the same layout and style for both mobile & desktop. Let me know if you approve it, then I'll incorporate this feature as well.

## screenshots
Not expanded:
![image](https://github.com/hasadna/open-bus-map-search/assets/104915367/c4dc06de-5d9b-432a-a660-93860b8d42a5)

Expanded:
![image](https://github.com/hasadna/open-bus-map-search/assets/104915367/c5908919-401b-4a33-bab0-dd49aa80b3b6)
