### PR TITLE
fix: improperly aligned header links

### DIFF
--- a/src/layout/header/Header.css
+++ b/src/layout/header/Header.css
@@ -9,3 +9,6 @@
   background: #303230;
 }
 
+.bulb-dark {
+  color: #fff;
+}

--- a/src/layout/header/Header.css
+++ b/src/layout/header/Header.css
@@ -9,11 +9,3 @@
   background: #303230;
 }
 
-.theme-icon {
-  width: 1rem;
-  transition: all 0.1s;
-}
-
-.theme-icon:hover {
-  transform: scale(1.1);
-}

--- a/src/layout/header/Header.tsx
+++ b/src/layout/header/Header.tsx
@@ -7,7 +7,7 @@ import './Header.css'
 import cn from 'classnames'
 import ToggleThemeButton from './ToggleThemeButton'
 import HeaderLinks from './HeaderLinks/HeaderLinks'
-import { LanguageToggle } from 'src/layout/header/LanguageToggle'
+import { LanguageToggle } from './LanguageToggle'
 
 const { Header } = Layout
 
@@ -18,9 +18,10 @@ const MainHeader = () => {
     <Header className={cn('main-header', { dark: isDarkTheme })}>
       <MenuOutlined onClick={() => setDrawerOpen(true)} className="hideOnDesktop" />
       <div style={{ flex: 1 }}>&nbsp;</div>
-      <LanguageToggle />
-      <ToggleThemeButton toggleTheme={toggleTheme} isDarkTheme={isDarkTheme} />
-      <HeaderLinks />
+      <HeaderLinks>
+        <LanguageToggle />
+        <ToggleThemeButton toggleTheme={toggleTheme} isDarkTheme={isDarkTheme} />
+      </HeaderLinks>
     </Header>
   )
 }

--- a/src/layout/header/HeaderLinks/HeaderLinks.scss
+++ b/src/layout/header/HeaderLinks/HeaderLinks.scss
@@ -7,6 +7,8 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  background: transparent;
+  border: none;
   font-size: 1.5em;
   padding-inline: 5px;
   cursor: pointer;

--- a/src/layout/header/HeaderLinks/HeaderLinks.tsx
+++ b/src/layout/header/HeaderLinks/HeaderLinks.tsx
@@ -7,9 +7,14 @@ import { HEADER_LINKS } from 'src/routes'
 
 type LinkType = Omit<(typeof HEADER_LINKS)[number], 'element'>
 
-const HeaderLinks: FC = () => {
+type HeaderLinksProps = {
+  children?: React.ReactNode
+}
+
+const HeaderLinks: FC<HeaderLinksProps> = ({ children }) => {
   return (
     <div className="header-links">
+      {children}
       {HEADER_LINKS.map((item) => {
         if (item.element === null) {
           return (

--- a/src/layout/header/LanguageToggle.tsx
+++ b/src/layout/header/LanguageToggle.tsx
@@ -15,8 +15,7 @@ export const LanguageToggle = () => {
       className="header-link"
       onClick={handleChangeLanguage}
       aria-label={t('Change Language')}
-      title={t('Change Language')}
-      style={{ border: 'none', background: 'transparent', cursor: 'pointer' }}>
+      title={t('Change Language')}>
       <GlobalOutlined />
     </button>
   )

--- a/src/layout/header/LanguageToggle.tsx
+++ b/src/layout/header/LanguageToggle.tsx
@@ -12,12 +12,12 @@ export const LanguageToggle = () => {
 
   return (
     <button
-      className="theme-icon"
+      className="header-link"
       onClick={handleChangeLanguage}
       aria-label={t('Change Language')}
       title={t('Change Language')}
-      style={{ margin: '1em', border: 'none', background: 'transparent', cursor: 'pointer' }}>
-      <GlobalOutlined style={{ fontSize: '1.7em' }} />
+      style={{ border: 'none', background: 'transparent', cursor: 'pointer' }}>
+      <GlobalOutlined />
     </button>
   )
 }

--- a/src/layout/header/ToggleThemeButton.tsx
+++ b/src/layout/header/ToggleThemeButton.tsx
@@ -14,16 +14,12 @@ const ToggleThemeButton: React.FC<ToggleThemeButtonProps> = ({ toggleTheme, isDa
 
   return (
     <button
-      className="theme-icon"
+      className="header-link"
       onClick={toggleTheme}
       aria-label={tooltip_title}
       title={tooltip_title}
       style={{ border: 'none', background: 'transparent', cursor: 'pointer' }}>
-      {isDarkTheme ? (
-        <BulbOutlined style={{ color: '#fff', fontSize: '1.5em' }} />
-      ) : (
-        <BulbFilled style={{ fontSize: '1.5em' }} />
-      )}
+      {isDarkTheme ? <BulbOutlined style={{ color: '#fff' }} /> : <BulbFilled />}
     </button>
   )
 }

--- a/src/layout/header/ToggleThemeButton.tsx
+++ b/src/layout/header/ToggleThemeButton.tsx
@@ -19,7 +19,7 @@ const ToggleThemeButton: React.FC<ToggleThemeButtonProps> = ({ toggleTheme, isDa
       aria-label={tooltip_title}
       title={tooltip_title}
       style={{ border: 'none', background: 'transparent', cursor: 'pointer' }}>
-      {isDarkTheme ? <BulbOutlined style={{ color: '#fff' }} /> : <BulbFilled />}
+      {isDarkTheme ? <BulbOutlined className="bulb-dark" /> : <BulbFilled />}
     </button>
   )
 }


### PR DESCRIPTION
# Description
Fixes improperly aligned header links by nesting them inside of ```<HeaderLinks />```

## screenshots
### Before
![chrome_7f4vfee6hQ](https://github.com/hasadna/open-bus-map-search/assets/54629307/b321413d-6899-4c25-9d6a-5ce1435b1a64)

### After
![chrome_5paHPoDMuM](https://github.com/hasadna/open-bus-map-search/assets/54629307/3f235b32-a764-4935-a067-bee6cdab02f6)
