### PR TITLE
fix: Temporary fix suggestion of the unreadable text in the Donate Modal

### DIFF
--- a/src/pages/DonateModal/DonateModal.tsx
+++ b/src/pages/DonateModal/DonateModal.tsx
@@ -24,7 +24,7 @@ const DonateModal: React.FC<DonateModalProps> = ({ isVisible, onClose }) => {
     <Modal
       open={isVisible}
       onClose={onClose}
-      div style={{ color: '#1498e5' }}
+      style={{ color: '#1498e5' }}
       aria-labelledby="modal-modal-title"
       aria-describedby="modal-modal-description">
       <Box dir={i18n.dir()} sx={style}>

--- a/src/pages/DonateModal/DonateModal.tsx
+++ b/src/pages/DonateModal/DonateModal.tsx
@@ -24,6 +24,7 @@ const DonateModal: React.FC<DonateModalProps> = ({ isVisible, onClose }) => {
     <Modal
       open={isVisible}
       onClose={onClose}
+      div style={{ color: '#1498e5' }}
       aria-labelledby="modal-modal-title"
       aria-describedby="modal-modal-description">
       <Box dir={i18n.dir()} sx={style}>


### PR DESCRIPTION
# Description
**Only a suggestion** for a Temporary fix of the unreadable text in the Donate Modal while in Dark mode.
Until I (or someone else) will be able to change the text color for *white* in dark mode and *black* in light mode,
I changed it to blue (as the button) so it will be readable in dark AND light modes.

## screenshots
![image](https://github.com/user-attachments/assets/990c22f2-4bf1-4d3e-9ee4-975447d29c2a)