### PR TITLE
ci: revert linux ubuntu version

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -60,7 +60,7 @@ jobs:
           name: docker-image
           path: /tmp/docker-image.tar
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
     env:
       APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}


### PR DESCRIPTION
# Description
Seems like chrome for testing doesn't work well on Linux Ubuntu 24.04:

* https://issues.chromium.org/issues/373753919?pli=1
* https://github.com/puppeteer/puppeteer/issues/12818

This PR change `ubuntu latest` to `ubuntu 22`