### PR TITLE
fix: replace hardcoded Hebrew text with i18n translations in DateNavigator and charts

### DIFF
--- a/src/locale/en.json
+++ b/src/locale/en.json
@@ -254,6 +254,12 @@
   "order_by_hour": "by hour",
   "order_by_severity": "by severity",
   "choose_dates": "Dates",
+  "date_navigator_prev_week": "Previous week",
+  "date_navigator_prev_day": "Previous day",
+  "date_navigator_today": "Today",
+  "date_navigator_next_day": "Next day",
+  "date_navigator_next_week": "Next week",
+  "gaps_tooltip_rides_executed": "{{percentage}}% of rides were executed ({{actual}}/{{planned}})",
   "single_line_map_title": "Locations of selected lines",
   "operatorSelectorOptions": {
     "all": "all"

--- a/src/locale/he.json
+++ b/src/locale/he.json
@@ -256,6 +256,12 @@
   "order_by_hour": "לפי שעה",
   "order_by_severity": "לפי חומרה",
   "choose_dates": "תאריכים",
+  "date_navigator_prev_week": "שבוע קודם",
+  "date_navigator_prev_day": "יום קודם",
+  "date_navigator_today": "היום",
+  "date_navigator_next_day": "יום הבא",
+  "date_navigator_next_week": "שבוע הבא",
+  "gaps_tooltip_rides_executed": "בוצעו {{percentage}}% מהנסיעות ({{actual}}/{{planned}})",
   "single_line_map_title": "מיקומים של קו שנבחר",
   "reportBug": {
     "description": "טופס זה נועד על מנת שנוכל לקבל פידבק ולשפר את האפליקציה. לתשומת לבך - הטופס נשלח לGitHub, והמידע שיצויין בו יהיה ציבורי.",

--- a/src/locale/ru.json
+++ b/src/locale/ru.json
@@ -253,6 +253,12 @@
   "order_by_hour": "по часам",
   "order_by_severity": "по серьезности",
   "choose_dates": "Даты",
+  "date_navigator_prev_week": "Предыдущая неделя",
+  "date_navigator_prev_day": "Предыдущий день",
+  "date_navigator_today": "Сегодня",
+  "date_navigator_next_day": "Следующий день",
+  "date_navigator_next_week": "Следующая неделя",
+  "gaps_tooltip_rides_executed": "Выполнено {{percentage}}% поездок ({{actual}}/{{planned}})",
   "single_line_map_title": "Местоположения выбранных линий",
   "operatorSelectorOptions": {
     "all": "все"

--- a/src/pages/components/dateNavigator/DateNavigator.tsx
+++ b/src/pages/components/dateNavigator/DateNavigator.tsx
@@ -1,5 +1,6 @@
 import { Today } from '@mui/icons-material'
 import { Box, Button, ButtonGroup } from '@mui/material'
+import { useTranslation } from 'react-i18next'
 import dayjs from 'src/dayjs'
 import './DateNavigator.scss'
 
@@ -9,6 +10,8 @@ interface DateNavigatorProps {
 }
 
 export const DateNavigator = ({ currentTime, onChange }: DateNavigatorProps) => {
+  const { t } = useTranslation()
+
   const handleChange = (amount: number, unit: 'day' | 'week') => {
     const newTime =
       amount > 0 ? currentTime.add(amount, unit) : currentTime.subtract(Math.abs(amount), unit)
@@ -28,22 +31,22 @@ export const DateNavigator = ({ currentTime, onChange }: DateNavigatorProps) => 
           borderRadius: 2,
         }}>
         <Button onClick={() => handleChange(-1, 'week')} className="nav-btn">
-          שבוע קודם
+          {t('date_navigator_prev_week')}
         </Button>
         <Button onClick={() => handleChange(-1, 'day')} className="nav-btn">
-          יום קודם
+          {t('date_navigator_prev_day')}
         </Button>
         <Button
           onClick={handleToday}
           className="nav-btn today"
           startIcon={<Today fontSize="small" />}>
-          היום
+          {t('date_navigator_today')}
         </Button>
         <Button onClick={() => handleChange(1, 'day')} className="nav-btn">
-          יום הבא
+          {t('date_navigator_next_day')}
         </Button>
         <Button onClick={() => handleChange(1, 'week')} className="nav-btn">
-          שבוע הבא
+          {t('date_navigator_next_week')}
         </Button>
       </ButtonGroup>
     </Box>

--- a/src/pages/dashboard/ArrivalByTimeChart/ArrivalByTimeChart.tsx
+++ b/src/pages/dashboard/ArrivalByTimeChart/ArrivalByTimeChart.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
 import {
   CartesianGrid,
   Line,
@@ -107,6 +108,7 @@ export default function ArrivalByTimeChart({
   data: ArrivalByTimeData[]
   operatorId: string
 }) {
+  const { t } = useTranslation()
   const filteredData = useMemo(() => filterDataByOperator(data, operatorId), [data, operatorId])
   const groupedData = useMemo(() => groupDataByHourOrDay(filteredData), [filteredData])
 
@@ -134,7 +136,7 @@ export default function ArrivalByTimeChart({
                     <Widget>
                       <InfoTable>
                         <InfoItem
-                          label="זמן"
+                          label={t('sample_time')}
                           value={dayjs(
                             // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                             payload[0].payload.gtfsRouteHour
@@ -144,10 +146,10 @@ export default function ArrivalByTimeChart({
                             payload[0].payload.gtfsRouteHour ? 'HH:mm-DD/MM/YY' : 'DD/MM/YY',
                           )}
                         />
-                        <InfoItem label="ביצוע" value={payload[0].payload.current} />
-                        <InfoItem label="תכנון" value={payload[0].payload.max} />
+                        <InfoItem label={t('rides_actual')} value={payload[0].payload.current} />
+                        <InfoItem label={t('rides_planned')} value={payload[0].payload.max} />
                         <InfoItem
-                          label="דיוק"
+                          label={t('planned_status')}
                           value={`${payload[0].payload.percent.toFixed(2)}%`}
                         />
                       </InfoTable>

--- a/src/pages/gapsPatterns/GapsPatternsPage.tsx
+++ b/src/pages/gapsPatterns/GapsPatternsPage.tsx
@@ -47,13 +47,18 @@ type CustomTooltipProps = TooltipProps<number, string> & {
 }
 
 const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
+  const { t } = useTranslation()
   if (active && payload && payload.length > 1) {
     const actualRides = payload[0].value || 0
     const plannedRides = payload[1].value || 0
     const actualPercentage = ((actualRides / plannedRides) * 100).toFixed(0)
     return (
       <div className="custom-tooltip tooltip-style">
-        {` בוצעו ${actualPercentage}% מהנסיעות (${actualRides}/${plannedRides})`}
+        {t('gaps_tooltip_rides_executed', {
+          percentage: actualPercentage,
+          actual: actualRides,
+          planned: plannedRides,
+        })}
       </div>
     )
   }


### PR DESCRIPTION
## Summary

Fixes #959

Several UI components were rendering hardcoded Hebrew text regardless of the user's selected language (English, Hebrew, Russian). This caused non-Hebrew users to see Hebrew labels even when the app was set to English or Russian.

### Components fixed

- **`DateNavigator`** — buttons showed hardcoded Hebrew: `שבוע קודם`, `יום קודם`, `היום`, `יום הבא`, `שבוע הבא`
- **`GapsPatternsPage`** — chart hover tooltip showed hardcoded Hebrew: `בוצעו X% מהנסיעות (actual/planned)`
- **`ArrivalByTimeChart`** — tooltip labels showed hardcoded Hebrew: `זמן`, `ביצוע`, `תכנון`, `דיוק`

### Changes

- Added new i18n keys to `en.json`, `he.json`, and `ru.json`:
  - `date_navigator_prev_week`, `date_navigator_prev_day`, `date_navigator_today`, `date_navigator_next_day`, `date_navigator_next_week`
  - `gaps_tooltip_rides_executed` (with interpolation: `{{percentage}}`, `{{actual}}`, `{{planned}}`)
- Updated all three components to use `useTranslation()` and `t()` calls
- Reused existing keys (`sample_time`, `rides_actual`, `rides_planned`, `planned_status`) in `ArrivalByTimeChart` where applicable

### Before / After

| Language | Before | After |
|---|---|---|
| English | `שבוע קודם` | `Previous week` |
| Russian | `שבוע קודם` | `Предыдущая неделя` |
| Hebrew | `שבוע קודם` | `שבוע קודם` ✓ |


