### PR TITLE
fix: hide dashboard menu item behind easter egg

### DIFF
--- a/src/layout/index.tsx
+++ b/src/layout/index.tsx
@@ -45,6 +45,11 @@ export function MainLayout() {
                     <Envelope />
                   </Link>
                 </EasterEgg>
+                <EasterEgg code="dashboard">
+                  <Link to="/dashboard">
+                    <Envelope />
+                  </Link>
+                </EasterEgg>
               </Suspense>
             </StyledBody>
           </StyledContent>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -45,12 +45,6 @@ export const PAGES = [
     element: <HomePage />,
   },
   {
-    label: 'dashboard_page_title',
-    path: '/dashboard',
-    icon: <LaptopOutlined />,
-    element: <DashboardPage />,
-  },
-  {
     label: 'timeline_page_title',
     path: '/timeline',
     searchParamsRequired: true,
@@ -133,6 +127,12 @@ export const HEADER_LINKS = [
 ] as const
 
 const HIDDEN_PAGES = [
+  {
+    label: 'dashboard_page_title',
+    path: '/dashboard',
+    icon: <LaptopOutlined />,
+    element: <DashboardPage />,
+  },
   {
     label: 'data-research',
     path: '/data-research',

--- a/tests/dashboard.spec.ts
+++ b/tests/dashboard.spec.ts
@@ -1,12 +1,4 @@
-import {
-  expect,
-  fillDateField,
-  harOptions,
-  setupTest,
-  test,
-  visitPage,
-  waitForSkeletonsToHide,
-} from './utils'
+import { expect, fillDateField, harOptions, setupTest, test, waitForSkeletonsToHide } from './utils'
 
 const TRIP_EXISTENCE_ITEMS = [
   'קיום נסיעות',
@@ -18,7 +10,9 @@ test.describe('dashboard tests', () => {
   test.beforeEach(async ({ page, advancedRouteFromHAR }) => {
     await setupTest(page)
     await advancedRouteFromHAR('tests/HAR/dashboard.har', harOptions)
-    await visitPage(page, 'dashboard_page_title')
+    await page.goto('/dashboard')
+    await page.locator('.preloader').waitFor({ state: 'hidden' })
+    await page.waitForLoadState('networkidle')
     await page.getByText('הקווים הגרועים ביותר').waitFor()
     await waitForSkeletonsToHide(page)
   })

--- a/tests/menu.spec.ts
+++ b/tests/menu.spec.ts
@@ -2,7 +2,6 @@ import { expect, setupTest, test } from './utils'
 
 const MENU_ITEMS = [
   'ראשי',
-  'קיום נסיעות',
   'היסטוריית נסיעות',
   'נסיעות שלא בוצעו',
   'דפוסי נסיעות שלא בוצעו',

--- a/tests/visual.spec.ts
+++ b/tests/visual.spec.ts
@@ -38,7 +38,10 @@ for (const mode of ['Light', 'Dark', 'LTR']) {
       eyes,
     }) => {
       await advancedRouteFromHAR('tests/HAR/dashboard.har', harOptions)
-      await visitPage(page, 'dashboard_page_title')
+      await page.goto('/dashboard')
+      await page.locator('.preloader').waitFor({ state: 'hidden' })
+      await page.waitForLoadState('networkidle')
+      await waitForSkeletonsToHide(page)
       await page.getByText('אגד').first().waitFor()
       await waitForSkeletonsToHide(page)
       await eyes.check('dashboard page', {
@@ -124,6 +127,7 @@ for (const mode of ['Light', 'Dark', 'LTR']) {
 
     test(`Data Research Page Should Look Good [${mode}]`, async ({ page, eyes }) => {
       await page.goto('/data-research')
+      await page.locator('.preloader').waitFor({ state: 'hidden' })
       await page.waitForLoadState('networkidle')
       await waitForSkeletonsToHide(page)
       await eyes.check('data research page')


### PR DESCRIPTION
## Summary
- hide the dashboard entry in the main menu behind the existing easter egg mechanism
- keep the non-functional dashboard page out of the default navigation for now
- update related tests to match the hidden menu state