### PR TITLE
fix(gtfs-service-api): change routes filter to correctly check if a route is in the given range

### DIFF
--- a/src/api/gtfsService.ts
+++ b/src/api/gtfsService.ts
@@ -29,7 +29,11 @@ export async function getRoutesAsync(
   )
   const routes = Object.values(
     gtfsRoutes
-      .filter((route) => route.date.getDate() === toTimestamp.date())
+      .filter(
+        (route) =>
+          route.date.getDate() >= fromTimestamp.date() &&
+          route.date.getDate() <= toTimestamp.date(),
+      )
       .map((route) => fromGtfsRoute(route))
       .reduce(
         (agg, line) => {


### PR DESCRIPTION
Resolves #538 

# Description
The filter in the gtfsService was wrong and probably assumed the **to** and **from** dates were the same (see #538)
The correct filter is now in place checking each route against the to and the from dates like it should.

## screenshots
![image](https://github.com/hasadna/open-bus-map-search/assets/93577239/4ab30340-a10d-47f9-8eab-2f05d93517b1)
