### PR TITLE
refactor(styles): migrate from @import to @use for SCSS variables

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -1,7 +1,7 @@
-// import hebbo:
-@import 'https://fonts.googleapis.com/css?family=Heebo:400,500,700&display=swap';
-@import './resources/variables';
-@import './shared/shared.css';
+@use './resources/variables';
+@use './shared/shared.css';
+
+@import url('https://fonts.googleapis.com/css?family=Heebo:400,500,700&display=swap');
 
 .main {
   flex-direction: row;

--- a/src/layout/sidebar/menu/menu.scss
+++ b/src/layout/sidebar/menu/menu.scss
@@ -1,4 +1,4 @@
-@import '../../../resources/variables';
+@use '../../../resources/variables' as *;
 
 .menu {
     flex-direction: column;

--- a/src/layout/sidebar/sidebar.scss
+++ b/src/layout/sidebar/sidebar.scss
@@ -1,4 +1,3 @@
-@import '../../resources/variables';
 
 .hideOnMobile {
   display: none;

--- a/src/pages/components/DisplayGapsPercentage.scss
+++ b/src/pages/components/DisplayGapsPercentage.scss
@@ -1,4 +1,4 @@
-@import '../../resources/variables';
+@use '../../resources/variables' as *;
 
 .gaps-percentage-displayed {
   font-weight: bold;

--- a/src/pages/dashboard/DashboardPage.scss
+++ b/src/pages/dashboard/DashboardPage.scss
@@ -1,4 +1,4 @@
-@import "../../resources/variables";
+@use "../../resources/variables" as *;
 
 .title {
   font-weight: 500;


### PR DESCRIPTION
# Description

the `import` scss syntax is deprecated, and `use` should be used instead.

source - 
https://sass-lang.com/blog/import-is-deprecated/