### PR TITLE
refactor: widget and selectors

### DIFF
--- a/src/pages/about/index.tsx
+++ b/src/pages/about/index.tsx
@@ -188,7 +188,7 @@ const Contributors = () => {
   const { contributors, isLoading, isError } = useContributions()
 
   return (
-    <Widget>
+    <Widget marginBottom>
       <h2>{t('aboutPage.contributors')}</h2>
       <p>
         {t('aboutPage.contributorsText')}

--- a/src/pages/components/OperatorSelector.tsx
+++ b/src/pages/components/OperatorSelector.tsx
@@ -23,7 +23,7 @@ export default function OperatorSelector({
     getOperators(filter).then(setOperators)
   }, [filter])
 
-  const value = operators.find((operator) => operator.id === operatorId)
+  const value = operators.find((operator) => operator.id === operatorId) || null
 
   return (
     <Autocomplete

--- a/src/pages/components/RouteSelector.tsx
+++ b/src/pages/components/RouteSelector.tsx
@@ -21,7 +21,7 @@ const getRouteTitle = (route: BusRoute, t: TFunction<'translation', undefined>) 
 
 const RouteSelector = ({ routes, routeKey, disabled, setRouteKey }: RouteSelectorProps) => {
   const { t } = useTranslation()
-  const value = routes.find((route) => route.key === routeKey)
+  const value = routes.find((route) => route.key === routeKey) || null
 
   useEffect(() => {
     routes.sort((a, b) => {

--- a/src/pages/components/StopSelector.tsx
+++ b/src/pages/components/StopSelector.tsx
@@ -18,13 +18,14 @@ const StopSelector = ({ stops, stopKey, setStopKey }: StopSelectorProps) => {
     <Autocomplete
       disablePortal
       value={value}
-      onChange={(e, value) => setStopKey(value ? value.key : '0')}
+      onChange={(e, value) => setStopKey(value ? value.key : '')}
       id="stop-select"
       options={stops}
       renderInput={(params) => (
         <TextField {...params} label={formatted(t('choose_stop'), stops.length.toString())} />
       )}
       getOptionLabel={(stop) => stop.name}
+      getOptionKey={(stop) => stop.key}
     />
   )
 }

--- a/src/pages/components/StopSelector.tsx
+++ b/src/pages/components/StopSelector.tsx
@@ -10,8 +10,7 @@ type StopSelectorProps = {
 }
 
 const StopSelector = ({ stops, stopKey, setStopKey }: StopSelectorProps) => {
-  const valueFinned = stops.find((stop) => stop.key === stopKey)
-  const value = valueFinned ? valueFinned : null
+  const value = stops.find((stop) => stop.key === stopKey) || null
   const { t } = useTranslation()
 
   return (

--- a/src/pages/dashboard/ArrivalByTimeChart/DayTimeChart.tsx
+++ b/src/pages/dashboard/ArrivalByTimeChart/DayTimeChart.tsx
@@ -40,7 +40,7 @@ const DayTimeChart: FC<DayTimeChartProps> = ({ startDate, endDate, operatorId })
   )
 
   return (
-    <Widget>
+    <Widget marginBottom>
       <h2 className="title">
         {groupByHour ? t('dashboard_page_graph_title_hour') : t('dashboard_page_graph_title_day')}
       </h2>

--- a/src/pages/gapsPatterns/GapsPatternsPage.tsx
+++ b/src/pages/gapsPatterns/GapsPatternsPage.tsx
@@ -71,7 +71,7 @@ function GapsByHour({ lineRef, operatorRef, fromDate, toDate }: BusLineStatistic
 
   return (
     lineRef > 0 && (
-      <Widget>
+      <Widget marginBottom>
         {isLoading && lineRef ? (
           <Skeleton active />
         ) : (

--- a/src/pages/publicAppeal/index.tsx
+++ b/src/pages/publicAppeal/index.tsx
@@ -17,7 +17,7 @@ const PublicAppeal = () => {
           {t(`${pageName}.title`)}
         </Title>
         {tasks.map((task, i) => (
-          <Task title={task.title} description={task.description} index={i} key={i} />
+          <Task {...task} marginBottom={tasks.length - 1 === i} key={i} />
         ))}
       </Space>
     </PublicAppealStyle>
@@ -25,14 +25,14 @@ const PublicAppeal = () => {
 }
 
 type TaskDetails = {
-  index: number
   title: string
   description: string
+  marginBottom?: boolean
 }
 
-const Task = ({ index, title, description }: TaskDetails) => {
+const Task = ({ title, description, marginBottom }: TaskDetails) => {
   return (
-    <Widget key={index}>
+    <Widget marginBottom={marginBottom}>
       <h2 className="public">{title}</h2>
       <p>{description}</p>
       <a href="https://open-bus-stride-api.hasadna.org.il/docs">Open Bus Stride API</a>

--- a/src/pages/singleLineMap/index.tsx
+++ b/src/pages/singleLineMap/index.tsx
@@ -45,8 +45,9 @@ const SingleLineMapPage = () => {
         }))
       })
       .catch((err) => {
-        console.error(err)
-        setSearch((current) => ({ ...current, routes: undefined, routeKey: undefined }))
+        if (err?.cause?.name !== 'AbortError') {
+          setSearch((current) => ({ ...current, routes: undefined, routeKey: undefined }))
+        }
       })
 
     return () => controller.abort()
@@ -65,7 +66,7 @@ const SingleLineMapPage = () => {
     plannedRouteStops,
     startTime,
     setStartTime,
-  } = useSingleLineData(selectedRoute?.lineRef, selectedRoute?.routeIds)
+  } = useSingleLineData(selectedRoute?.lineRef, selectedRoute?.routeIds, timestamp)
 
   const handleTimestampChange = (time: moment.Moment | null) => {
     setSearch((current) => ({ ...current, timestamp: time?.valueOf() ?? Date.now() }))

--- a/src/pages/singleLineMap/index.tsx
+++ b/src/pages/singleLineMap/index.tsx
@@ -66,7 +66,7 @@ const SingleLineMapPage = () => {
     plannedRouteStops,
     startTime,
     setStartTime,
-  } = useSingleLineData(selectedRoute?.lineRef, selectedRoute?.routeIds, timestamp)
+  } = useSingleLineData(selectedRoute?.lineRef, selectedRoute?.routeIds)
 
   const handleTimestampChange = (time: moment.Moment | null) => {
     setSearch((current) => ({ ...current, timestamp: time?.valueOf() ?? Date.now() }))

--- a/src/shared/Widget.tsx
+++ b/src/shared/Widget.tsx
@@ -1,13 +1,18 @@
 import { Card, CardContent } from '@mui/material'
 import cn from 'classnames'
-
 import { useTheme } from 'src/layout/ThemeContext'
 
-const Widget = (props: { children?: React.ReactNode }) => {
+const Widget = ({
+  marginBottom,
+  children,
+}: {
+  marginBottom?: boolean
+  children?: React.ReactNode
+}) => {
   const { isDarkTheme } = useTheme()
   return (
-    <Card className={cn('card widget', { dark: isDarkTheme })}>
-      <CardContent>{props.children} </CardContent>
+    <Card className={cn('card widget', { dark: isDarkTheme, marginBottom })}>
+      <CardContent>{children} </CardContent>
     </Card>
   )
 }

--- a/src/shared/Widget.tsx
+++ b/src/shared/Widget.tsx
@@ -12,7 +12,7 @@ const Widget = ({
   const { isDarkTheme } = useTheme()
   return (
     <Card className={cn('card widget', { dark: isDarkTheme, marginBottom })}>
-      <CardContent>{children} </CardContent>
+      <CardContent>{children}</CardContent>
     </Card>
   )
 }

--- a/src/shared/shared.css
+++ b/src/shared/shared.css
@@ -1,6 +1,7 @@
 .widget {
   border-radius: 4px;
 }
+
 .widget.marginBottom {
   margin-bottom: 16px;
 }

--- a/src/shared/shared.css
+++ b/src/shared/shared.css
@@ -1,9 +1,8 @@
 .widget {
   border-radius: 4px;
 }
-
-.widget:last-of-type {
-  margin-bottom: 20px;
+.widget.marginBottom {
+  margin-bottom: 16px;
 }
 
 .card.dark {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd())
 
   return {
-    base: env?.ASSET_URL || '/',
+    base: env?.ASSET_URL || '',
     plugins: [
       react(),
       ...(env?.VITE_COVERAGE

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd())
 
   return {
-    base: env?.ASSET_URL || '',
+    base: env?.ASSET_URL || '/',
     plugins: [
       react(),
       ...(env?.VITE_COVERAGE


### PR DESCRIPTION
- **Widget**: Replace `last-of-type` with `marginBottom` props for consistent UI spacing.  
- **OperatorSelector**, **RouteSelector**: Reintroduce `null` as a possible `value` (was unintentionally removed in an earlier PR).  
- **StopSelector**: Set `getOptionKey`.  
- **Task**: Remove unnecessary `index` props and add `marginBottom` props.

I want to change this before I add the Operator page