### PR TITLE
test: set fixed time to the map page tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "@jest/globals": "^29.7.0",
         "@nx/eslint": "^18.2.2",
         "@nx/eslint-plugin": "^18.3.4",
-        "@playwright/test": "^1.43.1",
+        "@playwright/test": "^1.46.1",
         "@storybook/addon-essentials": "^7.5.3",
         "@storybook/addon-interactions": "^7.6.17",
         "@storybook/addon-links": "^7.6.17",
@@ -5907,18 +5907,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.43.1.tgz",
-      "integrity": "sha512-HgtQzFgNEEo4TE22K/X7sYTYNqEMMTZmFS8kTq6m8hXj+m1D8TgwgIbumHddJa9h4yl4GkKb8/bgAl2+g7eDgA==",
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.1.tgz",
+      "integrity": "sha512-Fq6SwLujA/DOIvNC2EL/SojJnkKf/rAwJ//APpJJHRyMi1PdKrY3Az+4XNQ51N4RTbItbIByQ0jgd1tayq1aeA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.43.1"
+        "playwright": "1.46.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -21184,17 +21185,18 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.43.1.tgz",
-      "integrity": "sha512-V7SoH0ai2kNt1Md9E3Gwas5B9m8KR2GVvwZnAI6Pg0m3sh7UvgiYhRrhsziCmqMJNouPckiOhk8T+9bSAK0VIA==",
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.1.tgz",
+      "integrity": "sha512-oPcr1yqoXLCkgKtD5eNUPLiN40rYEM39odNpIb6VE6S7/15gJmA1NzVv6zJYusV0e7tzvkU/utBFNa/Kpxmwng==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.43.1"
+        "playwright-core": "1.46.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
@@ -21210,14 +21212,15 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.43.1.tgz",
-      "integrity": "sha512-EI36Mto2Vrx6VF7rm708qSnesVQKbxEWvPrfA1IPY6HgczBplDx7ENtx+K2n4kJ41sLLkuGfmb0ZLSSXlDhqPg==",
+      "version": "1.46.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.1.tgz",
+      "integrity": "sha512-h9LqIQaAv+CYvWzsZ+h3RsrqCStkBHlgo6/TJlFst3cOTlLghBQlJwPOZKQJTKNaD3QIB7aAVQ+gfWbN3NXB7A==",
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "@jest/globals": "^29.7.0",
     "@nx/eslint": "^18.2.2",
     "@nx/eslint-plugin": "^18.3.4",
-    "@playwright/test": "^1.43.1",
+    "@playwright/test": "^1.46.1",
     "@storybook/addon-essentials": "^7.5.3",
     "@storybook/addon-interactions": "^7.6.17",
     "@storybook/addon-links": "^7.6.17",

--- a/tests/clearButton.spec.ts
+++ b/tests/clearButton.spec.ts
@@ -166,6 +166,7 @@ test.describe('clearButton functionality', () => {
     test('after clear the `minutes` input - it should has value equals to `1`', async ({
       page,
     }) => {
+      await page.clock.setFixedTime(new Date('2023-05-01T00:00:00.000Z'))
       await visitPage(page, 'מפה לפי זמן', /map/)
       const minutes = page.getByLabel('דקות')
       let getValueAttribute = await minutes.getAttribute('value')

--- a/tests/visual.spec.ts
+++ b/tests/visual.spec.ts
@@ -89,6 +89,7 @@ test.describe('Visual Tests', () => {
   })
 
   test('map page should look good', async ({ page }) => {
+    await page.clock.setFixedTime(new Date('2023-05-01T00:00:00.000Z'))
     await page.goto('/map')
     await page.locator('.leaflet-marker-icon').first().waitFor({ state: 'visible' })
     await page.locator('.ant-spin-dot').first().waitFor({ state: 'hidden' })


### PR DESCRIPTION
# Description
Sometimes when tests are visiting the realtime page, they load too-recent data that haven't loaded yet.
This PR suggest to set a specific arbitrary time to ensure the tests will remain consistent