### PR TITLE
style: align headers icons

### DIFF
--- a/src/layout/header/Header.css
+++ b/src/layout/header/Header.css
@@ -1,12 +1,22 @@
 .main-header {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   background: #fff;
 }
 
 .main-header.dark {
   background: #303230;
+}
+
+@media (width < 768px) {
+  .main-header {
+    justify-content: space-between;
+  }
+
+  .main-header.dark {
+    justify-content: space-between;
+  }
 }
 
 .theme-icon {


### PR DESCRIPTION
Hi, this fix is for the following bug - 
https://github.com/hasadna/open-bus-map-search/issues/974

It seems that in the header.css file the '.main-header' template with the field "justify-content" modified the behavior of the headers icons not to be aligned as expected. I change it to "flex-end" that verify that in each language we are using the headers icons bar will be at the end of line which means the other side as expected. Below there is an example of before and after the change.

Before change:
![main_head_bar_in_chrome](https://github.com/user-attachments/assets/81c55078-9656-4af6-899c-791516fb379a)
![main_head_bar_in_firefox](https://github.com/user-attachments/assets/72418cbd-559a-4fd9-b419-3012bc5611fa)

After change:
![fix_head_bar_in_chrome](https://github.com/user-attachments/assets/45f1725f-e16b-48b3-9197-cbbcfe2e3764)
![fix_head_bar_in_firefox](https://github.com/user-attachments/assets/cd1e5234-06ba-4dbe-8234-45bd6774a6dd)
