### PR TITLE
fix: adjust debaunce from 200 miliseconds to 500 miliseconds

### DIFF
--- a/src/pages/components/LineSelector.tsx
+++ b/src/pages/components/LineSelector.tsx
@@ -13,7 +13,7 @@ type LineSelectorProps = {
 
 const LineSelector = ({ lineNumber, setLineNumber }: LineSelectorProps) => {
   const [value, setValue] = useState<LineSelectorProps['lineNumber']>(lineNumber)
-  const debouncedSetLineNumber = useCallback(debounce(setLineNumber, 200), [setLineNumber])
+  const debouncedSetLineNumber = useCallback(debounce(setLineNumber, 500), [setLineNumber])
   const { t } = useTranslation()
 
   useLayoutEffect(() => {


### PR DESCRIPTION
# Description
I simply adjusted the debounce rate of the line text box from 200 miliseconds to 500 miliseconds in order to prevent unneccessary  API calls to server.

This PR relates to bug #1113 