### PR TITLE
feat: add sticky inputs section to gaps and timeline pages

### DIFF
--- a/src/pages/components/StickyInputs.tsx
+++ b/src/pages/components/StickyInputs.tsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components'
+
+export const StickyInputs = styled.div`
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background: inherit;
+  padding-bottom: 8px;
+`

--- a/src/pages/gaps/index.tsx
+++ b/src/pages/gaps/index.tsx
@@ -14,6 +14,7 @@ import OperatorSelector from '../components/OperatorSelector'
 import { PageContainer } from '../components/PageContainer'
 import RouteSelector from '../components/RouteSelector'
 import { Row } from '../components/Row'
+import { StickyInputs } from '../components/StickyInputs'
 import GapsTable from './GapsTable'
 
 const GapsPage = () => {
@@ -102,50 +103,52 @@ const GapsPage = () => {
       <Alert severity="info" variant="outlined" icon={false}>
         {t('gaps_page_description')}
       </Alert>
-      <Grid container spacing={2} sx={{ maxWidth: INPUT_SIZE }}>
-        {/* choose date */}
-        <Grid size={{ xs: 4 }}>
-          <Label text={t('choose_date')} />
+      <StickyInputs>
+        <Grid container spacing={2} sx={{ maxWidth: INPUT_SIZE }}>
+          {/* choose date */}
+          <Grid size={{ xs: 4 }}>
+            <Label text={t('choose_date')} />
+          </Grid>
+          <Grid size={{ xs: 8 }}>
+            <DateSelector time={dayjs(timestamp)} onChange={handleTimestampChange} />
+          </Grid>
+          {/* choose operator */}
+          <Grid size={{ xs: 4 }}>
+            <Label text={t('choose_operator')} />
+          </Grid>
+          <Grid size={{ xs: 8 }}>
+            <OperatorSelector operatorId={operatorId} setOperatorId={handleOperatorChange} />
+          </Grid>
+          {/* choose line */}
+          <Grid size={{ xs: 4 }}>
+            <Label text={t('choose_line')} />
+          </Grid>
+          <Grid size={{ xs: 8 }}>
+            <LineNumberSelector lineNumber={lineNumber} setLineNumber={handleLineNumberChange} />
+          </Grid>
+          {/* choose routes */}
+          <Grid size={{ xs: 12 }}>
+            {routes?.length === 0 ? (
+              <NotFound>{t('line_not_found')}</NotFound>
+            ) : (
+              <RouteSelector
+                routes={routes || []}
+                disabled={!routes}
+                routeKey={routeKey}
+                setRouteKey={handleRouteKeyChange}
+              />
+            )}
+          </Grid>
+          <Grid size={{ xs: 12 }}>
+            {gapsIsLoading && (
+              <Row>
+                <Label text={t('loading_gaps')} />
+                <CircularProgress />
+              </Row>
+            )}
+          </Grid>
         </Grid>
-        <Grid size={{ xs: 8 }}>
-          <DateSelector time={dayjs(timestamp)} onChange={handleTimestampChange} />
-        </Grid>
-        {/* choose operator */}
-        <Grid size={{ xs: 4 }}>
-          <Label text={t('choose_operator')} />
-        </Grid>
-        <Grid size={{ xs: 8 }}>
-          <OperatorSelector operatorId={operatorId} setOperatorId={handleOperatorChange} />
-        </Grid>
-        {/* choose line */}
-        <Grid size={{ xs: 4 }}>
-          <Label text={t('choose_line')} />
-        </Grid>
-        <Grid size={{ xs: 8 }}>
-          <LineNumberSelector lineNumber={lineNumber} setLineNumber={handleLineNumberChange} />
-        </Grid>
-        {/* choose routes */}
-        <Grid size={{ xs: 12 }}>
-          {routes?.length === 0 ? (
-            <NotFound>{t('line_not_found')}</NotFound>
-          ) : (
-            <RouteSelector
-              routes={routes || []}
-              disabled={!routes}
-              routeKey={routeKey}
-              setRouteKey={handleRouteKeyChange}
-            />
-          )}
-        </Grid>
-        <Grid size={{ xs: 12 }}>
-          {gapsIsLoading && (
-            <Row>
-              <Label text={t('loading_gaps')} />
-              <CircularProgress />
-            </Row>
-          )}
-        </Grid>
-      </Grid>
+      </StickyInputs>
       {routeKey && routeKey !== '' && (
         <GapsTable
           loading={gapsIsLoading}

--- a/src/pages/historicTimeline/index.tsx
+++ b/src/pages/historicTimeline/index.tsx
@@ -15,6 +15,7 @@ import LineNumberSelector from 'src/pages/components/LineSelector'
 import OperatorSelector from 'src/pages/components/OperatorSelector'
 import RouteSelector from 'src/pages/components/RouteSelector'
 import { Row } from 'src/pages/components/Row'
+import { StickyInputs } from 'src/pages/components/StickyInputs'
 import StopSelector from 'src/pages/components/StopSelector'
 import { TimelineBoard } from 'src/pages/components/timeline/TimelineBoard'
 import { MARGIN_MEDIUM } from 'src/resources/sizes'
@@ -108,108 +109,112 @@ const TimelinePage = () => {
             {t('no_data_from_ETL')}
           </Alert>
         )}
-      <Grid container spacing={2}>
-        {/* choose date */}
-        <Grid size={{ lg: 4, md: 6, xs: 12 }}>
-          <DateSelector
-            time={dayjs(timestamp)}
-            onChange={(ts) => {
-              if (!ts) return
-              const currentTime = dayjs(timestamp)
-              const newTimestamp = ts
-                .hour(currentTime.hour())
-                .minute(currentTime.minute())
-                .second(currentTime.second())
-                .valueOf()
-              setSearch((current) => ({ ...current, timestamp: newTimestamp }))
-            }}
-          />
-        </Grid>
-        {/* choose time */}
-        <Grid size={{ lg: 4, md: 6, xs: 12 }}>
-          <TimeSelector
-            time={dayjs(timestamp)}
-            onChange={(ts) => {
-              if (!ts) return
-              const currentDate = dayjs(timestamp)
-              const newTimestamp = currentDate
-                .hour(ts.hour())
-                .minute(ts.minute())
-                .second(ts.second())
-                .valueOf()
-              setSearch((current) => ({ ...current, timestamp: newTimestamp }))
-            }}
-          />
-        </Grid>
-        {/* choose operator */}
-        <Grid size={{ lg: 4, md: 6, xs: 12 }}>
-          <OperatorSelector
-            operatorId={operatorId}
-            setOperatorId={(id) => setSearch((current) => ({ ...current, operatorId: id }))}
-          />
-        </Grid>
-        {/* choose line */}
-        <Grid size={{ lg: 4, md: 6, xs: 12 }}>
-          <LineNumberSelector
-            lineNumber={lineNumber}
-            setLineNumber={(number) => setSearch((current) => ({ ...current, lineNumber: number }))}
-          />
-        </Grid>
-        {/* routes */}
-        <Grid container size={{ lg: 4, md: 6, xs: 12 }}>
-          <Row style={{ width: '100%' }}>
-            <div style={{ width: '100%' }}>
-              {routesQuery.data?.length === 0 ? (
-                <NotFound>{t('line_not_found')}</NotFound>
-              ) : (
-                <RouteSelector
-                  disabled={!routesQuery.data}
-                  routes={routesQuery.data || []}
-                  routeKey={routeKey}
-                  setRouteKey={(key) => setSearch((current) => ({ ...current, routeKey: key }))}
+      <StickyInputs>
+        <Grid container spacing={2}>
+          {/* choose date */}
+          <Grid size={{ lg: 4, md: 6, xs: 12 }}>
+            <DateSelector
+              time={dayjs(timestamp)}
+              onChange={(ts) => {
+                if (!ts) return
+                const currentTime = dayjs(timestamp)
+                const newTimestamp = ts
+                  .hour(currentTime.hour())
+                  .minute(currentTime.minute())
+                  .second(currentTime.second())
+                  .valueOf()
+                setSearch((current) => ({ ...current, timestamp: newTimestamp }))
+              }}
+            />
+          </Grid>
+          {/* choose time */}
+          <Grid size={{ lg: 4, md: 6, xs: 12 }}>
+            <TimeSelector
+              time={dayjs(timestamp)}
+              onChange={(ts) => {
+                if (!ts) return
+                const currentDate = dayjs(timestamp)
+                const newTimestamp = currentDate
+                  .hour(ts.hour())
+                  .minute(ts.minute())
+                  .second(ts.second())
+                  .valueOf()
+                setSearch((current) => ({ ...current, timestamp: newTimestamp }))
+              }}
+            />
+          </Grid>
+          {/* choose operator */}
+          <Grid size={{ lg: 4, md: 6, xs: 12 }}>
+            <OperatorSelector
+              operatorId={operatorId}
+              setOperatorId={(id) => setSearch((current) => ({ ...current, operatorId: id }))}
+            />
+          </Grid>
+          {/* choose line */}
+          <Grid size={{ lg: 4, md: 6, xs: 12 }}>
+            <LineNumberSelector
+              lineNumber={lineNumber}
+              setLineNumber={(number) =>
+                setSearch((current) => ({ ...current, lineNumber: number }))
+              }
+            />
+          </Grid>
+          {/* routes */}
+          <Grid container size={{ lg: 4, md: 6, xs: 12 }}>
+            <Row style={{ width: '100%' }}>
+              <div style={{ width: '100%' }}>
+                {routesQuery.data?.length === 0 ? (
+                  <NotFound>{t('line_not_found')}</NotFound>
+                ) : (
+                  <RouteSelector
+                    disabled={!routesQuery.data}
+                    routes={routesQuery.data || []}
+                    routeKey={routeKey}
+                    setRouteKey={(key) => setSearch((current) => ({ ...current, routeKey: key }))}
+                  />
+                )}
+              </div>
+              {routesQuery.isLoading && <CircularProgress />}
+            </Row>
+          </Grid>
+          {/* stops */}
+          <Grid container size={{ lg: 4, md: 6, xs: 12 }}>
+            <Row style={{ width: '100%' }}>
+              <div style={{ width: '100%' }}>
+                <StopSelector
+                  disabled={!stopsQuery.data}
+                  stops={stopsQuery.data || []}
+                  stopKey={stopKey}
+                  setStopKey={(key) => setStopKey(key)}
                 />
-              )}
-            </div>
-            {routesQuery.isLoading && <CircularProgress />}
-          </Row>
+              </div>
+              {stopsQuery.isLoading && <CircularProgress />}
+            </Row>
+          </Grid>
         </Grid>
-        {/* stops */}
-        <Grid container size={{ lg: 4, md: 6, xs: 12 }}>
-          <Row style={{ width: '100%' }}>
-            <div style={{ width: '100%' }}>
-              <StopSelector
-                disabled={!stopsQuery.data}
-                stops={stopsQuery.data || []}
-                stopKey={stopKey}
-                setStopKey={(key) => setStopKey(key)}
+      </StickyInputs>
+      {/* hits timeline */}
+      {selectedRoute && selectedStop && (
+        <Widget marginBottom>
+          {hitsQuery.isLoading && (
+            <Row>
+              <Label text={t('loading_hits')} />
+              <CircularProgress />
+            </Row>
+          )}
+          {!hitsQuery.isLoading &&
+            ((hitsQuery.data?.gtfsTime && hitsQuery.data.gtfsTime.length > 0) ||
+            (hitsQuery.data?.siriTime && hitsQuery.data.siriTime.length > 0) ? (
+              <StyledTimelineBoard
+                target={dayjs(timestamp)}
+                gtfsTimes={hitsQuery.data.gtfsTime}
+                siriTimes={hitsQuery.data.siriTime}
               />
-            </div>
-            {stopsQuery.isLoading && <CircularProgress />}
-          </Row>
-        </Grid>
-        {/* hits timeline */}
-        {selectedRoute && selectedStop && (
-          <Widget marginBottom>
-            {hitsQuery.isLoading && (
-              <Row>
-                <Label text={t('loading_hits')} />
-                <CircularProgress />
-              </Row>
-            )}
-            {!hitsQuery.isLoading &&
-              ((hitsQuery.data?.gtfsTime && hitsQuery.data.gtfsTime.length > 0) ||
-              (hitsQuery.data?.siriTime && hitsQuery.data.siriTime.length > 0) ? (
-                <StyledTimelineBoard
-                  target={dayjs(timestamp)}
-                  gtfsTimes={hitsQuery.data.gtfsTime}
-                  siriTimes={hitsQuery.data.siriTime}
-                />
-              ) : (
-                <NotFound>{t('hits_not_found')}</NotFound>
-              ))}
-          </Widget>
-        )}
-      </Grid>
+            ) : (
+              <NotFound>{t('hits_not_found')}</NotFound>
+            ))}
+        </Widget>
+      )}
     </PageContainer>
   )
 }


### PR DESCRIPTION
## Summary
Created a reusable `StickyInputs` component that keeps filter controls visible when scrolling through results. Applied to:
- **Gaps page** — date, operator, line, and route selectors stay pinned at top
- **Historic timeline page** — all input controls stay visible while scrolling through timeline data

Uses CSS `position: sticky` with `z-index: 100` and inherits the page background.

Closes #1059

## Test plan
- [x] TypeScript compiles clean
- [x] ESLint passes on changed files
- [x] Unit tests pass (9/9)
- [x] CI Playwright tests pass
- [x] CI Docker build passes

Note: Working from a fork so visual tests/previews are unavailable. Happy to re-submit from a branch on the main repo now that I have contributor access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)