### PR TITLE
style: Change `title` color so it will be visible in dark mode

### DIFF
--- a/src/pages/dashboard/DashboardPage.scss
+++ b/src/pages/dashboard/DashboardPage.scss
@@ -4,7 +4,6 @@
   font-weight: 500;
   font-size: 24px;
   line-height: 35px;
-  color: #3e3d67;
 }
 
 .widget {


### PR DESCRIPTION
# Description
* This is probably the minor pull request ever, but the `title` class on dark mode is almost invisibly, so i removed the color for the text and now the title is black (on light mode) and white (on dark mode).
* Tested on all pages related and consumed `title` and all good.

## screenshots
**Before**:
<img width="1271" alt="Screenshot 2024-04-18 at 11 26 37" src="https://github.com/hasadna/open-bus-map-search/assets/37614975/f19f4edd-e91d-444e-b1ef-9fe07839b1f0">

**After**:
<img width="1279" alt="Screenshot 2024-04-18 at 11 24 40" src="https://github.com/hasadna/open-bus-map-search/assets/37614975/763825b4-627f-4335-8af2-b38fc4945f39">
