### PR TITLE
fix: show success message on bug report submission

### DIFF
--- a/src/pages/bugReport/BugReportForm.tsx
+++ b/src/pages/bugReport/BugReportForm.tsx
@@ -19,11 +19,8 @@ const BugReportForm = () => {
   const mutation = useMutation({
     mutationFn: (values: CreateIssuePostRequest) =>
       ISSUES_API.issuesCreatePost({ createIssuePostRequest: values }),
-    onSuccess: (response) => {
-      if (response.data?.state === 'open') {
-        form.resetFields()
-        // setFileList([])
-      }
+    onSuccess: () => {
+      form.resetFields()
     },
     onError: (error) => {
       console.error('Error submitting bug report:', error)
@@ -62,11 +59,15 @@ const BugReportForm = () => {
         </p>
       }>
       <span>{t('reportBug.description')}</span>
-      {mutation.isSuccess && mutation.data?.data && (
+      {mutation.isSuccess && (
         <Alert severity="success" sx={{ marginBottom: 2 }}>
-          <a href={mutation.data.data.url} target="_blank" rel="noopener noreferrer">
-            {t('reportBug.viewIssue')} (Github)
-          </a>
+          {mutation.data?.data?.url ? (
+            <a href={mutation.data.data.url} target="_blank" rel="noopener noreferrer">
+              {t('reportBug.viewIssue')} (Github)
+            </a>
+          ) : (
+            t('reportBug.success', { defaultValue: 'Bug report submitted successfully!' })
+          )}
         </Alert>
       )}
 


### PR DESCRIPTION
## Summary
The bug report form showed an error message even when the GitHub issue was created successfully. The `onSuccess` handler checked `response.data?.state === 'open'` which didn't match the actual API response structure.

- Removed the strict `state === 'open'` check — form now resets on any successful API call
- Show success alert even when the issue URL isn't available in the response (fallback message)
- Users will no longer see a false error and submit duplicate reports

Closes #1431

## Test plan
- [x] TypeScript compiles clean
- [x] ESLint + Prettier pass
- [x] Unit tests pass (9/9)
- [x] Existing Playwright tests cover success submission (mocked API returns 200 → success alert visible)
- [x] Existing Playwright tests cover error submission (mocked API returns 500 → error alert visible)
- [x] Existing Playwright tests cover missing field validation

Note: `tests/bugReport.spec.ts` already has E2E tests for both success (`bug submission success`) and error (`bug submission server error`) use cases with mocked backend endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)