### PR TITLE
feat: add map expansion button to realtime map page

### DIFF
--- a/src/pages/realtimeMap/index.tsx
+++ b/src/pages/realtimeMap/index.tsx
@@ -42,6 +42,7 @@ const fiveMinutesAgo = moment().subtract(5, 'minutes')
 const fourMinutesAgo = moment(fiveMinutesAgo).add(1, 'minutes')
 
 export default function RealtimeMapPage() {
+  const [isExpanded, setIsExpanded] = useState<boolean>(false)
   const position: Point = {
     loc: [32.3057988, 34.85478613], // arbitrary default value... Netanya - best city to live & die in
     color: 0,
@@ -149,7 +150,7 @@ export default function RealtimeMapPage() {
         </Grid>
         <Grid xs={1}>{isLoading && <Spin size="small" />}</Grid>
       </Grid>
-      <div className="map-info">
+      <div className={`map-info ${isExpanded ? 'expanded' : 'collapsed'}`}>
         <MapContainer center={position.loc} zoom={8} scrollWheelZoom={true}>
           <TileLayer
             attribution='&copy <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'

--- a/src/pages/realtimeMap/index.tsx
+++ b/src/pages/realtimeMap/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { MapContainer, Marker, Polyline, Popup, TileLayer, useMap } from 'react-leaflet'
 import MarkerClusterGroup from 'react-leaflet-cluster'
 import { useTranslation } from 'react-i18next'
@@ -43,6 +43,8 @@ const fourMinutesAgo = moment(fiveMinutesAgo).add(1, 'minutes')
 
 export default function RealtimeMapPage() {
   const [isExpanded, setIsExpanded] = useState<boolean>(false)
+  const toggleExpanded = useCallback(() => setIsExpanded((expanded) => !expanded), [])
+
   const position: Point = {
     loc: [32.3057988, 34.85478613], // arbitrary default value... Netanya - best city to live & die in
     color: 0,

--- a/src/pages/realtimeMap/index.tsx
+++ b/src/pages/realtimeMap/index.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { MapContainer, Marker, Polyline, Popup, TileLayer, useMap } from 'react-leaflet'
 import MarkerClusterGroup from 'react-leaflet-cluster'
 import { useTranslation } from 'react-i18next'
-import { Spin, Typography } from 'antd'
+import { Button, Spin, Typography } from 'antd'
+import { ExpandAltOutlined } from '@ant-design/icons'
 import moment from 'moment'
 import getAgencyList, { Agency } from 'src/api/agencyList'
 import useVehicleLocations from 'src/api/useVehicleLocations'
@@ -153,6 +154,13 @@ export default function RealtimeMapPage() {
         <Grid xs={1}>{isLoading && <Spin size="small" />}</Grid>
       </Grid>
       <div className={`map-info ${isExpanded ? 'expanded' : 'collapsed'}`}>
+        <Button
+          type="primary"
+          className="expand-button"
+          shape="circle"
+          onClick={toggleExpanded}
+          icon={<ExpandAltOutlined />}
+        />
         <MapContainer center={position.loc} zoom={8} scrollWheelZoom={true}>
           <TileLayer
             attribution='&copy <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'


### PR DESCRIPTION
# Description
As I did on Issue #252, I implemented an expand button for the /map page as well.
Works for both mobile & desktop (looks fine on all screens as far as I checked).

## screenshots
!isExpanded:
![image](https://github.com/hasadna/open-bus-map-search/assets/104915367/2385785a-3fcf-44fa-a70e-864c250a1f26)

Expanded:
![image](https://github.com/hasadna/open-bus-map-search/assets/104915367/a098e308-fd6f-4929-a59b-4165435d6244)
