### PR TITLE
fix: time related issues in the "map by line" page

### DIFF
--- a/src/hooks/useSingleLineData.ts
+++ b/src/hooks/useSingleLineData.ts
@@ -37,6 +37,18 @@ export const useSingleLineData = (lineRef?: number, routeIds?: number[]) => {
     return pos
   }, [locations])
 
+  function convertTo24HourAndToNumber(time: string): number {
+    const match = time.match(/(\d+):(\d+):(\d+)\s(AM|PM)/)
+    if (!match) return 0
+
+    const [, hour, minute, , modifier] = match
+    let newHour = parseInt(hour, 10)
+    if (modifier === 'AM' && newHour === 12) newHour = 0
+    if (modifier === 'PM' && newHour !== 12) newHour += 12
+
+    return newHour * 60 + parseInt(minute, 10)
+  }
+
   const options = useMemo(() => {
     const options = positions
       .map((position) => position.point?.siri_ride__scheduled_start_time) // get all start times

--- a/src/hooks/useSingleLineData.ts
+++ b/src/hooks/useSingleLineData.ts
@@ -13,10 +13,12 @@ export const useSingleLineData = (lineRef?: number, routeIds?: number[]) => {
   const [filteredPositions, setFilteredPositions] = useState<Point[]>([])
   const [startTime, setStartTime] = useState<string>('00:00:00')
   const [plannedRouteStops, setPlannedRouteStops] = useState<BusStop[]>([])
-
+  const today = new Date(timestamp)
+  const tomorrow = new Date(today)
+  tomorrow.setDate(tomorrow.getDate() + 1)
   const { locations, isLoading: locationsAreLoading } = useVehicleLocations({
-    from: +new Date(timestamp).setHours(0, 0, 0, 0),
-    to: +new Date(timestamp).setHours(23, 59, 59, 999),
+    from: +today.setHours(0, 0, 0, 0),
+    to: +new Date(tomorrow).setHours(0, 0, 0, 0),
     lineRef,
     splitMinutes: 60,
     pause: !lineRef,

--- a/src/hooks/useSingleLineData.ts
+++ b/src/hooks/useSingleLineData.ts
@@ -18,7 +18,7 @@ export const useSingleLineData = (lineRef?: number, routeIds?: number[]) => {
   tomorrow.setDate(tomorrow.getDate() + 1)
   const { locations, isLoading: locationsAreLoading } = useVehicleLocations({
     from: +today.setHours(0, 0, 0, 0),
-    to: +new Date(tomorrow).setHours(0, 0, 0, 0),
+    to: +tomorrow.setHours(0, 0, 0, 0),
     lineRef,
     splitMinutes: 60,
     pause: !lineRef,
@@ -50,10 +50,12 @@ export const useSingleLineData = (lineRef?: number, routeIds?: number[]) => {
   }
 
   const options = useMemo(() => {
-    const filteredPositions = positions.filter(
-      (position) =>
-        !!position.recorded_at_time && position.recorded_at_time > +today.setHours(0, 0, 0, 0),
-    )
+    const filteredPositions = positions.filter((position) => {
+      const startTime = position.point?.siri_ride__scheduled_start_time
+      return !!startTime && +new Date(startTime) > +today.setHours(0, 0, 0, 0)
+    })
+
+    if (filteredPositions.length === 0) return []
 
     const uniqueTimes = Array.from(
       new Set(

--- a/src/hooks/useSingleLineData.ts
+++ b/src/hooks/useSingleLineData.ts
@@ -50,16 +50,30 @@ export const useSingleLineData = (lineRef?: number, routeIds?: number[]) => {
   }
 
   const options = useMemo(() => {
-    const options = positions
-      .map((position) => position.point?.siri_ride__scheduled_start_time) // get all start times
-      .filter((time, i, arr) => arr.indexOf(time) === i) // unique
-      .map((time) => new Date(time ?? 0).toLocaleTimeString()) // convert to strings
+    const filteredPositions = positions.filter(
+      (position) =>
+        !!position.recorded_at_time && position.recorded_at_time > +today.setHours(0, 0, 0, 0),
+    )
+
+    const uniqueTimes = Array.from(
+      new Set(
+        filteredPositions
+          .map((position) => position.point?.siri_ride__scheduled_start_time)
+          .filter((time): time is string => !!time)
+          .map((time) => time.trim()),
+      ),
+    )
+      .map((time) => new Date(time).toLocaleTimeString()) // Convert to 24-hour time string
       .map((time) => ({
-        // convert to options
         value: time,
         label: time,
       }))
-    return options
+
+    const sortedOptions = uniqueTimes.sort(
+      (a, b) => convertTo24HourAndToNumber(a.value) - convertTo24HourAndToNumber(b.value),
+    )
+
+    return sortedOptions
   }, [positions])
 
   useEffect(() => {


### PR DESCRIPTION
# Description

Fixes #902.

Fixes the following issues:
1. Single lines times stopped at 6PM
2. First lines were from 11PM the day before
3. The wrong time was used to filter the times (recorded at times instead of scheduled start time) - which resulted in issue 2.

Optimizations:
1. Optimized the useMemo to return an empty array if no positions passed the filter (typically when no line is chosen yet)
2. Switched to using a Set to ensure times can only appear in options once

## screenshots
![image](https://github.com/user-attachments/assets/97230567-80bc-4db4-b860-d25b515ac729)

Taken at 22:58 (two minutes before the next bus is scheduled)
![image](https://github.com/user-attachments/assets/31f3fad2-e6ee-4e17-9d06-28f8a820f83c)

Taken at 23:00 (after the bus is scheduled)
![image](https://github.com/user-attachments/assets/83764e32-9bd0-488c-b576-08b845dd2553)
