### PR TITLE
test: add tests for 'about' page

### DIFF
--- a/tests/about.spec.ts
+++ b/tests/about.spec.ts
@@ -27,4 +27,15 @@ test.describe('About Page Tests', () => {
     await page.getByRole('link', { name: 'תרומות קטנות נוספות' }).click()
     await page.getByRole('heading', { name: 'הסדנא לידע ציבורי פותחת ומנגישה מידע' }).waitFor()
   })
+
+  test('clicking the links under "privacy" should lead to Google analytics', async ({ page }) => {
+    await page.goto('/');
+    await page.getByText('אודות').click()
+    await page.getByRole('link', { name: 'Google Analytics' }).click();
+    await expect(page).toHaveURL("https://marketingplatform\.google\.com\/about\/analytics/")
+    await page.goto('/');
+    await page.getByText('אודות').click()
+    await page.getByRole('link', { name: 'קראו כאן' }).click();
+    await expect(page).toHaveURL(/support\.google\.com\/analytics\/answer\/6004245\?hl=iw/)
+  });
 })

--- a/tests/about.spec.ts
+++ b/tests/about.spec.ts
@@ -29,13 +29,13 @@ test.describe('About Page Tests', () => {
   })
 
   test('clicking the links under "privacy" should lead to Google analytics', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/')
     await page.getByText('אודות').click()
-    await page.getByRole('link', { name: 'Google Analytics' }).click();
-    await expect(page).toHaveURL("https://marketingplatform\.google\.com\/about\/analytics/")
-    await page.goto('/');
+    await page.getByRole('link', { name: 'Google Analytics' }).click()
+    await expect(page).toHaveURL('https://marketingplatform.google.com/about/analytics/')
+    await page.goto('/')
     await page.getByText('אודות').click()
-    await page.getByRole('link', { name: 'קראו כאן' }).click();
+    await page.getByRole('link', { name: 'קראו כאן' }).click()
     await expect(page).toHaveURL(/support\.google\.com\/analytics\/answer\/6004245\?hl=iw/)
-  });
+  })
 })


### PR DESCRIPTION
# Description
clicking the links under "privacy" should lead to Google analytics