### PR TITLE
fix: line selector can now get letters as well

### DIFF
--- a/src/pages/components/LineSelector.tsx
+++ b/src/pages/components/LineSelector.tsx
@@ -34,7 +34,7 @@ const LineSelector = ({ lineNumber, setLineNumber }: LineSelectorProps) => {
     <TextField
       className={textFieldClass}
       label={t('choose_line')}
-      type="number"
+      type="text"
       value={value && +value < 0 ? 0 : value}
       onChange={(e) => {
         setValue(e.target.value)


### PR DESCRIPTION
# Description
You now can insert a letter to the line selector that used to get only numbers.
I checked with the api and it gets string for route_short_name(LineNumber).
Also checked locally and i.e: I tried 17א as line and it returned the  correct lines.
This pull request comes to solve issue #520 .

## screenshots
before the change(cannot insert letters):
![image](https://github.com/hasadna/open-bus-map-search/assets/104071579/a569babf-9eb9-4b25-85dc-d430e9a9ecd6)
after the change:
![image](https://github.com/hasadna/open-bus-map-search/assets/104071579/35491233-c031-4c56-be8f-a8dae156d30e)
![image](https://github.com/hasadna/open-bus-map-search/assets/104071579/02f2d018-9431-405e-9ae0-07a1ad22c756)

