### PR TITLE
refactor: map layers and tooltip navigation

### DIFF
--- a/src/pages/components/map-related/MapContent.tsx
+++ b/src/pages/components/map-related/MapContent.tsx
@@ -1,7 +1,7 @@
-import { Icon, IconOptions } from 'leaflet'
-import { useEffect, useState } from 'react'
+import { Icon, IconOptions, Marker as LeafletMarker } from 'leaflet'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { TileLayer } from 'react-leaflet'
+import { TileLayer, useMap } from 'react-leaflet'
 import { MapProps } from './map-types'
 import { MapIndexLayer } from './MapLayers/MapIndexLayer'
 import { MapPlannedRouteLayer } from './MapLayers/MapPlannedRouteLayer'
@@ -24,7 +24,9 @@ export const plannedRouteStopMarkerPath = `${import.meta.env.BASE_URL}marker-bus
 export const plannedRouteStopMarker = getIcon(plannedRouteStopMarkerPath, 20, 25)
 
 export function MapContent({ positions, plannedRouteStops, showNavigationButtons }: MapProps) {
+  const markerRef = useRef<{ [key: number]: LeafletMarker | null }>({})
   const [tileUrl, setTileUrl] = useState('https://tile-a.openstreetmap.fr/hot/{z}/{x}/{y}.png')
+  const map = useMap()
   const { i18n } = useTranslation()
 
   useRecenterOnDataChange({ positions, plannedRouteStops })
@@ -43,20 +45,32 @@ export function MapContent({ positions, plannedRouteStops, showNavigationButtons
     }
   }, [i18n])
 
+  const navigateMarkers = useCallback(
+    (positionId: number) => {
+      const pos = positions[positionId]
+      if (!map || !pos?.loc) return
+      const marker = markerRef.current[positionId]
+      if (marker) {
+        map.flyTo(pos.loc, map.getZoom())
+        marker.openPopup()
+      }
+    },
+    [map, positions],
+  )
+
   return (
     <>
       <TileLayer
         attribution='&copy <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url={tileUrl}
       />
-
       <MapIndexLayer showPlannedRoute={!!plannedRouteStops} />
-
-      <MapRouteLayer positions={positions} showNavigationButtons={showNavigationButtons} />
-
-      {plannedRouteStops?.length ? (
-        <MapPlannedRouteLayer plannedRouteStops={plannedRouteStops} />
-      ) : null}
+      <MapRouteLayer
+        positions={positions}
+        showNavigationButtons={showNavigationButtons}
+        navigateMarkers={navigateMarkers}
+      />
+      <MapPlannedRouteLayer plannedRouteStops={plannedRouteStops} />
     </>
   )
 }

--- a/src/pages/components/map-related/MapContent.tsx
+++ b/src/pages/components/map-related/MapContent.tsx
@@ -1,14 +1,11 @@
-import { t } from 'i18next'
-import { Icon, IconOptions, Marker as LeafletMarker } from 'leaflet'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { Icon, IconOptions } from 'leaflet'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Marker, Polyline, Popup, TileLayer, useMap } from 'react-leaflet'
-import { useAgencyList } from 'src/hooks/useAgencyList'
-import { busIcon, busIconPath } from '../utils/BusIcon'
+import { TileLayer } from 'react-leaflet'
 import { MapProps } from './map-types'
-import MapFooterButtons from './MapFooterButtons/MapFooterButtons'
-import { MapIndex } from './MapIndex'
-import { BusToolTip } from './MapLayers/BusToolTip'
+import { MapIndexLayer } from './MapLayers/MapIndexLayer'
+import { MapPlannedRouteLayer } from './MapLayers/MapPlannedRouteLayer'
+import { MapRouteLayer } from './MapLayers/MapRouteLayer'
 import { useRecenterOnDataChange } from './useRecenterOnDataChange'
 
 // configs for planned & actual routes - line color & marker icon
@@ -26,10 +23,7 @@ const actualRouteStopMarker = getIcon(actualRouteStopMarkerPath, 20, 20)
 const plannedRouteStopMarker = getIcon(plannedRouteStopMarkerPath, 20, 25)
 
 export function MapContent({ positions, plannedRouteStops, showNavigationButtons }: MapProps) {
-  const markerRef = useRef<{ [key: number]: LeafletMarker | null }>({})
   const [tileUrl, setTileUrl] = useState('https://tile-a.openstreetmap.fr/hot/{z}/{x}/{y}.png')
-  const agencyList = useAgencyList()
-  const map = useMap()
   const { i18n } = useTranslation()
 
   useRecenterOnDataChange({ positions, plannedRouteStops })
@@ -46,20 +40,7 @@ export function MapContent({ positions, plannedRouteStops, showNavigationButtons
     return () => {
       i18n.off('languageChanged', handleLanguageChange)
     }
-  }, [])
-
-  const navigateMarkers = useCallback(
-    (positionId: number) => {
-      const pos = positions[positionId]
-      if (!map || !pos?.loc) return
-      const marker = markerRef.current[positionId]
-      if (marker) {
-        map.flyTo(pos.loc, map.getZoom())
-        marker.openPopup()
-      }
-    },
-    [map, positions],
-  )
+  }, [i18n])
 
   return (
     <>
@@ -67,73 +48,29 @@ export function MapContent({ positions, plannedRouteStops, showNavigationButtons
         attribution='&copy <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
         url={tileUrl}
       />
-      <div className="map-index">
-        <MapIndex
-          lineColor={actualRouteLineColor}
-          imgSrc={actualRouteStopMarkerPath}
-          title={t('actualRoute')}
-        />
-        {plannedRouteStops && (
-          <MapIndex
-            lineColor={plannedRouteLineColor}
-            imgSrc={plannedRouteStopMarkerPath}
-            title={t('plannedRoute')}
-          />
-        )}
-      </div>
-      {positions.map((pos, i) => {
-        const icon =
-          i === 0
-            ? busIcon({
-                operator_id: pos.operator?.toString() || 'default',
-                name: agencyList.find((agency) => agency.operatorRef === pos.operator)?.agencyName,
-              })
-            : actualRouteStopMarker
-        return (
-          <Marker
-            ref={(ref) => {
-              markerRef.current[i] = ref
-            }}
-            position={pos.loc}
-            icon={icon}
-            key={i}>
-            <Popup minWidth={300} maxWidth={700}>
-              <BusToolTip position={pos} icon={busIconPath(pos.operator!)}>
-                {showNavigationButtons && (
-                  <MapFooterButtons
-                    index={i}
-                    positions={positions}
-                    navigateMarkers={navigateMarkers}
-                  />
-                )}
-              </BusToolTip>
-            </Popup>
-          </Marker>
-        )
-      })}
 
-      {plannedRouteStops?.length && (
-        <Polyline
-          pathOptions={{ color: plannedRouteLineColor }}
-          positions={plannedRouteStops.map((stop) => [
-            stop.location.latitude,
-            stop.location.longitude,
-          ])}
+      <MapIndexLayer
+        actualRouteLineColor={actualRouteLineColor}
+        actualRouteStopMarkerPath={actualRouteStopMarkerPath}
+        plannedRouteLineColor={plannedRouteLineColor}
+        plannedRouteStopMarkerPath={plannedRouteStopMarkerPath}
+        showPlannedRoute={!!plannedRouteStops}
+      />
+
+      <MapRouteLayer
+        actualRouteLineColor={actualRouteLineColor}
+        actualRouteStopMarker={actualRouteStopMarker}
+        positions={positions}
+        showNavigationButtons={showNavigationButtons}
+      />
+
+      {plannedRouteStops?.length ? (
+        <MapPlannedRouteLayer
+          plannedRouteLineColor={plannedRouteLineColor}
+          plannedRouteStopMarker={plannedRouteStopMarker}
+          plannedRouteStops={plannedRouteStops}
         />
-      )}
-      {plannedRouteStops?.length &&
-        plannedRouteStops.map((stop) => {
-          const { latitude, longitude } = stop.location
-          return (
-            <Marker key={stop.key} position={[latitude, longitude]} icon={plannedRouteStopMarker} />
-          )
-        })}
-      {positions.length > 0 && (
-        <Polyline
-          pathOptions={{ color: actualRouteLineColor }}
-          positions={positions.map((position) => position.loc)}
-        />
-      )}
+      ) : null}
     </>
   )
 }

--- a/src/pages/components/map-related/MapContent.tsx
+++ b/src/pages/components/map-related/MapContent.tsx
@@ -16,11 +16,11 @@ const getIcon = (path: string, width: number = 10, height: number = 10): Icon<Ic
 }
 
 export const actualRouteLineColor = 'orange'
-export const actualRouteStopMarkerPath = `${import.meta.env.BASE_URL}('marker-dot.png')`
+export const actualRouteStopMarkerPath = `${import.meta.env.BASE_URL}marker-dot.png`
 export const actualRouteStopMarker = getIcon(actualRouteStopMarkerPath, 20, 20)
 
 export const plannedRouteLineColor = 'black'
-export const plannedRouteStopMarkerPath = `${import.meta.env.BASE_URL}('marker-bus-stop.png')`
+export const plannedRouteStopMarkerPath = `${import.meta.env.BASE_URL}marker-bus-stop.png`
 export const plannedRouteStopMarker = getIcon(plannedRouteStopMarkerPath, 20, 25)
 
 export function MapContent({ positions, plannedRouteStops, showNavigationButtons }: MapProps) {

--- a/src/pages/components/map-related/MapContent.tsx
+++ b/src/pages/components/map-related/MapContent.tsx
@@ -8,19 +8,20 @@ import { MapPlannedRouteLayer } from './MapLayers/MapPlannedRouteLayer'
 import { MapRouteLayer } from './MapLayers/MapRouteLayer'
 import { useRecenterOnDataChange } from './useRecenterOnDataChange'
 
-// configs for planned & actual routes - line color & marker icon
 const getIcon = (path: string, width: number = 10, height: number = 10): Icon<IconOptions> => {
   return new Icon<IconOptions>({
     iconUrl: path,
     iconSize: [width, height],
   })
 }
-const actualRouteStopMarkerPath = '/marker-dot.png'
-const plannedRouteStopMarkerPath = '/marker-bus-stop.png'
-const actualRouteLineColor = 'orange'
-const plannedRouteLineColor = 'black'
-const actualRouteStopMarker = getIcon(actualRouteStopMarkerPath, 20, 20)
-const plannedRouteStopMarker = getIcon(plannedRouteStopMarkerPath, 20, 25)
+
+export const actualRouteStopMarkerPath = '/marker-dot.png'
+export const actualRouteLineColor = 'orange'
+export const actualRouteStopMarker = getIcon(actualRouteStopMarkerPath, 20, 20)
+
+export const plannedRouteLineColor = 'black'
+export const plannedRouteStopMarkerPath = '/marker-bus-stop.png'
+export const plannedRouteStopMarker = getIcon(plannedRouteStopMarkerPath, 20, 25)
 
 export function MapContent({ positions, plannedRouteStops, showNavigationButtons }: MapProps) {
   const [tileUrl, setTileUrl] = useState('https://tile-a.openstreetmap.fr/hot/{z}/{x}/{y}.png')
@@ -49,27 +50,12 @@ export function MapContent({ positions, plannedRouteStops, showNavigationButtons
         url={tileUrl}
       />
 
-      <MapIndexLayer
-        actualRouteLineColor={actualRouteLineColor}
-        actualRouteStopMarkerPath={actualRouteStopMarkerPath}
-        plannedRouteLineColor={plannedRouteLineColor}
-        plannedRouteStopMarkerPath={plannedRouteStopMarkerPath}
-        showPlannedRoute={!!plannedRouteStops}
-      />
+      <MapIndexLayer showPlannedRoute={!!plannedRouteStops} />
 
-      <MapRouteLayer
-        actualRouteLineColor={actualRouteLineColor}
-        actualRouteStopMarker={actualRouteStopMarker}
-        positions={positions}
-        showNavigationButtons={showNavigationButtons}
-      />
+      <MapRouteLayer positions={positions} showNavigationButtons={showNavigationButtons} />
 
       {plannedRouteStops?.length ? (
-        <MapPlannedRouteLayer
-          plannedRouteLineColor={plannedRouteLineColor}
-          plannedRouteStopMarker={plannedRouteStopMarker}
-          plannedRouteStops={plannedRouteStops}
-        />
+        <MapPlannedRouteLayer plannedRouteStops={plannedRouteStops} />
       ) : null}
     </>
   )

--- a/src/pages/components/map-related/MapContent.tsx
+++ b/src/pages/components/map-related/MapContent.tsx
@@ -15,12 +15,12 @@ const getIcon = (path: string, width: number = 10, height: number = 10): Icon<Ic
   })
 }
 
-export const actualRouteStopMarkerPath = '/marker-dot.png'
 export const actualRouteLineColor = 'orange'
+export const actualRouteStopMarkerPath = `${import.meta.env.BASE_URL}('marker-dot.png')`
 export const actualRouteStopMarker = getIcon(actualRouteStopMarkerPath, 20, 20)
 
 export const plannedRouteLineColor = 'black'
-export const plannedRouteStopMarkerPath = '/marker-bus-stop.png'
+export const plannedRouteStopMarkerPath = `${import.meta.env.BASE_URL}('marker-bus-stop.png')`
 export const plannedRouteStopMarker = getIcon(plannedRouteStopMarkerPath, 20, 25)
 
 export function MapContent({ positions, plannedRouteStops, showNavigationButtons }: MapProps) {

--- a/src/pages/components/map-related/MapContent.tsx
+++ b/src/pages/components/map-related/MapContent.tsx
@@ -1,5 +1,5 @@
 import { Icon, IconOptions, Marker as LeafletMarker } from 'leaflet'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TileLayer, useMap } from 'react-leaflet'
 import { MapProps } from './map-types'
@@ -24,7 +24,6 @@ export const plannedRouteStopMarkerPath = `${import.meta.env.BASE_URL}marker-bus
 export const plannedRouteStopMarker = getIcon(plannedRouteStopMarkerPath, 20, 25)
 
 export function MapContent({ positions, plannedRouteStops, showNavigationButtons }: MapProps) {
-  const markerRef = useRef<{ [key: number]: LeafletMarker | null }>({})
   const [tileUrl, setTileUrl] = useState('https://tile-a.openstreetmap.fr/hot/{z}/{x}/{y}.png')
   const map = useMap()
   const { i18n } = useTranslation()
@@ -46,10 +45,9 @@ export function MapContent({ positions, plannedRouteStops, showNavigationButtons
   }, [i18n])
 
   const navigateMarkers = useCallback(
-    (positionId: number) => {
+    (positionId: number, marker: LeafletMarker | null) => {
       const pos = positions[positionId]
       if (!map || !pos?.loc) return
-      const marker = markerRef.current[positionId]
       if (marker) {
         map.flyTo(pos.loc, map.getZoom())
         marker.openPopup()

--- a/src/pages/components/map-related/MapContent.tsx
+++ b/src/pages/components/map-related/MapContent.tsx
@@ -1,4 +1,4 @@
-import { Icon, IconOptions, Marker as LeafletMarker } from 'leaflet'
+import { Icon, IconOptions, Layer } from 'leaflet'
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { TileLayer, useMap } from 'react-leaflet'
@@ -45,13 +45,11 @@ export function MapContent({ positions, plannedRouteStops, showNavigationButtons
   }, [i18n])
 
   const navigateMarkers = useCallback(
-    (positionId: number, marker: LeafletMarker | null) => {
+    (positionId: number, marker: Layer) => {
       const pos = positions[positionId]
       if (!map || !pos?.loc) return
-      if (marker) {
-        map.flyTo(pos.loc, map.getZoom())
-        marker.openPopup()
-      }
+      map.flyTo(pos.loc, map.getZoom())
+      marker.openPopup()
     },
     [map, positions],
   )

--- a/src/pages/components/map-related/MapFooterButtons/MapFooterButtons.stories.tsx
+++ b/src/pages/components/map-related/MapFooterButtons/MapFooterButtons.stories.tsx
@@ -9,8 +9,8 @@ const meta = {
     layout: 'centered',
   },
   args: {
-    positions: [],
-    index: 3,
+    currentMarkerId: 3,
+    markerIds: [1, 2, 3, 4, 5],
     navigateMarkers: () => {},
   },
   decorators: [

--- a/src/pages/components/map-related/MapFooterButtons/MapFooterButtons.stories.tsx
+++ b/src/pages/components/map-related/MapFooterButtons/MapFooterButtons.stories.tsx
@@ -11,7 +11,7 @@ const meta = {
   args: {
     currentMarkerId: 3,
     markerIds: [1, 2, 3, 4, 5],
-    navigateMarkers: () => {},
+    navigateToMarker: () => {},
   },
   decorators: [
     (Story) => (

--- a/src/pages/components/map-related/MapFooterButtons/MapFooterButtons.tsx
+++ b/src/pages/components/map-related/MapFooterButtons/MapFooterButtons.tsx
@@ -4,10 +4,14 @@ import './MapFooterButtons.scss'
 type TMapFooterButtons = {
   currentMarkerId: number
   markerIds: number[]
-  navigateMarkers: (id: number) => void
+  navigateToMarker: (id: number) => void
 }
 
-function MapFooterButtons({ currentMarkerId, markerIds, navigateMarkers }: TMapFooterButtons) {
+function MapFooterButtons({
+  currentMarkerId,
+  markerIds,
+  navigateToMarker: navigateMarkers,
+}: TMapFooterButtons) {
   const currentIndex = markerIds.indexOf(currentMarkerId)
   const rightStep = markerIds[currentIndex + 1]
   const leftStep = markerIds[currentIndex - 1]

--- a/src/pages/components/map-related/MapFooterButtons/MapFooterButtons.tsx
+++ b/src/pages/components/map-related/MapFooterButtons/MapFooterButtons.tsx
@@ -1,32 +1,28 @@
 import { LeftOutlined, RightOutlined } from '@ant-design/icons'
-import type { Point } from '../map-types'
 import './MapFooterButtons.scss'
 
 type TMapFooterButtons = {
-  index: number
-  positions: Point[]
+  currentMarkerId: number
+  markerIds: number[]
   navigateMarkers: (id: number) => void
 }
 
-function MapFooterButtons({ index, positions, navigateMarkers }: TMapFooterButtons) {
-  const rightStep = index + 1
-  const leftStep = index - 1
-
-  const checkIfValidStep = (i: number) => {
-    return Boolean(positions.at(i))
-  }
+function MapFooterButtons({ currentMarkerId, markerIds, navigateMarkers }: TMapFooterButtons) {
+  const currentIndex = markerIds.indexOf(currentMarkerId)
+  const rightStep = markerIds[currentIndex + 1]
+  const leftStep = markerIds[currentIndex - 1]
+  const leftEnable = leftStep !== undefined
+  const rightEnable = rightStep !== undefined
 
   return (
-    <div className="map-footer-buttons">
+    <div className="map-footer-buttons" dir="rtl">
       <RightOutlined
-        title={'right-chevron'}
-        className={`${checkIfValidStep(rightStep) ? '' : 'disabled'}`}
-        onClick={() => navigateMarkers(rightStep)}
+        className={`${rightEnable ? '' : 'disabled'}`}
+        onClick={() => rightEnable && navigateMarkers(rightStep)}
       />
       <LeftOutlined
-        title={'left-chevron'}
-        className={`${checkIfValidStep(leftStep) ? '' : 'disabled'}`}
-        onClick={() => navigateMarkers(leftStep)}
+        className={`${leftEnable ? '' : 'disabled'}`}
+        onClick={() => leftEnable && navigateMarkers(leftStep)}
       />
     </div>
   )

--- a/src/pages/components/map-related/MapLayers/BusToolTip.scss
+++ b/src/pages/components/map-related/MapLayers/BusToolTip.scss
@@ -28,6 +28,7 @@
     max-height: 70%;
     overflow-y: auto;
     padding-left: 1rem;
+    margin-bottom: 0.75rem;
   }
 
   ul {

--- a/src/pages/components/map-related/MapLayers/MapIndexLayer.tsx
+++ b/src/pages/components/map-related/MapLayers/MapIndexLayer.tsx
@@ -1,0 +1,35 @@
+import { t } from 'i18next'
+import { MapIndex } from '../MapIndex'
+
+interface MapIndexLayerProps {
+  actualRouteLineColor: string
+  actualRouteStopMarkerPath: string
+  plannedRouteLineColor: string
+  plannedRouteStopMarkerPath: string
+  showPlannedRoute?: boolean
+}
+
+export function MapIndexLayer({
+  actualRouteLineColor,
+  actualRouteStopMarkerPath,
+  plannedRouteLineColor,
+  plannedRouteStopMarkerPath,
+  showPlannedRoute,
+}: MapIndexLayerProps) {
+  return (
+    <div className="map-index">
+      <MapIndex
+        lineColor={actualRouteLineColor}
+        imgSrc={actualRouteStopMarkerPath}
+        title={t('actualRoute')}
+      />
+      {showPlannedRoute && (
+        <MapIndex
+          lineColor={plannedRouteLineColor}
+          imgSrc={plannedRouteStopMarkerPath}
+          title={t('plannedRoute')}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/pages/components/map-related/MapLayers/MapIndexLayer.tsx
+++ b/src/pages/components/map-related/MapLayers/MapIndexLayer.tsx
@@ -1,21 +1,17 @@
 import { t } from 'i18next'
-import { MapIndex } from '../MapIndex'
-
-interface MapIndexLayerProps {
-  actualRouteLineColor: string
-  actualRouteStopMarkerPath: string
-  plannedRouteLineColor: string
-  plannedRouteStopMarkerPath: string
-  showPlannedRoute?: boolean
-}
-
-export function MapIndexLayer({
+import {
   actualRouteLineColor,
   actualRouteStopMarkerPath,
   plannedRouteLineColor,
   plannedRouteStopMarkerPath,
-  showPlannedRoute,
-}: MapIndexLayerProps) {
+} from '../MapContent'
+import { MapIndex } from '../MapIndex'
+
+interface MapIndexLayerProps {
+  showPlannedRoute?: boolean
+}
+
+export function MapIndexLayer({ showPlannedRoute }: MapIndexLayerProps) {
   return (
     <div className="map-index">
       <MapIndex

--- a/src/pages/components/map-related/MapLayers/MapPlannedRouteLayer.tsx
+++ b/src/pages/components/map-related/MapLayers/MapPlannedRouteLayer.tsx
@@ -1,18 +1,12 @@
-import type { Icon } from 'leaflet'
 import { Marker, Polyline } from 'react-leaflet'
 import type { BusStop } from 'src/model/busStop'
+import { plannedRouteLineColor, plannedRouteStopMarker } from '../MapContent'
 
 interface MapPlannedRouteLayerProps {
-  plannedRouteLineColor: string
-  plannedRouteStopMarker: Icon
   plannedRouteStops: BusStop[]
 }
 
-export function MapPlannedRouteLayer({
-  plannedRouteLineColor,
-  plannedRouteStopMarker,
-  plannedRouteStops,
-}: MapPlannedRouteLayerProps) {
+export function MapPlannedRouteLayer({ plannedRouteStops }: MapPlannedRouteLayerProps) {
   return (
     <>
       <Polyline

--- a/src/pages/components/map-related/MapLayers/MapPlannedRouteLayer.tsx
+++ b/src/pages/components/map-related/MapLayers/MapPlannedRouteLayer.tsx
@@ -16,12 +16,14 @@ export function MapPlannedRouteLayer({ plannedRouteStops }: MapPlannedRouteLayer
           stop.location.longitude,
         ])}
       />
-      {plannedRouteStops.map((stop) => {
-        const { latitude, longitude } = stop.location
-        return (
-          <Marker key={stop.key} position={[latitude, longitude]} icon={plannedRouteStopMarker} />
-        )
-      })}
+
+      {plannedRouteStops.map((stop) => (
+        <Marker
+          key={stop.key}
+          position={[stop.location.latitude, stop.location.longitude]}
+          icon={plannedRouteStopMarker}
+        />
+      ))}
     </>
   )
 }

--- a/src/pages/components/map-related/MapLayers/MapPlannedRouteLayer.tsx
+++ b/src/pages/components/map-related/MapLayers/MapPlannedRouteLayer.tsx
@@ -3,10 +3,10 @@ import type { BusStop } from 'src/model/busStop'
 import { plannedRouteLineColor, plannedRouteStopMarker } from '../MapContent'
 
 interface MapPlannedRouteLayerProps {
-  plannedRouteStops: BusStop[]
+  plannedRouteStops?: BusStop[]
 }
 
-export function MapPlannedRouteLayer({ plannedRouteStops }: MapPlannedRouteLayerProps) {
+export function MapPlannedRouteLayer({ plannedRouteStops = [] }: MapPlannedRouteLayerProps) {
   return (
     <>
       <Polyline

--- a/src/pages/components/map-related/MapLayers/MapPlannedRouteLayer.tsx
+++ b/src/pages/components/map-related/MapLayers/MapPlannedRouteLayer.tsx
@@ -1,0 +1,33 @@
+import type { Icon } from 'leaflet'
+import { Marker, Polyline } from 'react-leaflet'
+import type { BusStop } from 'src/model/busStop'
+
+interface MapPlannedRouteLayerProps {
+  plannedRouteLineColor: string
+  plannedRouteStopMarker: Icon
+  plannedRouteStops: BusStop[]
+}
+
+export function MapPlannedRouteLayer({
+  plannedRouteLineColor,
+  plannedRouteStopMarker,
+  plannedRouteStops,
+}: MapPlannedRouteLayerProps) {
+  return (
+    <>
+      <Polyline
+        pathOptions={{ color: plannedRouteLineColor }}
+        positions={plannedRouteStops.map((stop) => [
+          stop.location.latitude,
+          stop.location.longitude,
+        ])}
+      />
+      {plannedRouteStops.map((stop) => {
+        const { latitude, longitude } = stop.location
+        return (
+          <Marker key={stop.key} position={[latitude, longitude]} icon={plannedRouteStopMarker} />
+        )
+      })}
+    </>
+  )
+}

--- a/src/pages/components/map-related/MapLayers/MapRouteLayer.tsx
+++ b/src/pages/components/map-related/MapLayers/MapRouteLayer.tsx
@@ -1,4 +1,4 @@
-import type { Marker as LeafletMarker } from 'leaflet'
+import type { Layer } from 'leaflet'
 import { useCallback, useMemo, useRef } from 'react'
 import { Marker, Polyline, Popup } from 'react-leaflet'
 import { useAgencyList } from 'src/hooks/useAgencyList'
@@ -11,7 +11,7 @@ import { BusToolTip } from './BusToolTip'
 interface MapRouteLayerProps {
   positions: Point[]
   showNavigationButtons?: boolean
-  navigateMarkers: (id: number, marker: LeafletMarker | null) => void
+  navigateMarkers: (id: number, marker: Layer) => void
 }
 
 export function MapRouteLayer({
@@ -19,7 +19,7 @@ export function MapRouteLayer({
   showNavigationButtons,
   navigateMarkers,
 }: MapRouteLayerProps) {
-  const markerRef = useRef<{ [key: number]: LeafletMarker | null }>({})
+  const markerRef = useRef<{ [key: number]: Layer | null }>({})
   const agencyList = useAgencyList()
 
   const markerIdsByPositionId = useMemo(() => {
@@ -29,7 +29,7 @@ export function MapRouteLayer({
 
   const navigateToMarker = useCallback(
     (id: number) => {
-      navigateMarkers(id, markerRef.current[id] ?? null)
+      if (markerRef.current[id]) navigateMarkers(id, markerRef.current[id])
     },
     [navigateMarkers],
   )
@@ -63,7 +63,7 @@ export function MapRouteLayer({
                   <MapFooterButtons
                     currentMarkerId={i}
                     markerIds={markerIdsByPositionId.get(i) || []}
-                    navigateMarkers={navigateToMarker}
+                    navigateToMarker={navigateToMarker}
                   />
                 )}
               </BusToolTip>

--- a/src/pages/components/map-related/MapLayers/MapRouteLayer.tsx
+++ b/src/pages/components/map-related/MapLayers/MapRouteLayer.tsx
@@ -1,0 +1,89 @@
+import type { Icon } from 'leaflet'
+import { useCallback, useMemo, useRef } from 'react'
+import { Marker, Polyline, Popup, useMap } from 'react-leaflet'
+import { useAgencyList } from 'src/hooks/useAgencyList'
+import { busIcon, busIconPath } from '../../utils/BusIcon'
+import type { Point } from '../map-types'
+import MapFooterButtons from '../MapFooterButtons/MapFooterButtons'
+import { BusToolTip } from './BusToolTip'
+
+type PopupLayerRef = {
+  openPopup: () => void
+}
+
+interface MapRouteLayerProps {
+  actualRouteLineColor: string
+  actualRouteStopMarker: Icon
+  positions: Point[]
+  showNavigationButtons?: boolean
+}
+
+export function MapRouteLayer({
+  actualRouteLineColor,
+  actualRouteStopMarker,
+  positions,
+  showNavigationButtons,
+}: MapRouteLayerProps) {
+  const markerRef = useRef<{ [key: number]: PopupLayerRef | null }>({})
+  const agencyList = useAgencyList()
+  const map = useMap()
+
+  const markerIdsByPositionId = useMemo(() => {
+    const markerIds = positions.map((_, index) => index)
+    return new Map(markerIds.map((markerId) => [markerId, markerIds]))
+  }, [positions])
+
+  const navigateMarkers = useCallback(
+    (positionId: number) => {
+      const pos = positions[positionId]
+      if (!map || !pos?.loc) return
+      const marker = markerRef.current[positionId]
+      if (marker) {
+        map.flyTo(pos.loc, map.getZoom())
+        marker.openPopup()
+      }
+    },
+    [map, positions],
+  )
+
+  return (
+    <>
+      {positions.map((pos, i) => {
+        const icon =
+          i === 0
+            ? busIcon({
+                operator_id: pos.operator?.toString() || 'default',
+                name: agencyList.find((agency) => agency.operatorRef === pos.operator)?.agencyName,
+              })
+            : actualRouteStopMarker
+        return (
+          <Marker
+            ref={(ref) => {
+              markerRef.current[i] = ref
+            }}
+            position={pos.loc}
+            icon={icon}
+            key={i}>
+            <Popup minWidth={300} maxWidth={700}>
+              <BusToolTip position={pos} icon={busIconPath(pos.operator!)}>
+                {showNavigationButtons && (
+                  <MapFooterButtons
+                    currentMarkerId={i}
+                    markerIds={markerIdsByPositionId.get(i) || []}
+                    navigateMarkers={navigateMarkers}
+                  />
+                )}
+              </BusToolTip>
+            </Popup>
+          </Marker>
+        )
+      })}
+      {positions.length > 0 && (
+        <Polyline
+          pathOptions={{ color: actualRouteLineColor }}
+          positions={positions.map((position) => position.loc)}
+        />
+      )}
+    </>
+  )
+}

--- a/src/pages/components/map-related/MapLayers/MapRouteLayer.tsx
+++ b/src/pages/components/map-related/MapLayers/MapRouteLayer.tsx
@@ -71,12 +71,11 @@ export function MapRouteLayer({ positions, showNavigationButtons }: MapRouteLaye
           </Marker>
         )
       })}
-      {positions.length > 0 && (
-        <Polyline
-          pathOptions={{ color: actualRouteLineColor }}
-          positions={positions.map((position) => position.loc)}
-        />
-      )}
+
+      <Polyline
+        pathOptions={{ color: actualRouteLineColor }}
+        positions={positions.map((position) => position.loc)}
+      />
     </>
   )
 }

--- a/src/pages/components/map-related/MapLayers/MapRouteLayer.tsx
+++ b/src/pages/components/map-related/MapLayers/MapRouteLayer.tsx
@@ -1,9 +1,9 @@
-import type { Icon } from 'leaflet'
 import { useCallback, useMemo, useRef } from 'react'
 import { Marker, Polyline, Popup, useMap } from 'react-leaflet'
 import { useAgencyList } from 'src/hooks/useAgencyList'
 import { busIcon, busIconPath } from '../../utils/BusIcon'
 import type { Point } from '../map-types'
+import { actualRouteLineColor, actualRouteStopMarker } from '../MapContent'
 import MapFooterButtons from '../MapFooterButtons/MapFooterButtons'
 import { BusToolTip } from './BusToolTip'
 
@@ -12,18 +12,11 @@ type PopupLayerRef = {
 }
 
 interface MapRouteLayerProps {
-  actualRouteLineColor: string
-  actualRouteStopMarker: Icon
   positions: Point[]
   showNavigationButtons?: boolean
 }
 
-export function MapRouteLayer({
-  actualRouteLineColor,
-  actualRouteStopMarker,
-  positions,
-  showNavigationButtons,
-}: MapRouteLayerProps) {
+export function MapRouteLayer({ positions, showNavigationButtons }: MapRouteLayerProps) {
   const markerRef = useRef<{ [key: number]: PopupLayerRef | null }>({})
   const agencyList = useAgencyList()
   const map = useMap()

--- a/src/pages/components/map-related/MapLayers/MapRouteLayer.tsx
+++ b/src/pages/components/map-related/MapLayers/MapRouteLayer.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useMemo, useRef } from 'react'
-import { Marker, Polyline, Popup, useMap } from 'react-leaflet'
+import { useMemo, useRef } from 'react'
+import { Marker, Polyline, Popup } from 'react-leaflet'
 import { useAgencyList } from 'src/hooks/useAgencyList'
 import { busIcon, busIconPath } from '../../utils/BusIcon'
 import type { Point } from '../map-types'
@@ -14,30 +14,21 @@ type PopupLayerRef = {
 interface MapRouteLayerProps {
   positions: Point[]
   showNavigationButtons?: boolean
+  navigateMarkers: (id: number) => void
 }
 
-export function MapRouteLayer({ positions, showNavigationButtons }: MapRouteLayerProps) {
+export function MapRouteLayer({
+  positions,
+  showNavigationButtons,
+  navigateMarkers,
+}: MapRouteLayerProps) {
   const markerRef = useRef<{ [key: number]: PopupLayerRef | null }>({})
   const agencyList = useAgencyList()
-  const map = useMap()
 
   const markerIdsByPositionId = useMemo(() => {
     const markerIds = positions.map((_, index) => index)
     return new Map(markerIds.map((markerId) => [markerId, markerIds]))
   }, [positions])
-
-  const navigateMarkers = useCallback(
-    (positionId: number) => {
-      const pos = positions[positionId]
-      if (!map || !pos?.loc) return
-      const marker = markerRef.current[positionId]
-      if (marker) {
-        map.flyTo(pos.loc, map.getZoom())
-        marker.openPopup()
-      }
-    },
-    [map, positions],
-  )
 
   return (
     <>

--- a/src/pages/components/map-related/MapLayers/MapRouteLayer.tsx
+++ b/src/pages/components/map-related/MapLayers/MapRouteLayer.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useRef } from 'react'
+import type { Marker as LeafletMarker } from 'leaflet'
+import { useCallback, useMemo, useRef } from 'react'
 import { Marker, Polyline, Popup } from 'react-leaflet'
 import { useAgencyList } from 'src/hooks/useAgencyList'
 import { busIcon, busIconPath } from '../../utils/BusIcon'
@@ -7,14 +8,10 @@ import { actualRouteLineColor, actualRouteStopMarker } from '../MapContent'
 import MapFooterButtons from '../MapFooterButtons/MapFooterButtons'
 import { BusToolTip } from './BusToolTip'
 
-type PopupLayerRef = {
-  openPopup: () => void
-}
-
 interface MapRouteLayerProps {
   positions: Point[]
   showNavigationButtons?: boolean
-  navigateMarkers: (id: number) => void
+  navigateMarkers: (id: number, marker: LeafletMarker | null) => void
 }
 
 export function MapRouteLayer({
@@ -22,13 +19,20 @@ export function MapRouteLayer({
   showNavigationButtons,
   navigateMarkers,
 }: MapRouteLayerProps) {
-  const markerRef = useRef<{ [key: number]: PopupLayerRef | null }>({})
+  const markerRef = useRef<{ [key: number]: LeafletMarker | null }>({})
   const agencyList = useAgencyList()
 
   const markerIdsByPositionId = useMemo(() => {
     const markerIds = positions.map((_, index) => index)
     return new Map(markerIds.map((markerId) => [markerId, markerIds]))
   }, [positions])
+
+  const navigateToMarker = useCallback(
+    (id: number) => {
+      navigateMarkers(id, markerRef.current[id] ?? null)
+    },
+    [navigateMarkers],
+  )
 
   return (
     <>
@@ -59,7 +63,7 @@ export function MapRouteLayer({
                   <MapFooterButtons
                     currentMarkerId={i}
                     markerIds={markerIdsByPositionId.get(i) || []}
-                    navigateMarkers={navigateMarkers}
+                    navigateMarkers={navigateToMarker}
                   />
                 )}
               </BusToolTip>

--- a/src/pages/components/map-related/MapLayers/MapRouteLayer.tsx
+++ b/src/pages/components/map-related/MapLayers/MapRouteLayer.tsx
@@ -41,6 +41,11 @@ export function MapRouteLayer({ positions, showNavigationButtons }: MapRouteLaye
 
   return (
     <>
+      <Polyline
+        pathOptions={{ color: actualRouteLineColor }}
+        positions={positions.map((position) => position.loc)}
+      />
+
       {positions.map((pos, i) => {
         const icon =
           i === 0
@@ -71,11 +76,6 @@ export function MapRouteLayer({ positions, showNavigationButtons }: MapRouteLaye
           </Marker>
         )
       })}
-
-      <Polyline
-        pathOptions={{ color: actualRouteLineColor }}
-        positions={positions.map((position) => position.loc)}
-      />
     </>
   )
 }


### PR DESCRIPTION
## Summary
- Refactor map rendering into reusable route, planned-route, and index layer components.
- Update tooltip footer navigation to use marker ids and disable unavailable navigation arrows.
- Adjust tooltip spacing for the footer controls.

## Validation
- `npm run lint`