### PR TITLE
chore: add temporary route for the version release event

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -4,10 +4,19 @@
 @import './shared/shared.css';
 
 .main {
-    flex-direction: row;
-    font-family: Heebo;
+  flex-direction: row;
+  font-family: Heebo;
 }
 
-.page-title{
-    margin-top: 0;
+.page-title {
+  margin-top: 0;
+}
+
+iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+  position: absolute;
+  top: 0;
+  left: 0;
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -110,6 +110,7 @@ const getRoutesList = () => {
         }}
       />
       <Route path="data-research" element={<DataResearch />} />
+      <Route path="release" element={<iframe src="https://noam-gaash.co.il/databus/" />} />
       <Route path="*" element={<RedirectToDashboard />} key="back" />
     </Route>
     // </Suspense>


### PR DESCRIPTION
# Description
We'll make an event,
This code will be reverted afterward.
It's just a temporary ugly thing to put a landing page in here.

## screenshots
![image](https://github.com/hasadna/open-bus-map-search/assets/11145132/f673c34a-4a18-4b79-9c97-a6ae48dce2d4)
