### PR TITLE
fix: Fixed sidebar collapse arrow direction for RTL languages

### DIFF
--- a/src/layout/sidebar/SideBar.tsx
+++ b/src/layout/sidebar/SideBar.tsx
@@ -6,13 +6,18 @@ import { LayoutContextInterface, LayoutCtx } from '../LayoutContext'
 import Menu from './menu/Menu'
 import { Logo } from './logo'
 import { PAGES } from 'src/routes'
+import { useTranslation } from 'react-i18next'
 const { Sider } = Layout
 
 const CollapsedLogo = () => <h1 className={'sidebar-logo-collapsed'}>🚌</h1>
 
 export default function SideBar() {
+  const { i18n } = useTranslation()
   const { drawerOpen, setDrawerOpen } = useContext<LayoutContextInterface>(LayoutCtx)
   const [collapsed, setCollapsed] = useState(false)
+
+  const isRtl = i18n.language === 'he'
+
   return (
     <>
       <Drawer
@@ -35,6 +40,7 @@ export default function SideBar() {
         width={250}
         collapsible
         collapsed={collapsed}
+        reverseArrow={isRtl}
         onCollapse={(value: boolean) => setCollapsed(value)}
         className="hideOnMobile">
         <Link to={PAGES[0].path} replace>

--- a/src/layout/sidebar/SideBar.tsx
+++ b/src/layout/sidebar/SideBar.tsx
@@ -2,11 +2,11 @@ import './sidebar.scss'
 import { Drawer, Layout } from 'antd'
 import { useContext, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { useTranslation } from 'react-i18next'
 import { LayoutContextInterface, LayoutCtx } from '../LayoutContext'
 import Menu from './menu/Menu'
 import { Logo } from './logo'
 import { PAGES } from 'src/routes'
-import { useTranslation } from 'react-i18next'
 const { Sider } = Layout
 
 const CollapsedLogo = () => <h1 className={'sidebar-logo-collapsed'}>🚌</h1>


### PR DESCRIPTION
# Description
Fixed the sidebar collapse arrow to change direction based on the language, ensuring proper behavior for both LTR and RTL layouts. This update addresses issues with the arrow direction in Hebrew and other right-to-left languages, improving the user experience in these locales.


## screenshots
![image](https://github.com/user-attachments/assets/7628d119-9377-47e6-9a7e-745dc9d0a690)