### PR TITLE
chore: update dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,4 +11,4 @@ updates:
       interval: "weekly"
     reviewers:
       - "aviv1620"
-    open-pull-requests-limit: 15
+    open-pull-requests-limit: 3


### PR DESCRIPTION
no one is taking care of it, we don't have the capacity to handle 15 simultaneous pull requests.
