### PR TITLE
perf(rendering): useCallback for GitHub link onClick

### DIFF
--- a/src/layout/sidebar/GitHubLink/GitHubLink.tsx
+++ b/src/layout/sidebar/GitHubLink/GitHubLink.tsx
@@ -1,5 +1,6 @@
 import { GithubOutlined } from '@ant-design/icons'
 import { useTranslation } from 'react-i18next'
+import { useCallback } from 'react'
 import './GitHubLink.scss'
 
 export default function GitHubLink() {
@@ -12,9 +13,9 @@ export default function GitHubLink() {
     element: null,
   }
 
-  const handleClick = () => {
+  const handleClick = useCallback(() => {
     window.open(data.path, '_blank')
-  }
+  }, [])
 
   return (
     <div className="github-link" onClick={handleClick}>


### PR DESCRIPTION
# Description
Following #221, this adds useCallback for the GitHub link onClick.

## screenshots
![image](https://github.com/hasadna/open-bus-map-search/assets/107395990/94a6ea95-089e-4590-8a87-2853ddab2fb8)