### PR TITLE
feat: see planned rout even when no actual ride was executed

### DIFF
--- a/src/hooks/useSingleLineData.ts
+++ b/src/hooks/useSingleLineData.ts
@@ -14,17 +14,17 @@ export const useSingleLineData = (lineRef?: number, routeIds?: number[]) => {
   } = useContext(SearchContext)
 
   const [filteredPositions, setFilteredPositions] = useState<Point[]>([])
-  const [startTime, setStartTime] = useState<string>()
   const [plannedRouteStops, setPlannedRouteStops] = useState<BusStop[]>([])
+  const [startTime, setStartTime] = useState<string>()
 
-  const [selectDay, nextDay] = useMemo(() => {
-    const selectDay = moment(timestamp).startOf('day')
-    return [selectDay, selectDay.clone().add(1, 'day')]
+  const [today, tomorrow] = useMemo(() => {
+    const today = moment(timestamp).startOf('day')
+    return [today, today.clone().add(1, 'day')]
   }, [timestamp])
 
   const { locations, isLoading: locationsAreLoading } = useVehicleLocations({
-    from: selectDay.valueOf(),
-    to: nextDay.valueOf(),
+    from: today.valueOf(),
+    to: tomorrow.valueOf(),
     lineRef,
     splitMinutes: 360,
     pause: !lineRef,
@@ -48,7 +48,7 @@ export const useSingleLineData = (lineRef?: number, routeIds?: number[]) => {
       const startTime = position.point?.siri_ride__scheduled_start_time
       if (startTime) {
         const momentTime = moment(startTime)
-        if (momentTime.isBetween(selectDay, nextDay)) {
+        if (momentTime.isBetween(today, tomorrow)) {
           uniqueTimes.add(formatTime(momentTime))
         }
       }
@@ -57,7 +57,7 @@ export const useSingleLineData = (lineRef?: number, routeIds?: number[]) => {
     return Array.from(uniqueTimes)
       .sort()
       .map((time) => ({ value: time, label: time }))
-  }, [positions, selectDay, nextDay])
+  }, [positions, today, tomorrow])
 
   // Set Bus Postions
   useEffect(() => {
@@ -80,7 +80,7 @@ export const useSingleLineData = (lineRef?: number, routeIds?: number[]) => {
 
     if (routeIds?.length) {
       const [hour, minute] = startTime ? startTime.split(':').map(Number) : [0, 0]
-      const startTimeTimestamp = selectDay.clone().set({ hour, minute, second: 0, millisecond: 0 })
+      const startTimeTimestamp = today.clone().set({ hour, minute, second: 0, millisecond: 0 })
 
       getStopsForRouteAsync(routeIds, startTimeTimestamp)
         .then((stops) => {
@@ -98,7 +98,7 @@ export const useSingleLineData = (lineRef?: number, routeIds?: number[]) => {
     }
 
     return () => abortController.abort()
-  }, [startTime, selectDay, routeIds])
+  }, [startTime, today, routeIds])
 
   return {
     locationsAreLoading,

--- a/src/hooks/useSingleLineData.ts
+++ b/src/hooks/useSingleLineData.ts
@@ -23,8 +23,8 @@ export const useSingleLineData = (lineRef?: number, routeIds?: number[]) => {
   }, [timestamp])
 
   const { locations, isLoading: locationsAreLoading } = useVehicleLocations({
-    from: selectDay,
-    to: nextDay,
+    from: selectDay.valueOf(),
+    to: nextDay.valueOf(),
     lineRef,
     splitMinutes: 360,
     pause: !lineRef,
@@ -60,18 +60,19 @@ export const useSingleLineData = (lineRef?: number, routeIds?: number[]) => {
   }, [positions, selectDay, nextDay])
 
   // Set Bus Postions
-  const filteredBusPositions = useMemo(() => {
-    if (!startTime) return []
+  useEffect(() => {
+    if (!startTime) {
+      setFilteredPositions([])
+      return
+    }
 
-    return positions.filter((position) => {
+    const filtered = positions.filter((position) => {
       const scheduledTime = position.point?.siri_ride__scheduled_start_time
       return scheduledTime && formatTime(moment(scheduledTime)) === startTime
     })
-  }, [startTime, positions])
 
-  useEffect(() => {
-    setFilteredPositions(filteredBusPositions)
-  }, [filteredBusPositions])
+    setFilteredPositions(filtered)
+  }, [startTime, positions])
 
   // Set Bus Planned Stop
   useEffect(() => {

--- a/src/hooks/useSingleLineData.ts
+++ b/src/hooks/useSingleLineData.ts
@@ -6,7 +6,7 @@ import { BusStop } from 'src/model/busStop'
 import { SearchContext } from 'src/model/pageState'
 import { Point } from 'src/pages/timeBasedMap'
 
-export const useSingleLineData = (lineRef?: number, routeIds?: number[]) => {
+export const useSingleLineData = (lineRef?: number, routeIds?: number[], locale: string = 'he') => {
   const {
     search: { timestamp },
   } = useContext(SearchContext)
@@ -65,7 +65,7 @@ export const useSingleLineData = (lineRef?: number, routeIds?: number[]) => {
           .map((time) => time.trim()),
       ),
     )
-      .map((time) => new Date(time).toLocaleTimeString()) // Convert to 24-hour time string
+      .map((time) => new Date(time).toLocaleTimeString(locale))
       .map((time) => ({
         value: time,
         label: time,
@@ -76,15 +76,16 @@ export const useSingleLineData = (lineRef?: number, routeIds?: number[]) => {
     )
 
     return sortedOptions
-  }, [positions])
+  }, [positions, locale])
 
   useEffect(() => {
     if (startTime !== '00:00:00' && positions.length > 0) {
       setFilteredPositions(
         positions.filter(
           (position) =>
-            new Date(position.point?.siri_ride__scheduled_start_time ?? 0).toLocaleTimeString() ===
-            startTime,
+            new Date(position.point?.siri_ride__scheduled_start_time ?? 0).toLocaleTimeString(
+              locale,
+            ) === startTime,
         ),
       )
     }
@@ -95,7 +96,7 @@ export const useSingleLineData = (lineRef?: number, routeIds?: number[]) => {
       ).setHours(+hours, +minutes, 0, 0)
       handlePlannedRouteStops(routeIds ?? [], startTimeTimestamp)
     }
-  }, [startTime])
+  }, [startTime, locale])
 
   const handlePlannedRouteStops = async (routeIds: number[], startTimeTs: number) => {
     const stops = await getStopsForRouteAsync(routeIds, moment(startTimeTs))

--- a/src/pages/Map.scss
+++ b/src/pages/Map.scss
@@ -52,20 +52,20 @@ main > div,
         img {
           width: 20px;
           height: 20px;
-      }
-
+        }
       }
 
       &-title {
         width: 100px;
         text-align: left;
+        color: black;
       }
     }
   }
+}
 
-  .map-index.dark {
-    background-color: #303230;
-  }
+.map-index.dark {
+  background-color: #303230;
 }
 
 pre {

--- a/src/pages/components/FilterPositionsByStartTimeSelector.tsx
+++ b/src/pages/components/FilterPositionsByStartTimeSelector.tsx
@@ -5,9 +5,10 @@ type FilterPositionsByStartTimeSelectorProps = {
   options: {
     value: string
     label: string
+    gap: boolean
   }[]
-  startTime?: string
-  setStartTime: (time: string) => void
+  startTime?: string | null
+  setStartTime: (time: string | null) => void
 }
 
 export function FilterPositionsByStartTimeSelector({
@@ -25,7 +26,7 @@ export function FilterPositionsByStartTimeSelector({
       sx={{ width: '100%' }}
       disablePortal
       value={value}
-      onChange={(e, value) => setStartTime(value ? value.value : '0')}
+      onChange={(e, value) => setStartTime(value ? value.value : null)}
       id="start-time-select"
       options={options}
       renderInput={(params) => <TextField {...params} label={t('choose_start_time')} />}

--- a/src/pages/components/FilterPositionsByStartTimeSelector.tsx
+++ b/src/pages/components/FilterPositionsByStartTimeSelector.tsx
@@ -5,10 +5,9 @@ type FilterPositionsByStartTimeSelectorProps = {
   options: {
     value: string
     label: string
-    gap: boolean
   }[]
-  startTime?: string | null
-  setStartTime: (time: string | null) => void
+  startTime?: string
+  setStartTime: (time?: string) => void
 }
 
 export function FilterPositionsByStartTimeSelector({
@@ -26,7 +25,7 @@ export function FilterPositionsByStartTimeSelector({
       sx={{ width: '100%' }}
       disablePortal
       value={value}
-      onChange={(e, value) => setStartTime(value ? value.value : null)}
+      onChange={(e, value) => setStartTime(value?.value)}
       id="start-time-select"
       options={options}
       renderInput={(params) => <TextField {...params} label={t('choose_start_time')} />}

--- a/src/pages/components/RouteSelector.tsx
+++ b/src/pages/components/RouteSelector.tsx
@@ -7,8 +7,8 @@ import { formatted } from 'src/locale/utils'
 
 type RouteSelectorProps = {
   routes: BusRoute[]
-  routeKey: string | undefined
-  setRouteKey: (routeKey: string) => void
+  routeKey?: string
+  setRouteKey: (routeKey?: string) => void
 }
 
 const getRouteTitle = (route: BusRoute, t: TFunction<'translation', undefined>) =>
@@ -39,7 +39,7 @@ const RouteSelector = ({ routes, routeKey, setRouteKey }: RouteSelectorProps) =>
     <Autocomplete
       disablePortal
       value={value}
-      onChange={(e, value) => setRouteKey(value ? value.key : '0')}
+      onChange={(e, value) => setRouteKey(value?.key)}
       id="route-select"
       options={routes}
       renderInput={(params) => (

--- a/src/pages/components/map-related/MapContent.tsx
+++ b/src/pages/components/map-related/MapContent.tsx
@@ -38,7 +38,6 @@ export function MapContent({ positions, plannedRouteStops, showNavigationButtons
 
   useEffect(() => {
     const handleLanguageChange = (lng: string) => {
-      // console.log('Language changed to:', lng)
       const newUrl =
         lng === 'he'
           ? 'https://tile-a.openstreetmap.fr/hot/{z}/{x}/{y}.png'

--- a/src/pages/components/map-related/MapContent.tsx
+++ b/src/pages/components/map-related/MapContent.tsx
@@ -1,5 +1,5 @@
 import { t } from 'i18next'
-import { useRef, useEffect, useState } from 'react'
+import { useRef, useEffect, useState, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Marker, Polyline, Popup, TileLayer, useMap } from 'react-leaflet'
 import { Icon, IconOptions, Marker as LeafletMarker } from 'leaflet'
@@ -12,34 +12,22 @@ import { MapIndex } from './MapIndex'
 import MapFooterButtons from './MapFooterButtons/MapFooterButtons'
 import { useAgencyList } from 'src/api/agencyList'
 
+// configs for planned & actual routes - line color & marker icon
+const getIcon = (path: string, width: number = 10, height: number = 10): Icon<IconOptions> => {
+  return new Icon<IconOptions>({
+    iconUrl: path,
+    iconSize: [width, height],
+  })
+}
+const actualRouteStopMarkerPath = '/marker-dot.png'
+const plannedRouteStopMarkerPath = '/marker-bus-stop.png'
+const actualRouteLineColor = 'orange'
+const plannedRouteLineColor = 'black'
+const actualRouteStopMarker = getIcon(actualRouteStopMarkerPath, 20, 20)
+const plannedRouteStopMarker = getIcon(plannedRouteStopMarkerPath, 20, 25)
+
 export function MapContent({ positions, plannedRouteStops, showNavigationButtons }: MapProps) {
-  useRecenterOnDataChange({ positions, plannedRouteStops })
   const markerRef = useRef<{ [key: number]: LeafletMarker | null }>({})
-  const map = useMap()
-  const agencyList = useAgencyList()
-  const getIcon = (path: string, width: number = 10, height: number = 10): Icon<IconOptions> => {
-    return new Icon<IconOptions>({
-      iconUrl: path,
-      iconSize: [width, height],
-    })
-  }
-  // configs for planned & actual routes - line color & marker icon
-  const actualRouteStopMarkerPath = '/marker-dot.png'
-  const plannedRouteStopMarkerPath = '/marker-bus-stop.png'
-  const actualRouteLineColor = 'orange'
-  const plannedRouteLineColor = 'black'
-  const actualRouteStopMarker = getIcon(actualRouteStopMarkerPath, 20, 20)
-  const plannedRouteStopMarker = getIcon(plannedRouteStopMarkerPath, 20, 25)
-  const navigateMarkers = (positionId: number) => {
-    const loc = positions[positionId]?.loc
-    if (!map || !loc) return
-    const marker = markerRef?.current && markerRef?.current[positionId]
-    if (marker) {
-      map.flyTo(loc, map.getZoom())
-      marker.openPopup()
-    }
-  }
-  const { i18n } = useTranslation()
   const [tileUrl, setTileUrl] = useState('https://tile-a.openstreetmap.fr/hot/{z}/{x}/{y}.png')
 
   const agencyList = useAgencyList()
@@ -50,7 +38,7 @@ export function MapContent({ positions, plannedRouteStops, showNavigationButtons
 
   useEffect(() => {
     const handleLanguageChange = (lng: string) => {
-      console.log('Language changed to:', lng)
+      // console.log('Language changed to:', lng)
       const newUrl =
         lng === 'he'
           ? 'https://tile-a.openstreetmap.fr/hot/{z}/{x}/{y}.png'
@@ -62,6 +50,19 @@ export function MapContent({ positions, plannedRouteStops, showNavigationButtons
       i18n.off('languageChanged', handleLanguageChange)
     }
   }, [])
+
+  const navigateMarkers = useCallback(
+    (positionId: number) => {
+      const pos = positions[positionId]
+      if (!map || !pos?.loc) return
+      const marker = markerRef.current[positionId]
+      if (marker) {
+        map.flyTo(pos.loc, map.getZoom())
+        marker.openPopup()
+      }
+    },
+    [map, positions],
+  )
 
   return (
     <>

--- a/src/pages/components/map-related/MapContent.tsx
+++ b/src/pages/components/map-related/MapContent.tsx
@@ -125,10 +125,7 @@ export function MapContent({ positions, plannedRouteStops, showNavigationButtons
         plannedRouteStops.map((stop) => {
           const { latitude, longitude } = stop.location
           return (
-            <Marker
-              key={stop.key}
-              position={[latitude, longitude]}
-              icon={plannedRouteStopMarker}></Marker>
+            <Marker key={stop.key} position={[latitude, longitude]} icon={plannedRouteStopMarker} />
           )
         })}
       {positions.length && (

--- a/src/pages/components/map-related/MapContent.tsx
+++ b/src/pages/components/map-related/MapContent.tsx
@@ -126,7 +126,7 @@ export function MapContent({ positions, plannedRouteStops, showNavigationButtons
           const { latitude, longitude } = stop.location
           return (
             <Marker
-              key={'' + latitude + longitude}
+              key={stop.key}
               position={[latitude, longitude]}
               icon={plannedRouteStopMarker}></Marker>
           )

--- a/src/pages/components/map-related/MapContent.tsx
+++ b/src/pages/components/map-related/MapContent.tsx
@@ -41,6 +41,13 @@ export function MapContent({ positions, plannedRouteStops, showNavigationButtons
   }
   const { i18n } = useTranslation()
   const [tileUrl, setTileUrl] = useState('https://tile-a.openstreetmap.fr/hot/{z}/{x}/{y}.png')
+
+  const agencyList = useAgencyList()
+  const map = useMap()
+  const { i18n } = useTranslation()
+
+  useRecenterOnDataChange({ positions, plannedRouteStops })
+
   useEffect(() => {
     const handleLanguageChange = (lng: string) => {
       console.log('Language changed to:', lng)

--- a/src/pages/components/map-related/useRecenterOnDataChange.ts
+++ b/src/pages/components/map-related/useRecenterOnDataChange.ts
@@ -2,31 +2,45 @@ import { useEffect } from 'react'
 import { LatLngTuple } from 'leaflet'
 import { useMap } from 'react-leaflet'
 import { MapProps } from './map-types'
+import { BusStop } from 'src/model/busStop'
+import { Point } from 'src/pages/timeBasedMap'
+
+const calculatePoint = (acc: LatLngTuple, curr: Point | BusStop): LatLngTuple => {
+  if ('loc' in curr && curr.loc) {
+    return [acc[0] + curr.loc[0], acc[1] + curr.loc[1]]
+  }
+  if ('location' in curr && curr.location) {
+    return [acc[0] + curr.location.latitude, acc[1] + curr.location.longitude]
+  }
+  return acc
+}
+
+const calculateMean = (
+  positionsSum: LatLngTuple,
+  stopsSum: LatLngTuple,
+  totalPoints: number,
+): LatLngTuple => {
+  return [
+    (positionsSum[0] + stopsSum[0]) / totalPoints,
+    (positionsSum[1] + stopsSum[1]) / totalPoints,
+  ]
+}
 
 export function useRecenterOnDataChange({ positions = [], plannedRouteStops = [] }: MapProps) {
   const map = useMap()
 
   useEffect(() => {
-    if (!positions.length && !plannedRouteStops.length) return
+    if (positions.length === 0 && plannedRouteStops.length === 0) return
 
-    const positionsSum = positions.reduce(
-      ([lat, lng], pos) => [lat + pos.loc[0], lng + pos.loc[1]],
-      [0, 0],
-    )
-    const stopsSum = plannedRouteStops.reduce(
-      ([lat, lng], stop) => [lat + stop.location.latitude, lng + stop.location.longitude],
-      [0, 0],
-    )
-
+    const positionsSum = positions.reduce(calculatePoint, [0, 0])
+    const stopsSum = plannedRouteStops.reduce(calculatePoint, [0, 0])
     const totalPoints = positions.length + plannedRouteStops.length
 
-    const mean: LatLngTuple = [
-      (positionsSum[0] + stopsSum[0]) / totalPoints,
-      (positionsSum[1] + stopsSum[1]) / totalPoints,
-    ]
+    if (totalPoints === 0) return
 
-    // console.log('mean: ', mean)
-    if (mean[0] || mean[1]) {
+    const mean = calculateMean(positionsSum, stopsSum, totalPoints)
+
+    if (mean[0] !== 0 || mean[1] !== 0) {
       map.setView(mean, map.getZoom(), { animate: true })
     }
   }, [positions, plannedRouteStops, map])

--- a/src/pages/components/map-related/useRecenterOnDataChange.ts
+++ b/src/pages/components/map-related/useRecenterOnDataChange.ts
@@ -3,17 +3,31 @@ import { LatLngTuple } from 'leaflet'
 import { useMap } from 'react-leaflet'
 import { MapProps } from './map-types'
 
-export function useRecenterOnDataChange({ positions }: MapProps) {
+export function useRecenterOnDataChange({ positions = [], plannedRouteStops = [] }: MapProps) {
   const map = useMap()
-  const positionsSum = positions.reduce(
-    (acc, { loc }) => [acc[0] + loc[0], acc[1] + loc[1]],
-    [0, 0],
-  )
-  const mean: LatLngTuple = [positionsSum[0] / positions.length, positionsSum[1] / positions.length]
-  console.log('mean: ', mean)
+
   useEffect(() => {
+    if (!positions.length && !plannedRouteStops.length) return
+
+    const positionsSum = positions.reduce(
+      ([lat, lng], pos) => [lat + pos.loc[0], lng + pos.loc[1]],
+      [0, 0],
+    )
+    const stopsSum = plannedRouteStops.reduce(
+      ([lat, lng], stop) => [lat + stop.location.latitude, lng + stop.location.longitude],
+      [0, 0],
+    )
+
+    const totalPoints = positions.length + plannedRouteStops.length
+
+    const mean: LatLngTuple = [
+      (positionsSum[0] + stopsSum[0]) / totalPoints,
+      (positionsSum[1] + stopsSum[1]) / totalPoints,
+    ]
+
+    // console.log('mean: ', mean)
     if (mean[0] || mean[1]) {
       map.setView(mean, map.getZoom(), { animate: true })
     }
-  }, [mean])
+  }, [positions, plannedRouteStops, map])
 }

--- a/src/pages/singleLineMap/index.tsx
+++ b/src/pages/singleLineMap/index.tsx
@@ -27,6 +27,7 @@ const SingleLineMapPage = () => {
   useEffect(() => {
     if (!operatorId || operatorId === '0' || !lineNumber) {
       setSearch((current) => ({ ...current, routes: undefined, routeKey: undefined }))
+      setStartTime(undefined)
       return
     }
 

--- a/src/pages/singleLineMap/index.tsx
+++ b/src/pages/singleLineMap/index.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import Grid from '@mui/material/Unstable_Grid2'
 import { CircularProgress, Tooltip } from '@mui/material'
 import Typography from '@mui/material/Typography'
-import { SearchContext } from '../../model/pageState'
+import { PageSearchState, SearchContext } from '../../model/pageState'
 import { NotFound } from '../components/NotFound'
 import '../Map.scss'
 import { DateSelector } from '../components/DateSelector'
@@ -39,7 +39,7 @@ const SingleLineMapPage = () => {
           ...current,
           routes,
           routeKey:
-            // if is same line it save route key
+            // if is same line it keep route key
             current.lineNumber === lineNumber && current.operatorId === operatorId
               ? current.routeKey
               : undefined,
@@ -68,17 +68,9 @@ const SingleLineMapPage = () => {
     setStartTime,
   } = useSingleLineData(selectedRoute?.lineRef, selectedRoute?.routeIds)
 
-  const handleTimestampChange = (ts: Moment | null) =>
-    setSearch((current) => ({ ...current, timestamp: ts?.valueOf() ?? Date.now() }))
-
-  const handleOperatorChange = (operatorId: string) =>
-    setSearch((current) => ({ ...current, operatorId }))
-
-  const handleLineNumberChange = (lineNumber: string) =>
-    setSearch((current) => ({ ...current, lineNumber }))
-
-  const handleRouteKeyChange = (routeKey?: string) =>
-    setSearch((current) => ({ ...current, routeKey }))
+  const handleChange = <K extends keyof PageSearchState>(key: K, value: PageSearchState[K]) => {
+    setSearch((current) => ({ ...current, [key]: value }))
+  }
 
   return (
     <PageContainer className="map-container">
@@ -94,15 +86,24 @@ const SingleLineMapPage = () => {
         <Grid container spacing={2} xs={12}>
           {/* choose date*/}
           <Grid sm={4} xs={12}>
-            <DateSelector time={moment(timestamp)} onChange={handleTimestampChange} />
+            <DateSelector
+              time={moment(timestamp)}
+              onChange={(time) => handleChange('timestamp', time?.valueOf() ?? Date.now())}
+            />
           </Grid>
           {/* choose operator */}
           <Grid sm={4} xs={12}>
-            <OperatorSelector operatorId={operatorId} setOperatorId={handleOperatorChange} />
+            <OperatorSelector
+              operatorId={operatorId}
+              setOperatorId={(id) => handleChange('operatorId', id)}
+            />
           </Grid>
           {/* choose line number */}
           <Grid sm={4} xs={12}>
-            <LineNumberSelector lineNumber={lineNumber} setLineNumber={handleLineNumberChange} />
+            <LineNumberSelector
+              lineNumber={lineNumber}
+              setLineNumber={(line) => handleChange('lineNumber', line)}
+            />
           </Grid>
         </Grid>
         <Grid container spacing={2} xs={12} alignContent={'center'}>
@@ -115,7 +116,7 @@ const SingleLineMapPage = () => {
                 <RouteSelector
                   routes={routes}
                   routeKey={routeKey}
-                  setRouteKey={handleRouteKeyChange}
+                  setRouteKey={(key) => handleChange('routeKey', key)}
                 />
               ))}
           </Grid>

--- a/src/pages/singleLineMap/index.tsx
+++ b/src/pages/singleLineMap/index.tsx
@@ -60,7 +60,7 @@ const SingleLineMapPage = () => {
     plannedRouteStops,
     startTime,
     setStartTime,
-  } = useSingleLineData(selectedRoute?.lineRef, selectedRouteIds, i18n.language)
+  } = useSingleLineData(selectedRoute?.lineRef, selectedRouteIds)
 
   return (
     <PageContainer className="map-container">

--- a/src/pages/singleLineMap/index.tsx
+++ b/src/pages/singleLineMap/index.tsx
@@ -22,7 +22,7 @@ import { useSingleLineData } from 'src/hooks/useSingleLineData'
 const SingleLineMapPage = () => {
   const { search, setSearch } = useContext(SearchContext)
   const { operatorId, lineNumber, timestamp, routes, routeKey } = search
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
 
   useEffect(() => {
     const controller = new AbortController()
@@ -60,7 +60,7 @@ const SingleLineMapPage = () => {
     plannedRouteStops,
     startTime,
     setStartTime,
-  } = useSingleLineData(selectedRoute?.lineRef, selectedRouteIds)
+  } = useSingleLineData(selectedRoute?.lineRef, selectedRouteIds, i18n.language)
 
   return (
     <PageContainer className="map-container">

--- a/src/pages/singleLineMap/index.tsx
+++ b/src/pages/singleLineMap/index.tsx
@@ -1,10 +1,10 @@
-import moment, { Moment } from 'moment'
+import moment from 'moment'
 import { useContext, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import Grid from '@mui/material/Unstable_Grid2'
 import { CircularProgress, Tooltip } from '@mui/material'
 import Typography from '@mui/material/Typography'
-import { PageSearchState, SearchContext } from '../../model/pageState'
+import { SearchContext } from '../../model/pageState'
 import { NotFound } from '../components/NotFound'
 import '../Map.scss'
 import { DateSelector } from '../components/DateSelector'
@@ -68,8 +68,20 @@ const SingleLineMapPage = () => {
     setStartTime,
   } = useSingleLineData(selectedRoute?.lineRef, selectedRoute?.routeIds)
 
-  const handleChange = <K extends keyof PageSearchState>(key: K, value: PageSearchState[K]) => {
-    setSearch((current) => ({ ...current, [key]: value }))
+  const handleTimestampChange = (time: moment.Moment | null) => {
+    setSearch((current) => ({ ...current, timestamp: time?.valueOf() ?? Date.now() }))
+  }
+
+  const handleOperatorChange = (operatorId: string) => {
+    setSearch((current) => ({ ...current, operatorId }))
+  }
+
+  const handleLineNumberChange = (lineNumber: string) => {
+    setSearch((current) => ({ ...current, lineNumber }))
+  }
+
+  const handleRouteKeyChange = (routeKey?: string) => {
+    setSearch((current) => ({ ...current, routeKey }))
   }
 
   return (
@@ -86,24 +98,15 @@ const SingleLineMapPage = () => {
         <Grid container spacing={2} xs={12}>
           {/* choose date*/}
           <Grid sm={4} xs={12}>
-            <DateSelector
-              time={moment(timestamp)}
-              onChange={(time) => handleChange('timestamp', time?.valueOf() ?? Date.now())}
-            />
+            <DateSelector time={moment(timestamp)} onChange={handleTimestampChange} />
           </Grid>
           {/* choose operator */}
           <Grid sm={4} xs={12}>
-            <OperatorSelector
-              operatorId={operatorId}
-              setOperatorId={(id) => handleChange('operatorId', id)}
-            />
+            <OperatorSelector operatorId={operatorId} setOperatorId={handleOperatorChange} />
           </Grid>
           {/* choose line number */}
           <Grid sm={4} xs={12}>
-            <LineNumberSelector
-              lineNumber={lineNumber}
-              setLineNumber={(line) => handleChange('lineNumber', line)}
-            />
+            <LineNumberSelector lineNumber={lineNumber} setLineNumber={handleLineNumberChange} />
           </Grid>
         </Grid>
         <Grid container spacing={2} xs={12} alignContent={'center'}>
@@ -116,7 +119,7 @@ const SingleLineMapPage = () => {
                 <RouteSelector
                   routes={routes}
                   routeKey={routeKey}
-                  setRouteKey={(key) => handleChange('routeKey', key)}
+                  setRouteKey={handleRouteKeyChange}
                 />
               ))}
           </Grid>

--- a/tests/singlelineTest.spec.ts
+++ b/tests/singlelineTest.spec.ts
@@ -45,6 +45,28 @@ test.describe('Single line page tests', () => {
     await singleLinePage.selectRandomRoute()
   })
 
+  test('Test route appears after select route', async ({ page }) => {
+    await test.step('Navigate to "Map By Line"', async () => {
+      await page.goto('/')
+      await page.getByRole('link', { name: 'מפה לפי קו' }).click()
+    })
+
+    await test.step('Fill line info', async () => {
+      await page.getByLabel('חברה מפעילה').click()
+      await page.getByRole('option', { name: 'דן', exact: true }).click()
+      await page.getByPlaceholder('לדוגמה: 17א').fill('67')
+      await page.getByLabel('בחירת מסלול נסיעה (2 אפשרויות)').click()
+      await page
+        .getByRole('option', { name: 'קניון איילון-רמת גן ⟵ איצטדיון וינטר-רמת גן' })
+        .click()
+    })
+
+    await test.step('Verify bus stop marker is visible', async () => {
+      const stopMarker = page.locator('leaflet-pane > img[src="/marker-bus-stop.png"]')
+      await expect(stopMarker).toBeVisible()
+    })
+  })
+
   test('tooltip appears after clicking on map point in single line map', async ({ page }) => {
     await test.step('Navigate to "Map By Line"', async () => {
       await page.goto('/')
@@ -64,7 +86,7 @@ test.describe('Single line page tests', () => {
     })
 
     await test.step('Click on bus button', async () => {
-      const button = page.locator('.leaflet-pane > img:nth-child(7)')
+      const button = page.locator('leaflet-pane>img[src="/marker-dot.png"]:nth-child(7)')
       await button.click()
       await button.click({ force: true })
     })

--- a/tests/singlelineTest.spec.ts
+++ b/tests/singlelineTest.spec.ts
@@ -61,9 +61,9 @@ test.describe('Single line page tests', () => {
         .click()
     })
 
-    await test.step('Verify bus stop marker is visible', async () => {
-      const stopMarker = page.locator('leaflet-pane > img[src="/marker-bus-stop.png"]')
-      await expect(stopMarker).toBeVisible()
+    await test.step('Verify bus stop marker is in the page', async () => {
+      const stopMarker = page.locator('.leaflet-marker-pane > img[src$="marker-bus-stop.png"]')
+      await expect(stopMarker).toHaveCount(33)
     })
   })
 
@@ -86,7 +86,7 @@ test.describe('Single line page tests', () => {
     })
 
     await test.step('Click on bus button', async () => {
-      const button = page.locator('leaflet-pane>img[src="/marker-dot.png"]:nth-child(7)')
+      const button = page.locator('.leaflet-marker-pane > img[src$="marker-dot.png"]').nth(6)
       await button.click()
       await button.click({ force: true })
     })


### PR DESCRIPTION
# Description
Display the planned route before selecting a time.
![Image](https://github.com/user-attachments/assets/ecf7569f-ec77-405f-95aa-73da4c8d0d02)

# Changelog
- **SingleLineMapPage**
  - Enhanced search functionality.
  - Improved event handling.
- **useSingleLineData**
  - Use `undefined` values for `startTime` instead of `'0'`.
  - Separate the `plannedRouteStops` from `filteredPositions` to allow for independent loading.
  - Optimized and refactored code.
- **RouteSelector and FilterPositionsByStartTimeSelector**
  - Replace `'0'` with `undefined` values.
- **MapContent**
  - Fixed the duplication of keys in `plannedRouteStops`.
  - Optimized and refactored code.
-  **useRecenterOnDataChange**
   - The map also focuses when `plannedRouteStops` are available.
   - Optimized and refactored code.
- **Map.scss**
  - Improved readability of `.map-index-title` in dark mode.
  ![image](https://github.com/user-attachments/assets/cfcb2ee9-625d-4472-8f85-65c18c5c6c01)
  - Formatted the file.
- **singlelineTest.spec.ts**
  - Add Test `route appears after select route`
  - Fix selector in `tooltip appears after clicking on map point` in single line map