### PR TITLE
fix: Restore timestamp param on gaps page.

### DIFF
--- a/src/pages/gaps/GapsTable.tsx
+++ b/src/pages/gaps/GapsTable.tsx
@@ -24,7 +24,7 @@ interface GapsTableProps {
   loading?: boolean
   initOnlyGapped?: boolean
   singleLineMapBaseHref: string
-  onStartTimeClick?: (startTime: string) => void
+  onStartTimeClick?: (startTime: string, timestamp: number) => void
 }
 
 const cellStyle = {
@@ -165,7 +165,13 @@ const GapsTable: React.FC<GapsTableProps> = ({
                             {hasRide ? (
                               <Link
                                 to={cellHref}
-                                onClick={() => onStartTimeClick?.(startTimeParam)}>
+                                onClick={() =>
+                                  gap.actualStartTime &&
+                                  onStartTimeClick?.(
+                                    startTimeParam,
+                                    gap.actualStartTime.startOf('day').valueOf(),
+                                  )
+                                }>
                                 {time}
                               </Link>
                             ) : (

--- a/src/pages/gaps/index.tsx
+++ b/src/pages/gaps/index.tsx
@@ -96,7 +96,7 @@ const GapsPage = () => {
   }
 
   const handleStartTimeClick = useCallback(
-    (startTime: string) => {
+    (startTime: string, timestamp: number) => {
       setSearch((current) => ({ ...current, startTime, timestamp }))
     },
     [setSearch],


### PR DESCRIPTION
Restoring the changes form #1539 I have accidentally reverted when merging PR #1543.