### PR TITLE
fix: gap between widgets #375

### DIFF
--- a/src/shared/shared.css
+++ b/src/shared/shared.css
@@ -1,8 +1,5 @@
 .widget {
-  border: 1px solid #e0e0e0;
   border-radius: 4px;
   padding: 20px;
-  box-sizing: border-box;
   margin-bottom: 20px;
-  background-color: white;
 }


### PR DESCRIPTION
# Description 
resolving issue #375 
dashbord widget  changes in shared.css for performing gap between widgets and removing inner border. 

## screenshots
![Screenshot 2024-01-07 202150](https://github.com/hasadna/open-bus-map-search/assets/145331020/4d237f2a-6f8c-479e-b5d0-43f581c7c907)
