### PR TITLE
test: add tests for public appeal

### DIFF
--- a/tests/publicAppeal.spec.ts
+++ b/tests/publicAppeal.spec.ts
@@ -13,5 +13,5 @@ test('clicking "Open Bus Stride API" link should lead to "https://open-bus-strid
   await page.getByText('קול קורא').click()
   await page.getByRole('link', { name: 'Open Bus Stride API' }).first().click()
   await page.getByRole('heading', { name: 'Open Bus Stride API' }).waitFor()
-  await expect(page).toHaveURL(/open-bus-stride-api.hasadna.org.il/)
+  await expect(page).toHaveURL(/open-bus-stride-api\.hasadna\.org\.il/)
 })

--- a/tests/publicAppeal.spec.ts
+++ b/tests/publicAppeal.spec.ts
@@ -1,0 +1,17 @@
+import { test, expect } from '@playwright/test'
+
+test('"קול קורא" menu item should redirect to the public appeal page', async ({ page }) => {
+  await page.goto('/')
+  await page.getByText('קול קורא').click()
+  await expect(page).toHaveURL(/public-appeal/)
+})
+
+test('clicking "Open Bus Stride API" link should lead to "https://open-bus-stride-api.hasadna.org.il/docs"', async ({
+  page,
+}) => {
+  await page.goto('/')
+  await page.getByText('קול קורא').click()
+  await page.getByRole('link', { name: 'Open Bus Stride API' }).first().click()
+  await page.getByRole('heading', { name: 'Open Bus Stride API' }).waitFor()
+  await expect(page).toHaveURL(/open-bus-stride-api.hasadna.org.il/)
+})


### PR DESCRIPTION
# Description
Public Appeal menue item should lead to "קול קורא" and its link inside should lead to the Docs page in Hasadna site.