### PR TITLE
fix: jest warning value provided is not in a recognized RFC2822 or ISO format.

### DIFF
--- a/src/api/gapsService.ts
+++ b/src/api/gapsService.ts
@@ -12,12 +12,13 @@ export function parseTime(time: 'null'): null
 export function parseTime(time: Exclude<string, 'null'>): Moment
 
 export function parseTime(time: string): Moment | null {
+  if (time == 'null') return null
+
   const utcMoment: Moment = moment.utc(time).tz('Asia/Jerusalem')
-  if (time !== 'null' && utcMoment.isValid()) {
-    return utcMoment
-  } else {
-    return null
-  }
+
+  if (!utcMoment.isValid()) return null
+
+  return utcMoment
 }
 
 const USE_API = true


### PR DESCRIPTION
# Description

fix the warning when jest say:
```console.warn
    Deprecation warning: value provided is not in a recognized RFC2822 or ISO format. moment construction falls back to js Date(), which is not reliable across all browsers and versions. Non RFC2822/ISO date formats are discouraged. Please refer to http://momentjs.com/guides/#/warnings/js-date/ 
for more info.
    Arguments: 
    [0] _isAMomentObject: true, _isUTC: true, _useUTC: true, _l: undefined, _i: null, _f: undefined, _strict: undefined, _locale: [object Object]
    Error
        at Function.createFromInputFallback (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\moment\moment.js:324:25)
        at configFromString (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\moment\moment.js:2613:19)
        at configFromInput (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\moment\moment.js:3056:13)
        at prepareConfig (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\moment\moment.js:3039:13)
        at createFromConfig (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\moment\moment.js:3006:44)
        at createLocalOrUTC (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\moment\moment.js:3100:16)
        at Function.createUTC [as utc] (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\moment\moment.js:106:16)
        at parseTime (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\src\api\gapsService.ts:15:36)
        at Object.<anonymous> (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\src\pages\components\utils\index.test.ts:62:28)
        at Promise.then.completed (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\jest-circus\build\utils.js:298:28)
        at new Promise (<anonymous>)
        at callAsyncCircusFn (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\jest-circus\build\utils.js:231:10)
        at _callCircusTest (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\jest-circus\build\run.js:316:40)
        at processTicksAndRejections (node:internal/process/task_queues:95:5)
        at async _runTest (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\jest-circus\build\run.js:252:3)
        at async _runTestsForDescribeBlock (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\jest-circus\build\run.js:126:9)
        at async _runTestsForDescribeBlock (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\jest-circus\build\run.js:121:9)
        at async run (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\jest-circus\build\run.js:71:3)
        at async runAndTransformResultsToJestFormat (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\jest-circus\build\legacy-code-todo-rewrite\jestAdapterInit.js:122:21)
        at async jestAdapter (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\jest-circus\build\legacy-code-todo-rewrite\jestAdapter.js:79:19)
        at async runTestInternal (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\jest-runner\build\runTest.js:367:16)
        at async runTest (C:\Users\avivh\Desktop\projects\Open_Bus\open-bus-map-search\node_modules\jest-runner\build\runTest.js:444:34)```