### PR TITLE
fix: handle rides that continue past midnight (service day)

### DIFF
--- a/src/hooks/useSingleLineData.ts
+++ b/src/hooks/useSingleLineData.ts
@@ -5,6 +5,7 @@ import useVehicleLocations from 'src/hooks/useVehicleLocations'
 import { BusRoute } from 'src/model/busRoute'
 import { BusStop } from 'src/model/busStop'
 import { SearchContext } from 'src/model/pageState'
+import { getServiceDayBounds } from 'src/model/serviceDay'
 import { type Point, toPoint } from 'src/pages/components/map-related/map-types'
 import { routeStartEnd, vehicleIDFormat } from 'src/pages/components/utils/rotueUtils'
 import {
@@ -85,9 +86,9 @@ export const useSingleLineData = (
     return routes?.find((route) => route.key === routeKey)
   }, [routes, routeKey])
 
-  const [today, tomorrow] = useMemo(() => {
-    const today = dayjs(search.timestamp).startOf('day')
-    return [today, today.add(1, 'day')]
+  const [serviceDayStart, serviceDayEnd] = useMemo(() => {
+    const { start, end } = getServiceDayBounds(dayjs(search.timestamp))
+    return [start, end]
   }, [search.timestamp])
 
   const validVehicleNumber = useMemo(() => {
@@ -97,8 +98,8 @@ export const useSingleLineData = (
   }, [vehicleNumber])
 
   const { locations, isLoading: locationsAreLoading } = useVehicleLocations({
-    from: today.valueOf(),
-    to: tomorrow.valueOf(),
+    from: serviceDayStart.valueOf(),
+    to: serviceDayEnd.valueOf(),
     operatorRef: operatorId ? Number(operatorId) : undefined,
     lineRef: selectedRoute?.lineRef ? Number(selectedRoute.lineRef) : undefined,
     vehicleRef: validVehicleNumber,
@@ -121,7 +122,7 @@ export const useSingleLineData = (
         const startTime = position.point?.siriRideScheduledStartTime
         if (!startTime) continue
         const dayjsTime = dayjs(startTime)
-        if (dayjsTime.isAfter(today) && dayjsTime.isBefore(tomorrow)) {
+        if (!dayjsTime.isBefore(serviceDayStart) && dayjsTime.isBefore(serviceDayEnd)) {
           const formattedTime = formatTime(dayjsTime)
           const key = `${formattedTime}|${position.point?.siriRideVehicleRef}`
           if (!uniqueTimes.has(key)) {
@@ -167,7 +168,7 @@ export const useSingleLineData = (
     }
 
     fetchOptions()
-  }, [positions, today, tomorrow, vehicleNumber])
+  }, [positions, serviceDayStart, serviceDayEnd, vehicleNumber])
 
   useEffect(() => {
     const parsedStartTime = parseStartTimeToken(startTime)
@@ -198,7 +199,11 @@ export const useSingleLineData = (
         const scheduledTime = parsedStartTime?.scheduledTime
         const scheduledLine = parsedStartTime?.lineRef
         const [hour, minute] = scheduledTime ? scheduledTime.split(':').map(Number) : [0, 0]
-        const startTimeTimestamp = today.hour(hour).minute(minute).second(0).millisecond(0)
+        const startTimeTimestamp = serviceDayStart
+          .hour(hour)
+          .minute(minute)
+          .second(0)
+          .millisecond(0)
         let routeIds: number[] | undefined
         if (selectedRoute?.routeIds && selectedRoute.routeIds.length > 0) {
           routeIds = selectedRoute.routeIds
@@ -219,7 +224,7 @@ export const useSingleLineData = (
       }
     }
     fetchStops()
-  }, [selectedRoute?.routeIds, operatorId, startTime, today])
+  }, [selectedRoute?.routeIds, operatorId, startTime, serviceDayStart])
 
   return {
     positions: filteredPositions,

--- a/src/model/serviceDay.ts
+++ b/src/model/serviceDay.ts
@@ -1,0 +1,90 @@
+/**
+ * Service Day Handling for Israeli Public Transit
+ *
+ * In the GTFS (General Transit Feed Specification) standard, a "service day"
+ * does not end at midnight. Instead, it extends past midnight to cover
+ * late-night routes that depart before midnight but arrive after.
+ *
+ * The GTFS spec represents post-midnight times using values > 24:00:00.
+ * For example, 1:30 AM on a service day that started the previous calendar
+ * day is represented as 25:30:00.
+ *
+ * Israeli bus routes commonly run past midnight. A bus departing at 23:30
+ * may complete its route at 00:30 the next calendar day. Without extending
+ * the query window past midnight, these rides appear to vanish at midnight.
+ *
+ * Industry standard implementations:
+ *   - OpenTripPlanner: uses a 3-day query window
+ *   - Transitland API: automatically includes overnight trips
+ *   - This app: extends the service day to 4:00 AM (28 hours)
+ *
+ * Reference: https://gtfs.org/documentation/schedule/reference/
+ * See also: stop_times.txt departure_time field documentation
+ */
+import dayjs from 'src/dayjs'
+
+/**
+ * The hour at which a service day ends (on the next calendar day).
+ * 4 AM is a common convention — most transit agencies do not schedule
+ * new service departures between ~2 AM and ~5 AM.
+ */
+export const SERVICE_DAY_END_HOUR = 4
+
+/**
+ * Total hours in a service day (24 + SERVICE_DAY_END_HOUR).
+ */
+export const SERVICE_DAY_HOURS = 24 + SERVICE_DAY_END_HOUR
+
+/**
+ * Returns the service day boundaries for a given timestamp.
+ *
+ * A service day starts at midnight (00:00) of the selected date
+ * and extends to SERVICE_DAY_END_HOUR (04:00) of the next calendar day.
+ *
+ * @example
+ * // For January 15th:
+ * // start = Jan 15 00:00
+ * // end   = Jan 16 04:00
+ * const { start, end } = getServiceDayBounds(dayjs('2024-01-15T14:00:00'))
+ */
+export function getServiceDayBounds(timestamp: dayjs.Dayjs) {
+  const start = timestamp.startOf('day')
+  const end = start.add(SERVICE_DAY_HOURS, 'hour')
+  return { start, end }
+}
+
+/**
+ * Converts a post-midnight hour (0-3) to its service day equivalent (24-27).
+ * Hours 4-23 are returned unchanged.
+ *
+ * This is useful for sorting and displaying times in service day order,
+ * where 00:30 after midnight should appear after 23:30, not before 01:00.
+ *
+ * @example
+ * toServiceDayHour(23) // => 23
+ * toServiceDayHour(0)  // => 24
+ * toServiceDayHour(1)  // => 25
+ * toServiceDayHour(3)  // => 27
+ * toServiceDayHour(4)  // => 4
+ */
+export function toServiceDayHour(hour: number): number {
+  return hour < SERVICE_DAY_END_HOUR ? hour + 24 : hour
+}
+
+/**
+ * Formats a service day hour for display.
+ * Hours 24-27 are displayed as "00:xx-03:xx (+1)" to indicate next day.
+ * Regular hours are displayed normally.
+ *
+ * @example
+ * formatServiceDayHour(23)  // => "23:00"
+ * formatServiceDayHour(24)  // => "00:00 (+1)"
+ * formatServiceDayHour(25)  // => "01:00 (+1)"
+ */
+export function formatServiceDayHour(serviceDayHour: number): string {
+  if (serviceDayHour >= 24) {
+    const displayHour = serviceDayHour - 24
+    return `${String(displayHour).padStart(2, '0')}:00 (+1)`
+  }
+  return `${String(serviceDayHour).padStart(2, '0')}:00`
+}

--- a/src/pages/gaps/GapsTable.tsx
+++ b/src/pages/gaps/GapsTable.tsx
@@ -84,8 +84,9 @@ const GapsTable: React.FC<GapsTableProps> = ({
   const groupedGaps = useMemo(() => {
     const map: Record<string, { gap: Gap; status: keyof typeof colors }[]> = {}
     for (const gap of filteredGaps) {
-      const hour = gap.plannedStartTime?.get('hour') ?? gap.actualStartTime?.get('hour')
-      if (hour === undefined) continue
+      const rawHour = gap.plannedStartTime?.get('hour') ?? gap.actualStartTime?.get('hour')
+      if (rawHour === undefined) continue
+      const hour = rawHour < 4 ? rawHour + 24 : rawHour
       const status = formatStatus(gap, filteredGaps)
       if (!map[hour]) map[hour] = []
       map[hour].push({ gap, status })
@@ -125,7 +126,7 @@ const GapsTable: React.FC<GapsTableProps> = ({
           <Table sx={{ maxWidth: 'fit-content' }}>
             <TableBody>
               {Object.keys(groupedGaps)
-                .sort((a, b) => (a === '0' ? 1 : b === '0' ? -1 : Number(a) - Number(b)))
+                .sort((a, b) => Number(a) - Number(b))
                 .map((hour) => (
                   <TableRow key={hour}>
                     {groupedGaps[hour].map(({ gap, status }, j) => {

--- a/src/pages/gaps/index.tsx
+++ b/src/pages/gaps/index.tsx
@@ -2,6 +2,7 @@ import { Alert, CircularProgress, Grid, Typography } from '@mui/material'
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import dayjs from 'src/dayjs'
+import { getServiceDayBounds } from 'src/model/serviceDay'
 import { INPUT_SIZE } from 'src/resources/sizes'
 import { Gap, getGapsAsync } from '../../api/gapsService'
 import { getRoutesAsync } from '../../api/gtfsService'
@@ -38,7 +39,8 @@ const GapsPage = () => {
     if (!selectedRoute) return
 
     setGapsIsLoading(true)
-    getGapsAsync(timestamp, timestamp, operatorId, selectedRoute.lineRef)
+    const { start, end } = getServiceDayBounds(dayjs(timestamp))
+    getGapsAsync(start.valueOf(), end.valueOf(), operatorId, selectedRoute.lineRef)
       .then(setGaps)
       .catch((err) => {
         console.error('Failed to fetch gaps:', err.message)


### PR DESCRIPTION
## Summary

Israeli buses commonly run past midnight. A ride departing at 23:30 may arrive at 00:30 the next day. Previously, post-midnight segments were invisible because the app queried midnight-to-midnight and filtered strictly within that window.

This fix introduces the GTFS **service day** concept — a transit day extends to 4:00 AM the next morning (28 hours), following the industry standard.

### What changed

**New file: `src/model/serviceDay.ts`**
- Documented module explaining the GTFS service day concept
- `getServiceDayBounds(timestamp)` — returns `{ start, end }` for a service day
- `toServiceDayHour(hour)` — converts post-midnight hours 0-3 to 24-27
- `formatServiceDayHour(hour)` — formats hours for display (e.g., `"00:00 (+1)"`)
- Constants: `SERVICE_DAY_END_HOUR = 4`, `SERVICE_DAY_HOURS = 28`

**`src/hooks/useSingleLineData.ts`**
- Extended fetch window from `[00:00, 24:00]` to `[00:00, 04:00+1]`
- Changed `isAfter(today) && isBefore(tomorrow)` to `!isBefore(start) && isBefore(end)` (inclusive start, exclusive end)

**`src/pages/gaps/index.tsx`**
- Changed from `getGapsAsync(timestamp, timestamp, ...)` to `getGapsAsync(dayStart, dayEnd, ...)`

**`src/pages/gaps/GapsTable.tsx`**
- Post-midnight hours (0-3) now map to 24-27 for correct service day ordering
- Removed old sort hack that pushed hour 0 to the end

### Industry reference
- **GTFS spec**: Times > 24:00:00 for post-midnight service ([reference](https://gtfs.org/documentation/schedule/reference/))
- **OpenTripPlanner**: 3-day query window
- **Transitland API**: Automatically includes overnight trips
- **Maintainer recommendation**: "Pull vehicle locations up to 4AM next morning" — @NoamGaash

Closes #1333

## Test plan
- [x] TypeScript compiles clean
- [x] ESLint + Prettier pass
- [x] Unit tests pass (9/9)
- [ ] Open single-line map for a line running past midnight (e.g., line 402)
- [ ] Verify ride continues past midnight on the map
- [ ] Verify gaps page shows correct data for overnight rides
- [ ] Verify hour grouping in gaps table shows 24:00, 25:00 etc. for post-midnight

🤖 Generated with [Claude Code](https://claude.com/claude-code)