### PR TITLE
chore: add SonarCloud static analysis workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -31,7 +31,7 @@ jobs:
         run: npx jest --coverage --coverageReporters=lcov
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v5
+        uses: SonarSource/sonarqube-scan-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -25,7 +25,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Run unit tests with coverage
         run: npx jest --coverage --coverageReporters=lcov

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,37 @@
+name: SonarCloud Analysis
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  sonarcloud:
+    name: SonarCloud Scan
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.fork == false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests with coverage
+        run: npx jest --coverage --coverageReporters=lcov
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=eran132_open-bus-map-search
-sonar.organization=eran132
+sonar.projectKey=hasadna_open-bus-map-search
+sonar.organization=hasadna
 sonar.projectName=open-bus-map-search
 
 sonar.sources=src

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,14 @@
+sonar.projectKey=hasadna_open-bus-map-search
+sonar.organization=hasadna
+sonar.projectName=open-bus-map-search
+
+sonar.sources=src
+sonar.tests=src
+sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts
+sonar.exclusions=**/node_modules/**,**/*.spec.ts,**/*.stories.tsx
+sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.stories.tsx
+
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.typescript.lcov.reportPaths=coverage/lcov.info
+
+sonar.sourceEncoding=UTF-8

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,5 @@
-sonar.projectKey=hasadna_open-bus-map-search
-sonar.organization=hasadna
+sonar.projectKey=eran132_open-bus-map-search
+sonar.organization=eran132
 sonar.projectName=open-bus-map-search
 
 sonar.sources=src


### PR DESCRIPTION
## Summary
- Adds `sonar-project.properties` with project config (sources, exclusions, coverage paths)
- Adds `.github/workflows/sonarcloud.yml` GitHub Action that runs on PRs and pushes to main
- Runs Jest with coverage and uploads results to SonarCloud for code quality and security analysis
- Skips fork PRs (SonarCloud requires secrets)

## Setup required
An org admin needs to:
1. Register the project at [sonarcloud.io](https://sonarcloud.io) (free for open source)
2. Add `SONAR_TOKEN` to repository secrets

## Test plan
- [ ] Verify workflow triggers on PR
- [ ] Verify SonarCloud dashboard shows analysis results after setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)