### PR TITLE
fix: Applitools per-branch baseline

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,6 @@
 import { EyesFixture } from '@applitools/eyes-playwright/fixture'
 import { defineConfig, devices } from '@playwright/test'
 import username from 'git-username'
-import { getBranch } from 'tests/utils'
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -47,7 +47,6 @@ export default defineConfig<EyesFixture>({
         { chromeEmulationInfo: { deviceName: 'Galaxy S23' } },
         { iosDeviceInfo: { deviceName: 'iPhone 16' } },
       ],
-      branchName: await getBranch(),
       parentBranchName: 'main',
     },
   },


### PR DESCRIPTION
# TL;DR
## This one-line fix make applitools set per-branch baseline in playwright tests.
### It is proven to work: this PR get the correct branch name in applitools, unlike previous ones.



### _The rest is claude's analysis on the root cause:_


# Applitools Browser Tests Always Filed Under "HEAD" Branch

## Symptom

In the Applitools dashboard, visual tests are split into two groups:

- **Component tests** (Storybook stories) — correctly filed under the PR branch name (e.g. `feat/my-feature`)
- **Browser tests** (full-page Playwright snapshots) — always filed under a branch named `HEAD`, regardless of which PR triggered them

The browser tests are the ones with no "component name" in the Applitools UI, because that concept comes from Storybook story titles and does not exist in Playwright tests.

## Background: Two Separate Test Runners

The project has two independent Applitools integrations, each with its own config:

| Runner | Config file | What it tests |
|---|---|---|
| `eyes-storybook` | `applitools.config.cjs` | Individual Storybook components (Puppeteer) |
| `eyes-playwright` | `playwright.config.ts` (`eyesConfig` block) | Full app pages in a real browser |

These configs share nothing. A change in one has no effect on the other (confirmed by commit `6a14a98`, where browser language had to be set separately in both files).

## Root Cause

### The explicit `branchName` override

`playwright.config.ts` explicitly sets the Applitools branch name:

```ts
// playwright.config.ts
eyesConfig: {
  branchName: await getBranch(),  // ← the problem
  parentBranchName: 'main',
}
```

`getBranch()` (defined in `tests/utils.ts`) runs:

```ts
exec('git rev-parse --abbrev-ref HEAD', ...)
```

### Detached HEAD in CI

The `visual-test` CI job checks out the code using a specific commit SHA:

```yaml
# .github/workflows/validate.yaml
- uses: actions/checkout@v6
  with:
    ref: ${{ github.event.pull_request.head.sha }}  # ← specific SHA
```

Checking out a SHA (rather than a branch ref) puts git in **detached HEAD state**. In that state, `git rev-parse --abbrev-ref HEAD` does not return a branch name — it returns the literal string `HEAD`.

This was verified locally by simulating the same detached HEAD state:

```
=== getBranch() (git rev-parse --abbrev-ref HEAD) ===
HEAD

=== Applitools auto-detection (git branch --show-current) ===
(empty — falls through to GITHUB_HEAD_REF)
```

Because `branchName` is explicitly set to the non-null string `"HEAD"`, the Applitools SDK's built-in auto-detection never runs.

### Why Storybook tests work correctly

`applitools.config.cjs` does **not** set `branchName`. When `branchName` is absent, the Applitools SDK (`@applitools/core`) runs its own `extractGitBranch()`, which tries CI environment variables first:

```js
// @applitools/core/dist/utils/extract-git-info.js
function extractCIBranchName() {
  return process.env.GITHUB_HEAD_REF  // ← set by GitHub Actions for PRs
    || extractGithubRefBranch()        // push events
    || process.env.CI_COMMIT_REF_NAME
    || ...
}
```

`GITHUB_HEAD_REF` is automatically set by GitHub Actions to the PR's head branch name (e.g. `feat/my-feature`). Since Storybook config does not override `branchName`, auto-detection runs and gets the correct value.

The Playwright config's explicit `branchName: await getBranch()` short-circuits this entire mechanism — the SDK sees a non-null value and skips auto-detection.

## Fix

**File:** `playwright.config.ts`, line 50 — delete the `branchName` line:

```diff
 eyesConfig: {
-  branchName: await getBranch(),
   parentBranchName: 'main',
 }
```

With no explicit `branchName`, `eyes-playwright` will use the same `extractGitBranch()` auto-detection that `eyes-storybook` already uses, reading `GITHUB_HEAD_REF` in CI and getting the real branch name.

`parentBranchName: 'main'` should be kept — it tells Applitools to fall back to `main`'s baseline when a new branch runs visual tests for the first time.

`getBranch()` in `tests/utils.ts` can also be deleted if it has no other callers.