### PR TITLE
ci: make previews available on forks

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,25 +1,14 @@
 name: Preview
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize]
 
 env:
   ASSET_URL: https://s3.amazonaws.com/noam-gaash.co.il/${{ github.run_id }}/open-bus/${{ github.sha }}
-  should_run: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
-jobs:
-  should_run:
-    runs-on: ubuntu-latest
-    outputs:
-      should_run: ${{ steps.set_should_run.outputs.should_run }}
-    steps:
-      - name: Set should_run
-        id: set_should_run
-        if: env.should_run
-        run: echo "::set-output name=should_run::true"
 
+jobs:
   build:
     runs-on: ubuntu-latest
-    needs: [should_run]
-    if: ${{ needs.should_run.outputs.should_run == 'true' }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -37,8 +26,6 @@ jobs:
           path: dist
   build-storybook:
     runs-on: ubuntu-latest
-    needs: [should_run]
-    if: ${{ needs.should_run.outputs.should_run == 'true' }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
I believe that if we'll use pull_request_target, the secrets will be available and previews will be available in forks