### PR TITLE
fix: add missing public appeal translation in english mode

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -70,6 +70,7 @@
   "start": "start",
   "end": "end",
   "about_title": "About",
+  "public_appeal_title": "Public Appeal",
   "donate_title": "For Donations",
   "report_a_bug_title": "Report a bug",
   "website_name": "Databus",


### PR DESCRIPTION
# Description
Adds missing public appeal translation for the english version of the site

## screenshots
Before: 
![image](https://github.com/user-attachments/assets/71f33dd1-fddb-4893-abee-4cf80d6610f5)

After:
![image](https://github.com/user-attachments/assets/ff4d57f3-51cf-41ee-b428-2e9eb8d46178)
