### PR TITLE
chore: Revert "chore: add temporary route for the version release event (#382)"

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -4,19 +4,10 @@
 @import './shared/shared.css';
 
 .main {
-  flex-direction: row;
-  font-family: Heebo;
+    flex-direction: row;
+    font-family: Heebo;
 }
 
-.page-title {
-  margin-top: 0;
-}
-
-iframe {
-  width: 100%;
-  height: 100%;
-  border: none;
-  position: absolute;
-  top: 0;
-  left: 0;
+.page-title{
+    margin-top: 0;
 }

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -104,17 +104,6 @@ const HIDDEN_PAGES = [
     icon: <InfoCircleOutlined />,
     element: <DataResearch />,
   },
-  {
-    label: 'release',
-    path: '/release',
-    icon: <InfoCircleOutlined />,
-    element: (
-      <>
-        <Spin />
-        <iframe src="https://noam-gaash.co.il/databus/" />
-      </>
-    ),
-  },
 ]
 
 const getRoutesList = () => {


### PR DESCRIPTION
remove the temporary route that shown the release event promotion 