### PR TITLE
feat: support hotlinking a specific language via URL

### DIFF
--- a/src/layout/ThemeContext.tsx
+++ b/src/layout/ThemeContext.tsx
@@ -17,8 +17,10 @@ import {
   useMemo,
 } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useLocation, useNavigate } from 'react-router'
 import { useLocalStorage } from 'usehooks-ts'
 import dayjs from 'src/dayjs'
+import { getLang, getPathWithoutLang } from 'src/locale/allTranslations'
 
 export interface ThemeContextInterface {
   toggleTheme: () => void
@@ -34,17 +36,24 @@ export const ThemeProvider = ({ children }: PropsWithChildren) => {
     'isDarkTheme',
     window.matchMedia('(prefers-color-scheme: dark)').matches,
   )
-  const [language, setLanguage] = useLocalStorage<string>('language', 'he')
+
+  const initialLang = getLang()
+  const [language, setLanguage] = useLocalStorage<string>('language', () => initialLang)
+
   const { i18n } = useTranslation()
+  const navigate = useNavigate()
 
   const toggleTheme = useCallback(() => setIsDarkTheme((prev) => !prev), [setIsDarkTheme])
+
+  const location = useLocation()
 
   const changeLanguage = useCallback(
     (newLanguage: string) => {
       setLanguage(newLanguage)
-      i18n.changeLanguage(newLanguage)
+      const pathWithoutLang = getPathWithoutLang(location.pathname)
+      navigate(`/${newLanguage}${pathWithoutLang}`)
     },
-    [i18n, setLanguage],
+    [setLanguage, navigate, location],
   )
 
   const contextValue = useMemo(

--- a/src/layout/sidebar/SideBar.tsx
+++ b/src/layout/sidebar/SideBar.tsx
@@ -18,7 +18,7 @@ export default function SideBar() {
   const { t, i18n } = useTranslation()
   const { drawerOpen, setDrawerOpen } = useContext<LayoutContextInterface>(LayoutCtx)
   const [collapsed, setCollapsed] = useState(false)
-  const { isDarkTheme } = useTheme()
+  const { isDarkTheme, currentLanguage } = useTheme()
 
   return (
     <>
@@ -47,7 +47,7 @@ export default function SideBar() {
         }}
         onCollapse={setCollapsed}
         className={cn('hideOnMobile', { dark: isDarkTheme })}>
-        <Link to={PAGES[0].path} replace>
+        <Link to={`/${currentLanguage}${PAGES[0].path}`} replace>
           {collapsed ? <CollapsedLogo /> : <Logo title={t('website_name')} dark={isDarkTheme} />}
         </Link>
         <div className="sidebar-divider" />

--- a/src/layout/sidebar/menu/Menu.tsx
+++ b/src/layout/sidebar/menu/Menu.tsx
@@ -4,6 +4,8 @@ import React, { useContext, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useLocation } from 'react-router'
 import { LayoutContextInterface, LayoutCtx } from 'src/layout/LayoutContext'
+import { useTheme } from 'src/layout/ThemeContext'
+import { getPathWithoutLang } from 'src/locale/allTranslations'
 import DonateModal from 'src/pages/DonateModal/DonateModal'
 import { PAGES } from 'src/routes'
 import './menu.scss'
@@ -53,6 +55,7 @@ function getGroup(label: React.ReactNode, key: React.Key, children: MenuItem[]):
 
 const MainMenu = ({ collapsed = false }: MainMenuProps) => {
   const { t } = useTranslation()
+  const { currentLanguage } = useTheme()
   const { setDrawerOpen } = useContext<LayoutContextInterface>(LayoutCtx)
   const [isDonateModalVisible, setDonateModalVisible] = useState(false)
 
@@ -73,7 +76,7 @@ const MainMenu = ({ collapsed = false }: MainMenuProps) => {
             itm.icon,
           )
         : getItem(
-            <Link to={itm.path} onClick={() => setDrawerOpen(false)}>
+            <Link to={`/${currentLanguage}${itm.path}`} onClick={() => setDrawerOpen(false)}>
               {t(itm.label)}
             </Link>,
             itm.path,
@@ -101,10 +104,10 @@ const MainMenu = ({ collapsed = false }: MainMenuProps) => {
   const items = collapsed ? flatItems : groupedItems
 
   const location = useLocation()
-  const [current, setCurrent] = useState(location.pathname || '/')
+  const [current, setCurrent] = useState(getPathWithoutLang(location.pathname) || '/')
 
   useEffect(() => {
-    const nextPath = location.pathname || '/'
+    const nextPath = getPathWithoutLang(location.pathname) || '/'
 
     if (current !== nextPath) {
       setCurrent(nextPath)

--- a/src/locale/allTranslations.ts
+++ b/src/locale/allTranslations.ts
@@ -5,11 +5,28 @@ import translationsEN from './en.json'
 import translationsHE from './he.json'
 import translationsRU from './ru.json'
 
-// Get saved language from localStorage or default to 'he'
-const savedLang =
-  typeof window !== 'undefined' && window.localStorage
-    ? localStorage.getItem('language') || 'he'
-    : 'he'
+export const SUPPORTED_LANGUAGES = ['en', 'ru', 'he', 'ar']
+
+// Get the path without the language prefix, if present
+export const getPathWithoutLang = (pathname: string): string => {
+  const parts = pathname.split('/').filter(Boolean)
+  if (!SUPPORTED_LANGUAGES.includes(parts[0])) return pathname
+  const rest = parts.slice(1).join('/')
+  return rest ? `/${rest}` : '/'
+}
+
+// Get saved language from URL or localStorage, default to 'he' if not found
+export const getLang = (): string => {
+  const parts = window.location.pathname.split('/').filter(Boolean)
+  const langPart = parts.find((part) => SUPPORTED_LANGUAGES.includes(part))
+  if (langPart) {
+    localStorage.setItem('language', langPart)
+    return langPart
+  }
+  return localStorage.getItem('language') || 'he'
+}
+
+const initialLang = getLang()
 
 i18n.use(initReactI18next).init({
   showSupportNotice: false,
@@ -19,7 +36,7 @@ i18n.use(initReactI18next).init({
     en: { translation: translationsEN },
     ru: { translation: translationsRU },
   },
-  lng: savedLang, // Use saved language or default to Hebrew
+  lng: initialLang,
   fallbackLng: 'he',
 })
 

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -145,27 +145,35 @@ const RedirectToHomepage = <Navigate to={routesList[0].path} replace />
 
 export const getRoutesList = () => {
   return (
-    <Route element={<MainRoute />}>
-      {routesList.map(({ path, element }) => (
-        <Route key={path} path={path} element={element} ErrorBoundary={ErrorPage} />
-      ))}
-      <Route
-        path="/profile/:gtfsRideGtfsRouteId"
-        element={<Profile />}
-        ErrorBoundary={ErrorPage}
-        loader={async ({ params }) => {
-          try {
-            const route = await getRouteById(params?.gtfsRideGtfsRouteId)
-            return { route }
-          } catch (error) {
-            return {
-              route: null,
-              message: (error as Error).message,
+    <Route path="/:lang?">
+      <Route element={<MainRoute />}>
+        {routesList.map(({ path, element }) => (
+          <Route
+            key={path}
+            path={path === '/' ? undefined : path.replace(/^\//, '')}
+            index={path === '/'}
+            element={element}
+            ErrorBoundary={ErrorPage}
+          />
+        ))}
+        <Route
+          path="profile/:gtfsRideGtfsRouteId"
+          element={<Profile />}
+          ErrorBoundary={ErrorPage}
+          loader={async ({ params }) => {
+            try {
+              const route = await getRouteById(params?.gtfsRideGtfsRouteId)
+              return { route }
+            } catch (error) {
+              return {
+                route: null,
+                message: (error as Error).message,
+              }
             }
-          }
-        }}
-      />
-      <Route path="*" element={RedirectToHomepage} key="back" />
+          }}
+        />
+        <Route path="*" element={RedirectToHomepage} key="back" />
+      </Route>
     </Route>
   )
 }
@@ -176,6 +184,9 @@ window.addEventListener('vite:preloadError', () => {
 
 const routes = createRoutesFromElements(getRoutesList())
 
-const router = createBrowserRouter(routes, { basename: import.meta.env.VITE_BASE_PATH })
+// If the URL doesn't have a language prefix, we will use the saved language or default to Hebrew
+const router = createBrowserRouter(routes, {
+  basename: import.meta.env.VITE_BASE_PATH || '/',
+})
 
 export default router


### PR DESCRIPTION
# Description

Adds a language prefix to all URLs so that language is encoded in the link itself, (and not only in local storage) making it possible to share links that open in a specific language.

For example: A link such as http://localhost:3000/en/gaps will always render the page in English.

Changes in the code:
- Added getLang() to allTranslations.ts that checks the URL for a language prefix before falling back to local storage.
- In routes/index.tsx the router basename is set dynamically to the detected language (from URL or local storage as its fallback).
 So all navigation links automatically preserve the language prefix.
- In ThemeContext.tsx implemented language switching via the UI which updates the URL to reflect the new language.

@NoamGaash 