### PR TITLE
fix: date selector styles in dark mode

### DIFF
--- a/src/pages/components/DateSelector.tsx
+++ b/src/pages/components/DateSelector.tsx
@@ -45,7 +45,6 @@ export function DateSelector({
       minDate={minDate || startOfTime}
       disabled={disabled}
       onError={(err) => setError(err)}
-      sx={{ width: { xs: '100%', sm: '70%' } }}
       slotProps={{
         calendarHeader: {
           sx: {
@@ -57,7 +56,6 @@ export function DateSelector({
         textField: {
           fullWidth: true,
           helperText: errorMessageKey && t(errorMessageKey),
-          sx: { bgcolor: '#ffffff', borderRadius: 1 },
         },
       }}
     />


### PR DESCRIPTION
revers styles  make in #1387
<img width="2991" height="435" alt="image" src="https://github.com/user-attachments/assets/81af3834-db5f-4918-8c3b-e718afae0bd5" />
left fix | right live page