### PR TITLE
docs: fixed a dead link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please feel free to submit pull requests and contribute to the project.
 For more details about contributing, see the [CONTRIBUTING.md](CONTRIBUTING.md) file.
 
 # Running the project locally
-An explanation how to run the project locally you can [read here](CONTRIBUTION.md#running-the-project-locally).
+An explanation how to run the project locally you can [read here](CONTRIBUTING.md#running-the-project-on-a-local-environment).
 
 ## View video (Hebrew language):
 ### The video will explain you how to contribute to the project:   


### PR DESCRIPTION
# Description
The link that is supposed to take you to the CONTRIBUTING.md takes you to a non existent CONTRIBUTION.md. I also fixed the hash anchor to take you to the intended part of the page.

## screenshots
![oie_EyNVRnATByD5](https://github.com/hasadna/open-bus-map-search/assets/154280901/bccc5731-a532-4d90-9ce2-136acefdcb06)
