### PR TITLE
Fix: Add scroll and bottom margin to live map

### DIFF
--- a/src/pages/Map.scss
+++ b/src/pages/Map.scss
@@ -9,8 +9,13 @@ main > div,
   flex: 1 1 auto;
 }
 
+.leaflet-container {
+  min-height: calc(100vh - 88px);
+}
+
 .map-info {
   position: relative;
+  margin-bottom: 1em;
 
   .map-index {
     position: absolute;
@@ -25,7 +30,7 @@ main > div,
       display: flex;
       justify-content: space-between;
       align-items: center;
-      
+
       &-config {
         align-items: center;
         margin-left: 1em;
@@ -52,8 +57,6 @@ main > div,
     }
   }
 }
-
-
 
 pre {
   direction: ltr;


### PR DESCRIPTION
Add scroll for pages with live map component. Also added a minor margin at the bottom of the map so it be visible that the map is not been cut by the end of the page.

Ran lint, unit & build on local machine.



![scroll and margin](https://github.com/hasadna/open-bus-map-search/assets/5049780/88d74eff-7242-4e56-b1a9-9cf18fe35266)
