### PR TITLE
fix: wrong line profile information

### DIFF
--- a/src/pages/components/map-related/MapLayers/BusToolTip.tsx
+++ b/src/pages/components/map-related/MapLayers/BusToolTip.tsx
@@ -44,7 +44,7 @@ export function BusToolTip({ position, icon }: BusToolTipProps) {
             <h1 className="title">
               {t('line')} :
               <span>
-                <Link to={`/profile/${siriRide.gtfsRouteRouteShortName}`}>
+                <Link to={`/profile/${siriRide.gtfsRideGtfsRouteId}`}>
                   {siriRide.gtfsRouteRouteShortName}
                 </Link>
               </span>


### PR DESCRIPTION
# Description
When pressing on line number to see line profile, it shows the right line information
It used to take line number as id, and now takes the real id for the correct line
This pull request comes to solve issue #565 

## screenshots
before the change(wrong line information):
![image](https://github.com/hasadna/open-bus-map-search/assets/104071579/6deea6da-aac7-437f-a2af-af0d58aa4bd9)
It gave the wrong information after pressing 25(for the line profile):
![image](https://github.com/hasadna/open-bus-map-search/assets/104071579/2795e222-ce65-4a99-b1c2-9538e3b9a4fc)
And after the change:
![image](https://github.com/hasadna/open-bus-map-search/assets/104071579/d1063793-314f-4669-a0f5-2f35ac99c8a0)
![image](https://github.com/hasadna/open-bus-map-search/assets/104071579/c7671532-c1da-46c8-bf92-740b36aec38e)

