### PR TITLE
ci: allow arielvino to trigger the claude workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,10 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && (github.event.comment.user.login == 'NoamGaash' || github.event.comment.user.login == 'AvivAbachi')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && (github.event.comment.user.login == 'NoamGaash' || github.event.comment.user.login == 'AvivAbachi')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && (github.event.review.user.login == 'NoamGaash' || github.event.review.user.login == 'AvivAbachi')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && (github.event.issue.user.login == 'NoamGaash' || github.event.issue.user.login == 'AvivAbachi'))
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude') && (github.event.comment.user.login == 'NoamGaash' || github.event.comment.user.login == 'AvivAbachi' || github.event.comment.user.login == 'arielvino')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && (github.event.comment.user.login == 'NoamGaash' || github.event.comment.user.login == 'AvivAbachi' || github.event.comment.user.login == 'arielvino')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && (github.event.review.user.login == 'NoamGaash' || github.event.review.user.login == 'AvivAbachi' || github.event.review.user.login == 'arielvino')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && (github.event.issue.user.login == 'NoamGaash' || github.event.issue.user.login == 'AvivAbachi' || github.event.issue.user.login == 'arielvino'))
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Updated the `if` conditions in the Claude GitHub Actions workflow to include `arielvino` in the list of authorized users. This grants them permission to invoke the Claude bot via issue comments, PR review comments, PR reviews, and issue descriptions.

# Description
### Summary
This PR adds `@arielvino` to the allowlist for the Claude GitHub Actions workflow, granting them permission to interact with the bot.

### Changes
- Updated the `if` conditions in the `claude` job to include `arielvino`.
- Applied the authorization check across all relevant GitHub event triggers (`issue_comment`, `pull_request_review_comment`, `pull_request_review`, and `issues`).