### PR TITLE
style: change DonationModal color

### DIFF
--- a/src/pages/DonateModal/DonateModal.tsx
+++ b/src/pages/DonateModal/DonateModal.tsx
@@ -24,7 +24,6 @@ export const DonateModal: React.FC<DonateModalProps> = ({ isVisible, onClose }) 
     <Modal
       open={isVisible}
       onClose={onClose}
-      style={{ color: '#1498e5' }}
       aria-modal="true"
       role="dialog"
       aria-labelledby="modal-modal-title"


### PR DESCRIPTION
the same things are written in DonateModal and DonateButton, so we can simply export it instead of writing it twice.

There's another problem where
the modal is using an aqua themed color instead of white, if it's intended I apologize