### PR TITLE
fix: prevent horizontal scroll on hackathon page mobile

### DIFF
--- a/src/pages/hackathon/ChallengeCard.tsx
+++ b/src/pages/hackathon/ChallengeCard.tsx
@@ -203,12 +203,14 @@ const CardTitle = styled.div`
   font-weight: 650;
   color: #111827;
   line-height: 1.4;
+  overflow-wrap: break-word;
 `
 
 const OneLiner = styled.div`
   font-size: 13px;
   color: #6b7280;
   line-height: 1.4;
+  overflow-wrap: break-word;
 `
 
 const ExpandRegion = styled.div<{ $open: boolean }>`
@@ -229,6 +231,7 @@ const ExpandContent = styled.div<{ $open: boolean }>`
     line-height: 1.7;
     color: #374151;
     margin: 6px 0 0;
+    overflow-wrap: break-word;
   }
 
   ul {
@@ -237,6 +240,7 @@ const ExpandContent = styled.div<{ $open: boolean }>`
     font-size: 13.5px;
     line-height: 1.65;
     color: #374151;
+    overflow-wrap: break-word;
   }
 `
 
@@ -329,6 +333,8 @@ const ExtLink = styled.a`
   color: #2563eb;
   text-decoration: none;
   font-size: 13.5px;
+  overflow-wrap: break-word;
+  word-break: break-word;
 
   &:hover {
     text-decoration: underline;

--- a/src/pages/hackathon/Hackathon.tsx
+++ b/src/pages/hackathon/Hackathon.tsx
@@ -224,6 +224,7 @@ const Page = styled.div`
   padding: 0 16px 32px;
   max-width: 980px;
   margin: 0 auto;
+  overflow-x: hidden;
 `
 
 const Hero = styled.section`
@@ -298,7 +299,7 @@ const PersonaGrid = styled.div`
 
 const WhyComeGrid = styled.div`
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 12px;
 `
 
@@ -408,6 +409,7 @@ const ScheduleList = styled.ol`
     gap: 12px;
     align-items: baseline;
     font-size: 14px;
+    flex-wrap: wrap;
   }
 `
 
@@ -416,6 +418,7 @@ const Time = styled.span`
   font-variant-numeric: tabular-nums;
   min-width: 110px;
   direction: ltr;
+  flex-shrink: 0;
 `
 
 const Filters = styled.div`
@@ -550,11 +553,14 @@ const FaqItem = styled.div`
   dt {
     font-weight: 600;
     margin-bottom: 4px;
+    overflow-wrap: break-word;
   }
   dd {
     margin: 0;
     opacity: 0.85;
     line-height: 1.6;
+    overflow-wrap: break-word;
+    word-break: break-word;
   }
 `
 


### PR DESCRIPTION
## Summary

- **`FaqItem dd`** — `overflow-wrap + word-break`: the Gitpod devenv FAQ answer contains a raw 62-char URL that overflows any mobile viewport without this
- **`ExpandContent p/ul`, `ExtLink`, `CardTitle`, `OneLiner`** — `overflow-wrap: break-word` for long technical strings in challenge briefs (`.claude/settings.json`, `devcontainer.json`, etc.)
- **`WhyComeGrid`** — lowered `minmax(220px → 160px, 1fr)` so the grid collapses to 1 column on 320px screens
- **`ScheduleList li`** — `flex-wrap: wrap` + `flex-shrink: 0` on `Time` so schedule rows can stack on narrow screens
- **`Page`** — `overflow-x: hidden` as a backstop

## Test plan

- [ ] `/hackathon` on 375px (iPhone SE) — no horizontal scroll
- [ ] 320px viewport — grid sections stack to 1 column, schedule wraps
- [ ] Expand `harness-backend-devenv` challenge card — long brief wraps, no overflow
- [ ] FAQ "devenv" answer — Gitpod URL wraps within column
- [ ] Hebrew RTL desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)