### PR TITLE
fix: show success message on bug report submission

### DIFF
--- a/src/pages/bugReport/BugReportForm.tsx
+++ b/src/pages/bugReport/BugReportForm.tsx
@@ -19,11 +19,8 @@ const BugReportForm = () => {
   const mutation = useMutation({
     mutationFn: (values: CreateIssuePostRequest) =>
       ISSUES_API.issuesCreatePost({ createIssuePostRequest: values }),
-    onSuccess: (response) => {
-      if (response.data?.state === 'open') {
-        form.resetFields()
-        // setFileList([])
-      }
+    onSuccess: () => {
+      form.resetFields()
     },
     onError: (error) => {
       console.error('Error submitting bug report:', error)
@@ -62,11 +59,15 @@ const BugReportForm = () => {
         </p>
       }>
       <span>{t('reportBug.description')}</span>
-      {mutation.isSuccess && mutation.data?.data && (
+      {mutation.isSuccess && (
         <Alert severity="success" sx={{ marginBottom: 2 }}>
-          <a href={mutation.data.data.url} target="_blank" rel="noopener noreferrer">
-            {t('reportBug.viewIssue')} (Github)
-          </a>
+          {mutation.data?.data?.url ? (
+            <a href={mutation.data.data.url} target="_blank" rel="noopener noreferrer">
+              {t('reportBug.viewIssue')} (Github)
+            </a>
+          ) : (
+            t('reportBug.success', { defaultValue: 'Bug report submitted successfully!' })
+          )}
         </Alert>
       )}
 

--- a/src/pages/bugReport/BugReportForm.tsx
+++ b/src/pages/bugReport/BugReportForm.tsx
@@ -59,17 +59,21 @@ const BugReportForm = () => {
         </p>
       }>
       <span>{t('reportBug.description')}</span>
-      {mutation.isSuccess && (
-        <Alert severity="success" sx={{ marginBottom: 2 }}>
-          {mutation.data?.data?.url ? (
-            <a href={mutation.data.data.url} target="_blank" rel="noopener noreferrer">
-              {t('reportBug.viewIssue')} (Github)
-            </a>
-          ) : (
-            t('reportBug.success', { defaultValue: 'Bug report submitted successfully!' })
-          )}
-        </Alert>
-      )}
+      {mutation.isSuccess &&
+        (() => {
+          const issueUrl = mutation.data?.data?.url
+          return (
+            <Alert severity="success" sx={{ marginBottom: 2 }}>
+              {issueUrl ? (
+                <a href={issueUrl} target="_blank" rel="noopener noreferrer">
+                  {t('reportBug.viewIssue')} (GitHub)
+                </a>
+              ) : (
+                t('reportBug.success', { defaultValue: 'Bug report submitted successfully!' })
+              )}
+            </Alert>
+          )
+        })()}
 
       {mutation.isError && (
         <Alert severity="error" onClose={mutation.reset} sx={{ marginBottom: 2 }}>

--- a/tests/bugReport.spec.ts
+++ b/tests/bugReport.spec.ts
@@ -97,8 +97,51 @@ test('bug submission success', async ({ page }) => {
     await page.getByRole('button', { name: 'שלח את הדוח' }).click()
   })
 
-  await test.step('Verify error message is displayed', async () => {
-    await expect(page.getByText('לצפייה בדיווח (Github)')).toBeVisible()
+  await test.step('Verify success message is displayed', async () => {
+    await expect(page.getByText('לצפייה בדיווח (GitHub)')).toBeVisible()
+  })
+})
+
+const successBodyWithoutState = {
+  data: {
+    id: 123456,
+    number: 1347,
+    title: 'בדיקה',
+  },
+}
+
+test('bug submission success without state field', async ({ page }) => {
+  await test.step('Mock API to return success without state=open', async () => {
+    await page.route(
+      (url) => url.href.includes('/issues'),
+      (route) => route.fulfill({ status: 200, body: JSON.stringify(successBodyWithoutState) }),
+    )
+  })
+
+  await test.step('Open bug report modal', async () => {
+    await page.getByLabel('bug').locator('svg').click()
+  })
+
+  await test.step('Fill all required fields', async () => {
+    await page.getByLabel('סוג הבקשה').click()
+    await page.getByText('באג').click()
+    await page.getByLabel('כותרת/סיכום').fill('Test without state')
+    await page.getByLabel('שם מלא').fill('Test User')
+    await page.getByLabel('אי-מייל').fill('test@test.com')
+    await page.getByLabel('תיאור').fill('Testing without state field')
+    await page.getByLabel('סביבה (דפדפן, מערכת)').fill('Chrome')
+    await page.getByLabel('התנהגות צפויה').fill('Should show success')
+    await page.getByLabel('התנהגות נוכחית').fill('Previously showed error')
+    await page.getByLabel('באיזו תדירות זה קורה').click()
+    await page.getByText('תמיד').click()
+  })
+
+  await test.step('Submit the form', async () => {
+    await page.getByRole('button', { name: 'שלח את הדוח' }).click()
+  })
+
+  await test.step('Verify success message is displayed (not error)', async () => {
+    await expect(page.getByText('Bug report submitted successfully!')).toBeVisible()
   })
 })
 


### PR DESCRIPTION
Re-submitted from upstream branch (previously #1512).

## Summary
Fixed false error on successful submission by removing strict state check.

Closes #1431

## Test plan
- [x] TypeScript compiles clean
- [x] ESLint + Prettier pass
- [x] Unit tests pass (9/9)
- [x] Existing Playwright tests cover success/error cases (tests/bugReport.spec.ts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)