### PR TITLE
fix: Remove parentBranchName from playwright.config.ts

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -54,7 +54,6 @@ export default defineConfig<EyesFixture>({
         { chromeEmulationInfo: { deviceName: 'Galaxy S23' } },
         { iosDeviceInfo: { deviceName: 'iPhone 16' } },
       ],
-      parentBranchName: 'hasadna/open-bus-map-search/main',
     },
   },
   expect: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -54,7 +54,6 @@ export default defineConfig<EyesFixture>({
         { chromeEmulationInfo: { deviceName: 'Galaxy S23' } },
         { iosDeviceInfo: { deviceName: 'iPhone 16' } },
       ],
-      parentBranchName: 'main',
     },
   },
   expect: {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -54,6 +54,7 @@ export default defineConfig<EyesFixture>({
         { chromeEmulationInfo: { deviceName: 'Galaxy S23' } },
         { iosDeviceInfo: { deviceName: 'iPhone 16' } },
       ],
+      parentBranchName: 'hasadna/open-bus-map-search/main',
     },
   },
   expect: {

--- a/src/pages/publicAppeal/index.tsx
+++ b/src/pages/publicAppeal/index.tsx
@@ -13,7 +13,7 @@ const PublicAppeal = () => {
   return (
     <PublicAppealStyle>
       <Space direction="vertical" size="middle">
-        <Title className="page-title" level={3} style={{ backgroundColor: 'yellow' }}>
+        <Title className="page-title" level={3}>
           {t(`${pageName}.title`)}
         </Title>
         {tasks.map((task, i) => (

--- a/src/pages/publicAppeal/index.tsx
+++ b/src/pages/publicAppeal/index.tsx
@@ -13,7 +13,7 @@ const PublicAppeal = () => {
   return (
     <PublicAppealStyle>
       <Space direction="vertical" size="middle">
-        <Title className="page-title" level={3}>
+        <Title className="page-title" level={3} style={{ backgroundColor: 'yellow' }}>
           {t(`${pageName}.title`)}
         </Title>
         {tasks.map((task, i) => (


### PR DESCRIPTION
# Description

Deleted `parentBranchName` from playwright config.

## Why?

Recently every PR started to fail to get reported status from applitools.
I don't fully understand the root cause - but this change seem to fix it in most cases - and at least not make things worse.

It might be similar to the reason branchName needed to be removed in #1573 - where it was actually a harmful line that override the correct value.
Anyway I honestly state that it is only a guess.

(The obvious suspects were the PRs that bumped applitools versions or changed CI flow - like #1592 #1594 #1586 #1582 - but I checked and that DOES NOT match the timeline of when the error started to appear)

## The error:
<img width="1267" height="601" alt="image" src="https://github.com/user-attachments/assets/cd36b62f-e75b-4dd0-9938-bb32bf4b9600" />
