### PR TITLE
fix: Block end date#309

### DIFF
--- a/src/pages/components/DateSelector.tsx
+++ b/src/pages/components/DateSelector.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { DataAndTimeSelectorProps } from './utils/dateAndTime'
 import { DateValidationError } from '@mui/x-date-pickers'
 
-export function DateSelector({ time, onChange, customLabel, startDate }: DataAndTimeSelectorProps) {
+export function DateSelector({ time, onChange, customLabel, minDate }: DataAndTimeSelectorProps) {
   const [error, setError] = useState<DateValidationError | null>(null)
   const { t } = useTranslation()
 
@@ -31,7 +31,7 @@ export function DateSelector({ time, onChange, customLabel, startDate }: DataAnd
         format="DD/MM/YYYY"
         label={customLabel || t('choose_date')}
         disableFuture
-        minDate={startDate}
+        minDate={minDate}
         onError={(err) => setError(err)}
         slotProps={{
           textField: {

--- a/src/pages/components/DateSelector.tsx
+++ b/src/pages/components/DateSelector.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { DataAndTimeSelectorProps } from './utils/dateAndTime'
 import { DateValidationError } from '@mui/x-date-pickers'
 
-export function DateSelector({ time, onChange, customLabel }: DataAndTimeSelectorProps) {
+export function DateSelector({ time, onChange, customLabel, startDate }: DataAndTimeSelectorProps) {
   const [error, setError] = useState<DateValidationError | null>(null)
   const { t } = useTranslation()
 
@@ -31,6 +31,7 @@ export function DateSelector({ time, onChange, customLabel }: DataAndTimeSelecto
         format="DD/MM/YYYY"
         label={customLabel || t('choose_date')}
         disableFuture
+        minDate={startDate}
         onError={(err) => setError(err)}
         slotProps={{
           textField: {

--- a/src/pages/components/utils/dateAndTime.tsx
+++ b/src/pages/components/utils/dateAndTime.tsx
@@ -4,5 +4,5 @@ export type DataAndTimeSelectorProps = {
   time: moment.Moment
   onChange: (timeValid: moment.Moment) => void
   customLabel?: string
-  startDate?: moment.Moment
+  minDate?: moment.Moment
 }

--- a/src/pages/components/utils/dateAndTime.tsx
+++ b/src/pages/components/utils/dateAndTime.tsx
@@ -4,4 +4,5 @@ export type DataAndTimeSelectorProps = {
   time: moment.Moment
   onChange: (timeValid: moment.Moment) => void
   customLabel?: string
+  startDate?: moment.Moment
 }

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -56,6 +56,7 @@ const DashboardPage = () => {
             <DateSelector
               time={endDate}
               onChange={(data) => setEndDate(data)}
+              startDate={startDate}
               customLabel={t('end')}
             />
           </Grid>

--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -56,7 +56,7 @@ const DashboardPage = () => {
             <DateSelector
               time={endDate}
               onChange={(data) => setEndDate(data)}
-              startDate={startDate}
+              minDate={startDate}
               customLabel={t('end')}
             />
           </Grid>

--- a/src/pages/gapsPatterns/GapsPatternsPage.tsx
+++ b/src/pages/gapsPatterns/GapsPatternsPage.tsx
@@ -200,6 +200,7 @@ const GapsPatternsPage = () => {
             <DateSelector
               time={endDate}
               onChange={(data) => setEndDate(data)}
+              startDate={startDate}
               customLabel={t('end')}
             />
           </Grid>

--- a/src/pages/gapsPatterns/GapsPatternsPage.tsx
+++ b/src/pages/gapsPatterns/GapsPatternsPage.tsx
@@ -200,7 +200,7 @@ const GapsPatternsPage = () => {
             <DateSelector
               time={endDate}
               onChange={(data) => setEndDate(data)}
-              startDate={startDate}
+              minDate={startDate}
               customLabel={t('end')}
             />
           </Grid>


### PR DESCRIPTION
# Description
Added minimum date = start date to dashboard date picker, and gaps patterns page. 
I changed the DatePicker component to accept minDate. 
The dates before the start date are enabled for the end-date-picker. 

## screenshots
<img width="294" alt="image" src="https://github.com/hasadna/open-bus-map-search/assets/45571546/5770c98f-a0db-4716-93cb-d57e5b104e2b">