### PR TITLE
fix: dark mode hides map legend

### DIFF
--- a/src/locale/he.json
+++ b/src/locale/he.json
@@ -80,7 +80,7 @@
   "and_smaller_donors": "ותרומות קטנות נוספות של ידידי ואוהדי הסדנא.",
 
   "github_link": "למעבר אל GitHub",
-  "dark_mode_tooltip": "עבור למצב חשוך",
+  "dark_mode_tooltip": "עבור למצב כהה",
   "light_mode_tooltip": "עבור למצב בהיר",
   "Change Language": "English",
   "bug_title": "כותרת/סיכום",

--- a/src/pages/Map.scss
+++ b/src/pages/Map.scss
@@ -56,6 +56,10 @@ main > div,
       }
     }
   }
+
+  .map-index.dark {
+    background-color: #303230;
+  }
 }
 
 pre {

--- a/src/pages/components/map-related/MapWithLocationsAndPath.tsx
+++ b/src/pages/components/map-related/MapWithLocationsAndPath.tsx
@@ -11,6 +11,8 @@ import { ExpandAltOutlined } from '@ant-design/icons'
 import { BusStop } from 'src/model/busStop'
 import { t } from 'i18next'
 import '../../Map.scss'
+import { useTheme } from 'src/layout/ThemeContext'
+import cn from 'classnames'
 
 const position: Point = {
   loc: [32.3057988, 34.85478613], // arbitrary default value... Netanya - best city to live & die in
@@ -30,6 +32,7 @@ interface MapProps {
 }
 
 export function MapWithLocationsAndPath({ positions, plannedRouteStops }: MapProps) {
+  const { isDarkTheme } = useTheme()
   const agencyList = useAgencyList()
   const [isExpanded, setIsExpanded] = useState<boolean>(false)
   const toggleExpanded = useCallback(() => setIsExpanded((expanded) => !expanded), [])
@@ -62,7 +65,7 @@ export function MapWithLocationsAndPath({ positions, plannedRouteStops }: MapPro
           attribution='&copy <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
           url="https://tile-a.openstreetmap.fr/hot/{z}/{x}/{y}.png"
         />
-        <div className="map-index">
+        <div className={cn('map-index', { dark: isDarkTheme })}>
           <MapIndex
             lineColor={actualRouteLineColor}
             imgSrc={actualRouteStopMarkerPath}

--- a/tests/dashboard.spec.ts
+++ b/tests/dashboard.spec.ts
@@ -18,11 +18,11 @@ test.describe('dashboard tests', () => {
   test('page is working', async () => {})
 
   test('dark mode use localstorage', async ({ page }) => {
-    await page.getByLabel('עבור למצב חשוך').click()
+    await page.getByLabel('עבור למצב כהה').click()
     await page.reload()
     await page.getByLabel('עבור למצב בהיר').click()
     await page.reload()
-    await page.getByLabel('עבור למצב חשוך').click()
+    await page.getByLabel('עבור למצב כהה').click()
     await page.getByLabel('עבור למצב בהיר').click()
   })
 })


### PR DESCRIPTION
Resolves #579 

# Description
The map legend was kind of transparent in dark mode - I fixed it

Note: I have noticed there is a complete mess using different component libraries and configuring each one's dark mode options - the code is cumbersome - maybe we should consider sticking (strictly) with one library (and and replacing the others (e.g. MUI and not AntDesign - I have no personal preference)

## screenshots
Before:
![image](https://github.com/hasadna/open-bus-map-search/assets/93577239/774a31e1-5ff7-480a-a715-c455caed36ff)

After:
![image](https://github.com/hasadna/open-bus-map-search/assets/93577239/0571dfb3-d374-4aa1-bab2-12b04f59b246)
