### PR TITLE
fix: make Coveralls upload optional to tolerate server outages

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,6 +34,7 @@ jobs:
       - run: npx nyc report --reporter=lcovonly
       - name: Upload to Coveralls
         if: always()
+        continue-on-error: true
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `continue-on-error: true` to the Coveralls upload step
- Coveralls has been intermittently returning 530 errors (Cloudflare/server outages), causing the `Test with Coverage` job to show a red ❌ even though all tests pass
- With this change, a Coveralls outage shows a yellow ⚠️ warning instead of failing the job

## Test plan
- [ ] Verify `Test with Coverage` job passes even if Coveralls upload fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)