### PR TITLE
fix: make input labels visible at dark mode

### DIFF
--- a/src/pages/components/Label.tsx
+++ b/src/pages/components/Label.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components'
-
+import { Typography } from 'antd'
+const { Text } = Typography
 const StyledDiv = styled.div`
   display: inline-flex;
   width: 100%;
@@ -12,4 +13,8 @@ type LabelProps = {
   text: string
 }
 
-export const Label = ({ text }: LabelProps) => <StyledDiv>{text}</StyledDiv>
+export const Label = ({ text }: LabelProps) => (
+  <StyledDiv>
+    <Text>{text}</Text>
+  </StyledDiv>
+)


### PR DESCRIPTION
# Description
make input visible at dark mode

## screenshots
![image](https://github.com/hasadna/open-bus-map-search/assets/1336862/3d8d6b2a-56a0-43bb-af0e-ad87e2b13c66)
