### PR TITLE
fix: Exclude Israel Railways from single-line map

### DIFF
--- a/src/hooks/useSingleLineData.ts
+++ b/src/hooks/useSingleLineData.ts
@@ -14,6 +14,13 @@ import {
 
 const formatTime = (time: dayjs.ConfigType) => toIsraelTimezone(time).format('HH:mm')
 
+const LIGHT_TRAIN_OPERATORS = new Set(['21', '22'])
+
+const VEHICLE_NUMBER_TEST = {
+  lightTrain: /^\d{1,6}$/,
+  bus: /^\d{7,8}$/,
+} as const
+
 export const useSingleLineData = (
   operatorId?: string,
   lineNumber?: string,
@@ -91,10 +98,16 @@ export const useSingleLineData = (
   }, [search.timestamp])
 
   const validVehicleNumber = useMemo(() => {
-    return vehicleNumber && /^\d{7,8}$/.test(vehicleNumber.toString())
-      ? Number(vehicleNumber)
-      : undefined
-  }, [vehicleNumber])
+    if (!vehicleNumber) return undefined
+
+    const vehicleNumberText = String(vehicleNumber)
+    const isLightTrain = LIGHT_TRAIN_OPERATORS.has(operatorId ?? '')
+    const vehicleNumberTest = isLightTrain
+      ? VEHICLE_NUMBER_TEST.lightTrain
+      : VEHICLE_NUMBER_TEST.bus
+
+    return vehicleNumberTest.test(vehicleNumberText) ? vehicleNumber : undefined
+  }, [operatorId, vehicleNumber])
 
   const { locations, isLoading: locationsAreLoading } = useVehicleLocations({
     from: today.valueOf(),

--- a/src/model/operator.ts
+++ b/src/model/operator.ts
@@ -5,23 +5,26 @@ export type Operator = {
   id: string
 }
 
-export const MAJOR_OPERATORS = ['3', '5', '15', '18', '25', '34'] // ['אלקטרה אפיקים', 'דן', 'מטרופולין', 'קווים', 'אגד', 'תנופה']
+export const MAJOR_OPERATORS = new Set(['3', '5', '15', '18', '25', '34']) // ['אלקטרה אפיקים', 'דן', 'מטרופולין', 'קווים', 'אגד', 'תנופה']
+export const ISRAEL_TRAIN_ID = '2'
 
 /**
  * Get operators list, based on agencies fetched from MOT api
  * @param filter Operator ID list
  * @returns List of operators
  */
-export async function getOperators(filter?: string[]): Promise<Operator[]> {
-  const agencyList = await getAgencyList()
-  const seen = new Map<string, Operator>()
-  for (const agency of agencyList) {
-    const id = agency.operatorRef.toString()
-    if (!seen.has(id)) {
-      if (!filter || filter.includes(id)) {
-        seen.set(id, { name: agency.agencyName, id })
-      }
+export async function getOperators(filter?: Set<string>): Promise<Operator[]> {
+  const agencies = await getAgencyList()
+  const operators = new Map<string, Operator>()
+
+  for (const agency of agencies) {
+    const id = String(agency.operatorRef)
+
+    if (operators.has(id) || (filter && !filter.has(id))) {
+      continue
     }
+
+    operators.set(id, { id, name: agency.agencyName })
   }
-  return Array.from(seen.values())
+  return Array.from(operators.values())
 }

--- a/src/pages/components/OperatorSelector.stories.tsx
+++ b/src/pages/components/OperatorSelector.stories.tsx
@@ -33,7 +33,7 @@ const meta = {
       description: 'Filter function or criteria for the list of operators.',
       control: { type: 'object' },
       table: {
-        type: { summary: ' string[]' },
+        type: { summary: 'Set<string>' },
         defaultValue: { summary: 'undefined' },
       },
     },

--- a/src/pages/components/OperatorSelector.tsx
+++ b/src/pages/components/OperatorSelector.tsx
@@ -1,13 +1,14 @@
 import { Autocomplete, TextField } from '@mui/material'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { getOperators, Operator } from 'src/model/operator'
+import { getOperators, ISRAEL_TRAIN_ID, Operator } from 'src/model/operator'
 
 type OperatorSelectorProps = {
   operatorId?: string
   setOperatorId: (operatorId: string) => void
   disabled?: boolean
-  filter?: string[]
+  filter?: Set<string>
+  excludeIsraelRailways?: boolean
 }
 
 export default function OperatorSelector({
@@ -15,13 +16,20 @@ export default function OperatorSelector({
   setOperatorId,
   disabled,
   filter,
+  excludeIsraelRailways,
 }: OperatorSelectorProps) {
   const { t } = useTranslation()
   const [operators, setOperators] = useState<Operator[]>([])
 
   useEffect(() => {
-    getOperators(filter).then(setOperators)
-  }, [filter])
+    getOperators(filter).then((operators) =>
+      setOperators(
+        excludeIsraelRailways
+          ? operators.filter((operator) => operator.id !== ISRAEL_TRAIN_ID)
+          : operators,
+      ),
+    )
+  }, [filter, excludeIsraelRailways])
 
   const value = operators.find((operator) => operator.id === operatorId) || null
 

--- a/src/pages/dashboard/WorstLinesChart/WorstLinesChart.tsx
+++ b/src/pages/dashboard/WorstLinesChart/WorstLinesChart.tsx
@@ -19,7 +19,7 @@ const convertToWorstLineChartCompatibleStruct = (arr: GroupByRes[], operatorId?:
   return arr
     .filter((row) => {
       if (operatorId) return row.operatorRef?.operatorRef.toString() === operatorId
-      return row.operatorRef && MAJOR_OPERATORS.includes(row.operatorRef.operatorRef.toString())
+      return row.operatorRef && MAJOR_OPERATORS.has(row.operatorRef.operatorRef.toString())
     })
     .map(
       (item) =>

--- a/src/pages/operator/OperatorRoutes.tsx
+++ b/src/pages/operator/OperatorRoutes.tsx
@@ -4,6 +4,7 @@ import { useContext } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Link, useNavigate } from 'react-router'
 import styled from 'styled-components'
+import { ISRAEL_TRAIN_ID } from 'src/model/operator'
 import { SearchContext } from 'src/model/pageState'
 import Widget from 'src/shared/Widget'
 import { useAllRoutes } from '../../hooks/useAllRoutes'
@@ -47,19 +48,21 @@ export const OperatorRoutes = ({
                     <Link to={`/profile/${route.id}`}>{t('operator.profile')}</Link>
                   </TableCell>
                   <TableCell>
-                    <Link
-                      onClick={(e) => {
-                        e.preventDefault()
-                        setSearch((current) => ({
-                          ...current,
-                          lineNumber: route.line + route.suffix,
-                          routeKey: route.routeKey,
-                        }))
-                        navigate('/single-line-map')
-                      }}
-                      to={`/single-line-map`}>
-                      {t('operator.map')}
-                    </Link>
+                    {operatorId !== ISRAEL_TRAIN_ID && (
+                      <Link
+                        onClick={(e) => {
+                          e.preventDefault()
+                          setSearch((current) => ({
+                            ...current,
+                            lineNumber: route.line + route.suffix,
+                            routeKey: route.routeKey,
+                          }))
+                          navigate('/single-line-map')
+                        }}
+                        to={`/single-line-map`}>
+                        {t('operator.map')}
+                      </Link>
+                    )}
                   </TableCell>
                 </TableRow>
               ))}

--- a/src/pages/singleLineMap/index.tsx
+++ b/src/pages/singleLineMap/index.tsx
@@ -98,7 +98,11 @@ const SingleLineMapPage = () => {
           </Grid>
           {/* choose operator */}
           <Grid size={{ sm: 4, xs: 12 }}>
-            <OperatorSelector operatorId={operatorId} setOperatorId={handleOperatorChange} />
+            <OperatorSelector
+              operatorId={operatorId}
+              setOperatorId={handleOperatorChange}
+              excludeIsraelRailways
+            />
           </Grid>
           <Grid size={{ sm: 4, xs: 12 }}>
             {/* choose type */}


### PR DESCRIPTION
## Summary
- Excludes Israel Railways from the single-line map operator selector.
- Hides the single-line map link for Israel Railways routes on the operator page.
- Allows light-rail operators to use shorter vehicle ids for vehicle lookups.

## Note
These changes prepare the app for creating a separate page dedicated only to Israel Railways. Israel Railways remains available on the operator page for now, but it is no longer routed into the current single-line map flow.