### PR TITLE
fix: getAgencyList fallback

### DIFF
--- a/src/api/agencyList.ts
+++ b/src/api/agencyList.ts
@@ -21,21 +21,21 @@ const tryDates = [
  * @returns Agency data array, might contain DUPLICATE agencies with different `date` values
  */
 export default async function getAgencyList(): Promise<Agency[]> {
-  if (agencyList) return agencyList
-
-  let data: Agency[] = []
-  for (const date of tryDates) {
-    try {
-      const response = await fetch(`${BASE_PATH}/gtfs_agencies/list?date_from=${date}`)
-      if (!response.ok) continue
-      data = (await response.json()) as Agency[]
-      if (data.length > 0) break
-    } catch (err) {
-      console.error(err)
+  if (!agencyList) {
+    let data: Agency[] = []
+    for (const date of tryDates) {
+      try {
+        const response = await fetch(`${BASE_PATH}/gtfs_agencies/list?date_from=${date}`)
+        if (!response.ok) continue
+        data = (await response.json()) as Agency[]
+        if (data.length > 0) break
+      } catch (err) {
+        console.error(err)
+      }
     }
+    agencyList = data.filter(Boolean)
   }
 
-  agencyList = data.filter(Boolean)
   return agencyList
 }
 

--- a/src/api/agencyList.ts
+++ b/src/api/agencyList.ts
@@ -15,7 +15,10 @@ let agencyList: Agency[]
  */
 export default async function getAgencyList(): Promise<Agency[]> {
   if (!agencyList) {
-    const yesterday = moment().subtract(1, 'day').format('YYYY-MM-DD')
+    // Temporary workaround: using a fixed date for testing purposes.
+    // Replace with dynamic date logic when Backend fix.
+    // const yesterday = moment().subtract(1, 'day').format('YYYY-MM-DD')
+    const yesterday = moment('2025-05-18').format('YYYY-MM-DD')
     const response = await fetch(`${BASE_PATH}/gtfs_agencies/list?date_from=${yesterday}`)
     const data = (await response.json()) as Awaited<Agency[]>
     agencyList = data.filter(Boolean) // filter empty entries

--- a/src/api/agencyList.ts
+++ b/src/api/agencyList.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import moment from 'moment'
 import { BASE_PATH } from './apiConfig'
+
 export interface Agency {
   date: string // example - "2019-07-01"
   operator_ref: number // example - 25,
@@ -9,20 +10,32 @@ export interface Agency {
 
 let agencyList: Agency[]
 
+const tryDates = [
+  moment().subtract(1, 'day').format('YYYY-MM-DD'),
+  moment().subtract(8, 'day').format('YYYY-MM-DD'),
+  '2025-05-18',
+]
+
 /**
  * Fetch agency data from MOT api
  * @returns Agency data array, might contain DUPLICATE agencies with different `date` values
  */
 export default async function getAgencyList(): Promise<Agency[]> {
-  if (!agencyList) {
-    // Temporary workaround: using a fixed date for testing purposes.
-    // Replace with dynamic date logic when Backend fix.
-    // const yesterday = moment().subtract(1, 'day').format('YYYY-MM-DD')
-    const yesterday = moment('2025-05-18').format('YYYY-MM-DD')
-    const response = await fetch(`${BASE_PATH}/gtfs_agencies/list?date_from=${yesterday}`)
-    const data = (await response.json()) as Awaited<Agency[]>
-    agencyList = data.filter(Boolean) // filter empty entries
+  if (agencyList) return agencyList
+
+  let data: Agency[] = []
+  for (const date of tryDates) {
+    try {
+      const response = await fetch(`${BASE_PATH}/gtfs_agencies/list?date_from=${date}`)
+      if (!response.ok) continue
+      data = (await response.json()) as Agency[]
+      if (data.length > 0) break
+    } catch (err) {
+      console.error(err)
+    }
   }
+
+  agencyList = data.filter(Boolean)
   return agencyList
 }
 

--- a/tests/visual.spec.ts
+++ b/tests/visual.spec.ts
@@ -96,7 +96,7 @@ test.describe('Visual Tests', () => {
   test('operator page should look good', async ({ page }) => {
     await page.goto('/operator')
     await page.getByRole('combobox', { name: 'חברה מפעילה' }).click()
-    await page.getByRole('option', { name: 'אגד' }).click()
+    await page.getByRole('option', { name: 'אגד', exact: true }).click()
     await waitForSkeletonsToHide(page)
     await eyes.check('operator page', Target.window().layoutRegions('.chart', '.recharts-wrapper'))
   })


### PR DESCRIPTION
This PR addresses the following changes and fixes:

1. **Client API Update**: Disabled the dynamic date in the `getAgencyList()` method to ensure consistent data retrieval.
2. **Client Test Fix**: Resolved the visual test failure caused by operator discrepancies.

These updates are related to relevant issues: #1128.