### PR TITLE
fix: rides history page

### DIFF
--- a/src/api/gtfsService.ts
+++ b/src/api/gtfsService.ts
@@ -1,5 +1,9 @@
 import axios from 'axios'
-import { GtfsApi, GtfsRideWithRelatedPydanticModel } from 'open-bus-stride-client'
+import {
+  GtfsApi,
+  GtfsRideStopPydanticModel,
+  GtfsRideWithRelatedPydanticModel,
+} from 'open-bus-stride-client'
 import moment, { Moment } from 'moment'
 import { BusRoute, fromGtfsRoute } from 'src/model/busRoute'
 import { BusStop, fromGtfsStop } from 'src/model/busStop'
@@ -127,8 +131,8 @@ export async function getGtfsStopHitTimesAsync(stop: BusStop, timestamp: Moment)
 
   const rideIds = closestInTimeRides.map((ride) => ride.id).join(JOIN_SEPARATOR)
 
-  const maxEndTime = Math.max(...rides.map((ride) => Number(ride.endTime)))
   const minStartTime = Math.min(...rides.map((ride) => Number(ride.startTime)))
+  const maxEndTime = Math.max(...rides.map((ride) => Number(ride.endTime)))
 
   /* Fix StopHits bugs next steps TODO:
   1. Add a test to ensure this feature is working correctly.
@@ -156,7 +160,9 @@ export async function getGtfsStopHitTimesAsync(stop: BusStop, timestamp: Moment)
       throw new Error(`No stop hits found`)
     }
 
+    const stopHits: GtfsRideStopPydanticModel[] = stopHitsRes.data
 
+    return stopHits.sort((hit1, hit2) => +hit1.arrivalTime! - +hit2.arrivalTime!)
   } catch (error) {
     console.error(`Error fetching stop hits:`, error)
     return []

--- a/src/api/gtfsService.ts
+++ b/src/api/gtfsService.ts
@@ -148,11 +148,17 @@ export async function getGtfsStopHitTimesAsync(stop: BusStop, timestamp: Moment)
       params: stopHitsRequestPayLoad,
     })
 
+    if (stopHitsRes.status !== 200) {
+      throw new Error(`Error fetching stop hits: ${stopHitsRes.statusText}`)
+    }
 
-    return stopHitsRes.data.sort((hit1, hit2) => +hit1.arrivalTime! - +hit2.arrivalTime!)
+    if (stopHitsRes.data.length === 0) {
+      throw new Error(`No stop hits found`)
+    }
 
 
   } catch (error) {
-    console.error(`Error fetching stop hits for stop ${stop.stopId}:`, error)
+    console.error(`Error fetching stop hits:`, error)
+    return []
   }
 }


### PR DESCRIPTION
# Description
Fixes issue #856 by adding the required "arrival_time_from" and "arrival_time_to" fields to the gtfs_ride_stops api call. 
Changed the previous api call which utilized the gtfsAPI to an axios call directly to the server with the required data since the gtfsAPI whitelisted the required fields mentioned above which caused the api call to fail.

Still requires futher optimizations since the request is very slow and tests need to be written in future issues.

@NoamGaash 

![image](https://github.com/user-attachments/assets/5200879f-9663-47f0-9a5a-86f370822b5a)
![image](https://github.com/user-attachments/assets/0dbfeab0-275b-4803-8da3-a1e51fd67010)