### PR TITLE
fix: resolve SonarCloud critical issues and bugs

### DIFF
--- a/src/hooks/useVehicleLocations.ts
+++ b/src/hooks/useVehicleLocations.ts
@@ -41,8 +41,10 @@ const loadedLocations = new Map<
  * it also caches the data, so if the same interval is requested again, it will not load it again.
  */
 class LocationObservable {
-  constructor(query: VehicleLocationQuery) {
-    this.#loadData(query)
+  static create(query: VehicleLocationQuery) {
+    const instance = new LocationObservable()
+    void instance.#loadData(query)
+    return instance
   }
 
   data: SiriVehicleLocationWithRelatedPydanticModel[] = []
@@ -139,7 +141,10 @@ function getLocations(
 ) {
   const key = `${formatTime(from)}-${formatTime(to)}-${operatorRef}-${lineRef}-${vehicleRef}`
   if (!loadedLocations.has(key)) {
-    loadedLocations.set(key, new LocationObservable({ from, to, lineRef, vehicleRef, operatorRef }))
+    loadedLocations.set(
+      key,
+      LocationObservable.create({ from, to, lineRef, vehicleRef, operatorRef }),
+    )
   }
   const observable = loadedLocations.get(key)!
   return observable.observe(onUpdate)

--- a/src/pages/components/map-related/MapLayers/BusToolTip.tsx
+++ b/src/pages/components/map-related/MapLayers/BusToolTip.tsx
@@ -171,7 +171,7 @@ export function BusToolTip({ position, icon, children }: BusToolTipProps) {
                   data={position}
                   name={t('line')}
                 />
-                {route?.id && (
+                {route?.id != null && (
                   <CustomTreeView<GtfsRoutePydanticModel>
                     id={route?.id.toString()}
                     data={route}

--- a/src/pages/dashboard/WorstLinesChart/WorstLinesChart.tsx
+++ b/src/pages/dashboard/WorstLinesChart/WorstLinesChart.tsx
@@ -24,7 +24,10 @@ const convertToWorstLineChartCompatibleStruct = (arr: GroupByRes[], operatorId?:
     .map(
       (item) =>
         ({
-          id: `${item.lineRef}|${item.operatorRef?.operatorRef}` || 'Unknown',
+          id:
+            item.lineRef && item.operatorRef?.operatorRef
+              ? `${item.lineRef}|${item.operatorRef.operatorRef}`
+              : 'Unknown',
           operator_name: item.operatorRef?.agencyName || 'Unknown',
           short_name: JSON.parse(item.routeShortName || "['']")[0],
           long_name: item.routeLongName,


### PR DESCRIPTION
## Summary
Fixes critical issues and bugs identified by SonarCloud static analysis (see [dashboard](https://sonarcloud.io/project/overview?id=eran132_open-bus-map-search)):

- **CRITICAL**: Refactored `LocationObservable` to use a static factory method instead of launching async operations in the constructor
- **BUG**: Fixed conditional value leak in `BusToolTip` JSX — `route?.id && (...)` could render `0` in the DOM when `id` is `0`. Changed to `route?.id != null`
- **BUG**: Fixed dead code in `WorstLinesChart` — template literal `` `${x}|${y}` || 'Unknown' `` is always truthy, so the `'Unknown'` fallback was unreachable. Now checks values before interpolation

Skipped `TimelinePage.ts` false positive — Playwright's fixture `use()` was incorrectly flagged as a React Hook.

## Test plan
- [x] TypeScript compiles clean
- [x] ESLint + Prettier + Stylelint pass with 0 warnings
- [x] Unit tests pass (9/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)