### PR TITLE
feat: added gtfs manual link

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -151,6 +151,7 @@
   "at_time": "at",
   "vehicle_ref": "vehicle plate",
   "drive_direction": "drive direction",
+  "gtfs_manual": "GTFS manual",
   "bearing": "bearing",
   "coords": "coords",
   "hide_document": "Hide geeks data",

--- a/src/locale/he.json
+++ b/src/locale/he.json
@@ -154,6 +154,7 @@
   "at_time": "בשעה",
   "vehicle_ref": "לוחית רישוי",
   "drive_direction": "כיוון נסיעה",
+  "gtfs_manual": "מדריך GTFS",
   "directions":{
     "North": "צפון",
     "Northeast": "צפון-מזרח",

--- a/src/pages/components/map-related/MapLayers/BusToolTip.tsx
+++ b/src/pages/components/map-related/MapLayers/BusToolTip.tsx
@@ -14,6 +14,8 @@ import { getSiriRideWithRelated } from 'src/api/siriService'
 import type { Point } from 'src/pages/timeBasedMap'
 
 export type BusToolTipProps = { position: Point; icon: string; children?: ReactNode }
+const manualUrl: string =
+  'https://www.gov.il/BlobFolder/generalpage/gtfs_general_transit_feed_specifications/he/GTFS_Developer_Information_2024.11.21b.pdf'
 
 export function BusToolTip({ position, icon, children }: BusToolTipProps) {
   const [siriRide, setSiriRide] = useState<SiriRideWithRelatedPydanticModel | undefined>()
@@ -139,6 +141,15 @@ export function BusToolTip({ position, icon, children }: BusToolTipProps) {
 
             {showJson && (
               <div onClick={(e) => e.stopPropagation()}>
+                <a
+                  href={manualUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  style={{ display: 'flex', padding: '5px', backgroundColor: 'white' }}
+                  onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'lightgray')}
+                  onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'white')}>
+                  {t('gtfs_manual')}
+                </a>
                 <CustomTreeView<Point>
                   id={position.point?.id + ''}
                   data={position}


### PR DESCRIPTION
# Description
related to this issue : [https://github.com/hasadna/open-bus-map-search/issues/1043](url) 
i added a link to the gtfs manual in the geek data information , let me know if this is how you wanted to add it ?

## screenshots
<img width="346" alt="0EC82F0D-E32E-46F5-A24C-6B1AE37AE1E4" src="https://github.com/user-attachments/assets/02915ba8-92bb-4140-a5be-57ab1319969f" />
