### PR TITLE
test: stabilize tests

### DIFF
--- a/tests/clearButton.spec.ts
+++ b/tests/clearButton.spec.ts
@@ -15,6 +15,7 @@ async function fillDate(page: Page, twoDateElements: boolean = false) {
     await page.getByRole('gridcell', { name: '1', exact: true }).first().click()
     await page.getByLabel('בחירת תאריך').nth(1).click()
   } else {
+    await page.getByLabel('בחירת תאריך').nth(1).waitFor({ state: 'detached' })
     await page.getByLabel('בחירת תאריך').click()
   }
   await page.getByRole('gridcell', { name: '1', exact: true }).first().click()

--- a/tests/realtimemap.spec.ts
+++ b/tests/realtimemap.spec.ts
@@ -5,6 +5,7 @@ test('realtime-map page', async ({ page }) => {
   await page.getByText('מפה בזמן אמת', { exact: true }).click()
   await page.waitForURL(/map/)
   await page.getByRole('progressbar').waitFor({ state: 'hidden' })
+  await page.getByLabel('בחירת תאריך').nth(1).waitFor({ state: 'detached' })
   await page.getByLabel('בחירת תאריך').click()
   await page.getByRole('gridcell', { name: '1', exact: true }).click()
   await page.getByLabel('דקות').fill('6')


### PR DESCRIPTION
# Description
solve the following problem:
![image](https://github.com/hasadna/open-bus-map-search/assets/11145132/b46b0aac-ed06-46a8-be40-59d4bd21a6dc)

by waiting for the other date element to disappear.
(the first element is a leftover from the dashboard page)