### PR TITLE
fix: databus logo out of alignment in English mode

### DIFF
--- a/src/layout/sidebar/logo.tsx
+++ b/src/layout/sidebar/logo.tsx
@@ -37,7 +37,7 @@ export function Logo() {
         <circle className="st0" cx="3442.6" cy="1960.6" r="65.8" />
         <circle className="st0" cx="3223.9" cy="2225.35" r="65.8" />
       </svg>
-      דאטאבוס
+      <span>דאטאבוס</span>
     </h1>
   )
 }

--- a/src/layout/sidebar/sidebar.scss
+++ b/src/layout/sidebar/sidebar.scss
@@ -21,12 +21,18 @@
 }
 
 .sidebar-logo {
-  text-align: center;
   color: black;
   font-weight: 400;
   line-height: 0.9em;
-  text-indent: -37px;
-  padding-right: 32px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 0 10px;
+
+  span {
+    margin-right: 25%;
+  }
 
   svg {
     padding: 0 8px;


### PR DESCRIPTION
# Description
These changes have solved the alignment problem in the SVG logo.
In addition, the alignment problem in the "דאטאבוס" text was fixed.

## screenshots
![image](https://github.com/hasadna/open-bus-map-search/assets/20385035/5f7976b3-dd8e-44cf-be79-7984123fece0)
![image](https://github.com/hasadna/open-bus-map-search/assets/20385035/34ed9b0b-d8b8-4187-851b-0601eca4e63c)
![image](https://github.com/hasadna/open-bus-map-search/assets/20385035/24ae0372-81cb-464e-86df-34f5c3df218a)
![image](https://github.com/hasadna/open-bus-map-search/assets/20385035/c9f7e4aa-b303-493f-a83f-2b0975ff17a6)
![image](https://github.com/hasadna/open-bus-map-search/assets/20385035/1d4c76d4-e8a8-49fa-b825-468bec99e69c)
![image](https://github.com/hasadna/open-bus-map-search/assets/20385035/8cc29a79-ab22-432e-916d-d5d46c65129b)
![image](https://github.com/hasadna/open-bus-map-search/assets/20385035/8cf69c17-95d1-4d09-b22c-c8d67b0d4e17)
![image](https://github.com/hasadna/open-bus-map-search/assets/20385035/a5004920-a492-4273-8f4d-8e3583190eeb)

