### PR TITLE
test: add tests for patterns page

### DIFF
--- a/tests/patterns.spec.ts
+++ b/tests/patterns.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from '@playwright/test'
+import moment from 'moment'
+
+test('verify API call to gtfs_agencies/list - "Patterns"', async ({ page }) => {
+  let apiCallMade = false
+  page.on('request', (request) => {
+    if (request.url().includes('gtfs_agencies/list')) {
+      apiCallMade = true
+    }
+  })
+
+  await page.goto('/')
+  await page.getByRole('link', { name: 'דפוסי נסיעות שלא בוצעו' }).click()
+  await page.getByLabel('חברה מפעילה').click()
+  expect(apiCallMade).toBeTruthy()
+})
+
+test('Verify date_from parameter from "Patterns"', async ({ page }) => {
+  const apiRequest = page.waitForRequest((request) => request.url().includes('gtfs_agencies/list'))
+
+  await page.goto('/')
+  await page.getByRole('link', { name: 'דפוסי נסיעות שלא בוצעו' }).click()
+
+  const request = await apiRequest
+  const url = new URL(request.url())
+  const dateFromParam = url.searchParams.get('date_from')
+  const dateFrom = moment(dateFromParam)
+  const daysAgo = moment().diff(dateFrom, 'days')
+
+  expect(daysAgo).toBeGreaterThanOrEqual(0)
+  expect(daysAgo).toBeLessThanOrEqual(3)
+})


### PR DESCRIPTION
# Description
As in "Trips history" and "single line map" pages, I also added these tests for "Patterns" page;
a test to verify an API call for gtfs_agencies,
and a test to verify the dateFrom parameter is a recent date.