### PR TITLE
fix: changing map language

### DIFF
--- a/src/pages/components/map-related/MapContent.tsx
+++ b/src/pages/components/map-related/MapContent.tsx
@@ -1,5 +1,6 @@
 import { t } from 'i18next'
-import { useRef } from 'react'
+import { useRef, useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { Marker, Polyline, Popup, TileLayer, useMap } from 'react-leaflet'
 import { Icon, IconOptions, Marker as LeafletMarker } from 'leaflet'
 import { busIcon, busIconPath } from '../utils/BusIcon'
@@ -29,7 +30,6 @@ export function MapContent({ positions, plannedRouteStops, showNavigationButtons
   const plannedRouteLineColor = 'black'
   const actualRouteStopMarker = getIcon(actualRouteStopMarkerPath, 20, 20)
   const plannedRouteStopMarker = getIcon(plannedRouteStopMarkerPath, 20, 25)
-
   const navigateMarkers = (positionId: number) => {
     const loc = positions[positionId]?.loc
     if (!map || !loc) return
@@ -39,12 +39,28 @@ export function MapContent({ positions, plannedRouteStops, showNavigationButtons
       marker.openPopup()
     }
   }
+  const { i18n } = useTranslation()
+  const [tileUrl, setTileUrl] = useState('https://tile-a.openstreetmap.fr/hot/{z}/{x}/{y}.png')
+  useEffect(() => {
+    const handleLanguageChange = (lng: string) => {
+      console.log('Language changed to:', lng)
+      const newUrl =
+        lng === 'he'
+          ? 'https://tile-a.openstreetmap.fr/hot/{z}/{x}/{y}.png'
+          : 'https://tile-a.openstreetmap.fr/osmfr/{z}/{x}/{y}.png?lang=en'
+      setTileUrl(newUrl)
+    }
+    i18n.on('languageChanged', handleLanguageChange)
+    return () => {
+      i18n.off('languageChanged', handleLanguageChange)
+    }
+  }, [])
 
   return (
     <>
       <TileLayer
         attribution='&copy <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-        url="https://tile-a.openstreetmap.fr/hot/{z}/{x}/{y}.png"
+        url={tileUrl}
       />
       <div className="map-index">
         <MapIndex


### PR DESCRIPTION
Hi, this is my initial PR for the map translation bug - https://github.com/hasadna/open-bus-map-search/issues/950
It currently works only on 'Map by line'. I want to implement that also on 'Time based map' as well.
I think I can improve it mainly with the map URL. I couldn't find better solution at the moment and if we can make the render smoother. I tried to use dependency on the i18n.language but it seems not to work.

Hebrew map:
![hebrew_map](https://github.com/user-attachments/assets/d811f3db-810a-4aab-bde5-0ec17b41cc65)

English map:
![english_map](https://github.com/user-attachments/assets/dd341974-6fda-4e10-b9d7-f10d842c02cf)
