### PR TITLE
chore: dependabot disable groups.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,4 @@ updates:
       interval: "weekly"
     reviewers:
       - "aviv1620"
-    groups:
-      production-dependencies:
-        dependency-type: "production"
-      development-dependencies:
-        dependency-type: "development"
+    open-pull-requests-limit: 100

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,4 @@ updates:
       interval: "weekly"
     reviewers:
       - "aviv1620"
-    open-pull-requests-limit: 100
+    open-pull-requests-limit: 15


### PR DESCRIPTION
# Description
If all the update grouped to one PR we don't know witch update breaking changes.
if we not set up the `open-pull-requests-limit` the [default it only five PRs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit),