### PR TITLE
docs: add DisplayGapsPercentage to storybook

### DIFF
--- a/src/pages/components/DisplayGapsPercentage.stories.tsx
+++ b/src/pages/components/DisplayGapsPercentage.stories.tsx
@@ -1,0 +1,59 @@
+import { Meta, StoryObj } from '@storybook/react'
+import DisplayGapsPercentage from './DisplayGapsPercentage'
+
+const meta: Meta<typeof DisplayGapsPercentage> = {
+  title: 'Components/DisplayGapsPercentage',
+  component: DisplayGapsPercentage,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof DisplayGapsPercentage>
+
+export const GreatGapPercentage: Story = {
+  args: {
+    gapsPercentage: 5,
+    decentPercentage: 10,
+    terriblePercentage: 15,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'When gapsPercentage is lower than decentPercentage',
+      },
+    },
+  },
+}
+
+export const DecentGapPercentage: Story = {
+  args: {
+    gapsPercentage: 12,
+    decentPercentage: 10,
+    terriblePercentage: 15,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'When gapsPercentage is between decentPercentage and terriblePercentage',
+      },
+    },
+  },
+}
+
+export const TerribleGapPercentage: Story = {
+  args: {
+    gapsPercentage: 17,
+    decentPercentage: 10,
+    terriblePercentage: 15,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'When gapsPercentage is higher than terriblePercentage',
+      },
+    },
+  },
+}


### PR DESCRIPTION
# Description
Add DisplayGapsPercentage in storybook
Show different cases in documentation:

- When gapsPercentage is lower than decentPercentage
- When gapsPercentage is between decentPercentage and terriblePercentage
- When gapsPercentage is higher than terriblePercentage

It relates to: https://github.com/hasadna/open-bus-map-search/issues/892

## screenshots
![gaps-percentage](https://github.com/user-attachments/assets/8e4b658b-ae82-4efd-aad9-6d70817a8db9)
