### PR TITLE
test: add test for GitHub icon

### DIFF
--- a/tests/githubLink.spec.ts
+++ b/tests/githubLink.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test'
+
+test('make sure the corner GitHub icon leads to DataBus GitHub project', async ({ page }) => {
+  await page.goto('/')
+  const page1Promise = page.waitForEvent('popup')
+  await page.getByLabel('למעבר אל GitHub').locator('svg').click()
+  const page1 = await page1Promise
+  await expect(page1).toHaveURL(/open-bus-map-search/)
+  await expect(page1.getByRole('heading', { name: 'open-bus-map-search' })).toBeVisible()
+})


### PR DESCRIPTION
# Description
Make sure the corner GitHub icon leads to DataBus GitHub project