### PR TITLE
test: enable pattern

### DIFF
--- a/tests/visual.spec.ts
+++ b/tests/visual.spec.ts
@@ -14,7 +14,7 @@ test.describe('Visual Tests', () => {
     } else {
       eyes.setBatch(username() + ' is testing openbus ' + new Date().toLocaleString().split(',')[0])
     }
-    eyes.getConfiguration().setUseDom(true)
+    eyes.getConfiguration().setUseDom(true).setEnablePatterns(true)
     eyes.setParentBranchName('main')
     eyes.setBranchName((await getBranch()) || 'main')
   })


### PR DESCRIPTION
When visually testing the dashboard charts, we want the visual comparison to compare the general patterns of charts rather then expecting the exact same structure

https://help.applitools.com/hc/en-us/articles/4408368066957-useDom-and-enablePatterns-Flags

# Description
<Please describe the suggested changes>

## screenshots
<paste here>