### PR TITLE
fix: remove css override of white background on darkmode

### DIFF
--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -43,7 +43,7 @@ const DashboardPage = () => {
         {t('dashboard_page_description')}
       </Alert>
       {startDate > endDate ? (
-        <Alert severity="error" variant="outlined" sx={{ bgcolor: '#feeaea' }}>
+        <Alert severity="error" variant="outlined">
           {t('bug_date_alert')}
         </Alert>
       ) : null}

--- a/src/pages/gapsPatterns/GapsPatternsPage.tsx
+++ b/src/pages/gapsPatterns/GapsPatternsPage.tsx
@@ -191,7 +191,7 @@ const GapsPatternsPage = () => {
         </Alert>
       </Space>
       {startDate > endDate ? (
-        <Alert severity="error" variant="outlined" sx={{ bgcolor: '#feeaea' }}>
+        <Alert severity="error" variant="outlined">
           {t('bug_date_alert')}
         </Alert>
       ) : null}


### PR DESCRIPTION
@NoamGaash 
Fix description: 
Remove css override for white background that makes text unreadable while on Darkmode

How to test:
1. Go Dashboard/Gap patterns page 
2. select start date that is earlier than end date.
3. A new Alert message should appear above the dates picker with validation error.
4. Change to Dark mode and check that background of the validation error alert is not white and that the message is clear. 

