### PR TITLE
fix: enable no-floating-promises lint rule and fix all violations

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -114,7 +114,7 @@ const StoryBookWrapper = ({
   }, [darkMode, isDarkTheme, toggleTheme])
 
   useEffect(() => {
-    i18n.changeLanguage(locale)
+    void i18n.changeLanguage(locale)
   }, [locale])
 
   return children

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -67,7 +67,7 @@ export default [
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',
-      '@typescript-eslint/no-floating-promises': 'off',
+      '@typescript-eslint/no-floating-promises': 'error',
       '@typescript-eslint/no-base-to-string': 'off',
       '@typescript-eslint/no-unsafe-assignment': 'off',
       // Prettier

--- a/src/hooks/useSingleLineData.ts
+++ b/src/hooks/useSingleLineData.ts
@@ -166,7 +166,7 @@ export const useSingleLineData = (
       }
     }
 
-    fetchOptions()
+    void fetchOptions()
   }, [positions, today, tomorrow, vehicleNumber])
 
   useEffect(() => {
@@ -218,7 +218,7 @@ export const useSingleLineData = (
         setPlannedRouteStops([])
       }
     }
-    fetchStops()
+    void fetchStops()
   }, [selectedRoute?.routeIds, operatorId, startTime, today])
 
   return {

--- a/src/hooks/useVehicleLocations.ts
+++ b/src/hooks/useVehicleLocations.ts
@@ -42,7 +42,7 @@ const loadedLocations = new Map<
  */
 class LocationObservable {
   constructor(query: VehicleLocationQuery) {
-    this.#loadData(query)
+    void this.#loadData(query)
   }
 
   data: SiriVehicleLocationWithRelatedPydanticModel[] = []

--- a/src/layout/ThemeContext.tsx
+++ b/src/layout/ThemeContext.tsx
@@ -42,7 +42,7 @@ export const ThemeProvider = ({ children }: PropsWithChildren) => {
   const changeLanguage = useCallback(
     (newLanguage: string) => {
       setLanguage(newLanguage)
-      i18n.changeLanguage(newLanguage)
+      void i18n.changeLanguage(newLanguage)
     },
     [i18n, setLanguage],
   )
@@ -59,7 +59,7 @@ export const ThemeProvider = ({ children }: PropsWithChildren) => {
 
   useEffect(() => {
     if (!language) return
-    i18n.changeLanguage(language)
+    void i18n.changeLanguage(language)
     document.title = i18n.t('website_name')
     document.documentElement.dir = i18n.dir()
     document.documentElement.lang = language

--- a/src/layout/header/HeaderLinks/HeaderLinks.tsx
+++ b/src/layout/header/HeaderLinks/HeaderLinks.tsx
@@ -50,7 +50,7 @@ const InternalLink = ({ label, path, icon }: LinkType) => {
       title={t(label)}
       className="header-link"
       onClick={() => {
-        navigate(path)
+        void navigate(path)
       }}>
       {icon}
     </div>

--- a/src/locale/allTranslations.ts
+++ b/src/locale/allTranslations.ts
@@ -11,7 +11,7 @@ const savedLang =
     ? localStorage.getItem('language') || 'he'
     : 'he'
 
-i18n.use(initReactI18next).init({
+void i18n.use(initReactI18next).init({
   showSupportNotice: false,
   resources: {
     ar: { translation: translationsAR },

--- a/src/pages/components/OperatorSelector.tsx
+++ b/src/pages/components/OperatorSelector.tsx
@@ -20,7 +20,7 @@ export default function OperatorSelector({
   const [operators, setOperators] = useState<Operator[]>([])
 
   useEffect(() => {
-    getOperators(filter).then(setOperators)
+    void getOperators(filter).then(setOperators)
   }, [filter])
 
   const value = operators.find((operator) => operator.id === operatorId) || null

--- a/src/pages/components/map-related/MapLayers/ComplaintModal.tsx
+++ b/src/pages/components/map-related/MapLayers/ComplaintModal.tsx
@@ -70,7 +70,7 @@ const ComplaintModal = ({ modalOpen = false, setModalOpen, position }: Complaint
 
   useEffect(() => {
     setIsLoading(true)
-    getSiriRideWithRelated(
+    void getSiriRideWithRelated(
       (position.point!.siriRouteId || 0).toString(),
       (position.point!.siriRideVehicleRef || '').toString(),
       (position.point!.siriRouteLineRef || 0).toString(),

--- a/src/pages/gapsPatterns/GapsPatternsPage.tsx
+++ b/src/pages/gapsPatterns/GapsPatternsPage.tsx
@@ -178,7 +178,7 @@ const GapsPatternsPage = () => {
       setSearch((current) => ({ ...current, routeKey: undefined, routes: undefined }))
       return
     }
-    loadSearchData(signal)
+    void loadSearchData(signal)
     return () => controller.abort()
   }, [operatorId, lineNumber, endDate, startDate, setSearch])
 

--- a/src/pages/gapsPatterns/useGapsList.ts
+++ b/src/pages/gapsPatterns/useGapsList.ts
@@ -50,7 +50,7 @@ export const useGapsList = (
         console.error('Error fetching data:', error)
       }
     }
-    fetchData()
+    void fetchData()
 
     return () => {
       setHourlyData([])

--- a/src/pages/lineProfile/LineProfile.tsx
+++ b/src/pages/lineProfile/LineProfile.tsx
@@ -63,7 +63,7 @@ const LineProfile = () => {
     if (!time || !route) return
 
     const abortController = new AbortController()
-    getRoutesAsync(
+    void getRoutesAsync(
       time,
       time,
       route?.operatorRef.toString(),
@@ -73,7 +73,7 @@ const LineProfile = () => {
       .then((routes) => {
         const newRoute = routes?.find((r) => r.key === `${route.routeMkt}-${route.routeDirection}`)
         if (newRoute?.routeIds?.[0]) {
-          navigate(`/profile/${newRoute.routeIds[0]}`)
+          void navigate(`/profile/${newRoute.routeIds[0]}`)
         }
       })
       .catch((error) => console.error(error))
@@ -83,7 +83,7 @@ const LineProfile = () => {
     if (!key || !routes) return
     const newRoute = routes?.find((route) => route.key === key)
     if (newRoute?.routeIds?.[0]) {
-      navigate(`/profile/${newRoute.routeIds[0]}`)
+      void navigate(`/profile/${newRoute.routeIds[0]}`)
     }
   }
 

--- a/src/pages/operator/OperatorRoutes.tsx
+++ b/src/pages/operator/OperatorRoutes.tsx
@@ -55,7 +55,7 @@ export const OperatorRoutes = ({
                           lineNumber: route.line + route.suffix,
                           routeKey: route.routeKey,
                         }))
-                        navigate('/single-line-map')
+                        void navigate('/single-line-map')
                       }}
                       to={`/single-line-map`}>
                       {t('operator.map')}

--- a/tests/bugReport.spec.ts
+++ b/tests/bugReport.spec.ts
@@ -18,7 +18,7 @@ test('An instruction video for Report a bug', async ({ page }) => {
   await page.getByLabel('bug').locator('svg').click()
   await page.getByLabel('לפתוח סרטון על העמוד הזה').locator('svg').click()
   const videoFrame = page.locator('iframe')
-  expect(videoFrame).toBeVisible()
+  await expect(videoFrame).toBeVisible()
   await expect(videoFrame).toHaveAttribute('src', VIDEO_SRC)
   await videoFrame.contentFrame().getByLabel('Play', { exact: true }).click()
   await page.getByLabel('Close', { exact: true }).click()


### PR DESCRIPTION
## Summary
- Enabled the `@typescript-eslint/no-floating-promises` ESLint rule (was previously disabled)
- Fixed all 16 violations across 13 files
- 15 fire-and-forget promises marked with `void` (i18n.changeLanguage, navigate, prefetch calls)
- 1 test assertion was missing `await`

Closes #1446

## Test plan
- [x] TypeScript compiles clean
- [x] ESLint passes with 0 warnings (including the new rule)
- [x] Stylelint + Prettier pass
- [x] Unit tests pass (9/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)