### PR TITLE
feat: Use moon-sun icons for theme switch

### DIFF
--- a/src/layout/header/Header.css
+++ b/src/layout/header/Header.css
@@ -40,6 +40,6 @@
   transform: scale(1.1);
 }
 
-.bulb-dark {
+.theme-icon-dark {
   color: #fff;
 }

--- a/src/layout/header/ToggleThemeButton.tsx
+++ b/src/layout/header/ToggleThemeButton.tsx
@@ -1,4 +1,5 @@
-import { BulbFilled, BulbOutlined } from '@ant-design/icons'
+import DarkModeIcon from '@mui/icons-material/DarkMode'
+import LightModeIcon from '@mui/icons-material/LightMode'
 import React from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -19,7 +20,7 @@ const ToggleThemeButton: React.FC<ToggleThemeButtonProps> = ({ toggleTheme, isDa
       aria-label={tooltip_title}
       title={tooltip_title}
       style={{ border: 'none', background: 'transparent', cursor: 'pointer' }}>
-      {isDarkTheme ? <BulbOutlined className="bulb-dark" /> : <BulbFilled />}
+      {isDarkTheme ? <LightModeIcon className="theme-icon-dark" /> : <DarkModeIcon />}
     </button>
   )
 }


### PR DESCRIPTION
# Description

#### Replaced the bulb icons with sun/moon icons - more intuitive.

## screenshots

<img width="311" height="73" alt="image" src="https://github.com/user-attachments/assets/45391675-4b1d-4b41-bfd8-19b3f121aab9" />
<img width="311" height="73" alt="image" src="https://github.com/user-attachments/assets/6d73e688-368b-4c93-b9d0-394928985116" />
