### PR TITLE
ci: fixing deployment comment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on: pull_request
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   build:


### PR DESCRIPTION
this permission change should propagate to the [deploy-preview.yml](https://github.com/hasadna/open-bus-map-search/blob/main/.github/workflows/deploy-preview.yml) workflow 

https://docs.github.com/en/actions/reference/workflows-and-actions/reusable-workflows#access-and-permissions-for-nested-workflows