### PR TITLE
test: upgrade visual test iphone

### DIFF
--- a/tests/visual.spec.ts
+++ b/tests/visual.spec.ts
@@ -9,7 +9,7 @@ test.describe('Visual Tests', () => {
       { width: 1280, height: 720, name: 'safari' },
       { width: 375, height: 667, name: 'chrome' },
       {
-        iosDeviceInfo: { deviceName: 'iPhone 8' },
+        iosDeviceInfo: { deviceName: 'iPhone 16' },
       },
     ],
   })


### PR DESCRIPTION
# Description
Many of our tests got aborted because we used deprecated iPhone 8
https://applitools.com/docs/topics/overview/ufg-devices.html
This pull request renders our applications on iphone 16 instead, and that's fixing the tests