### PR TITLE
test: add unit tests for startTimeUtils

### DIFF
--- a/src/pages/components/utils/startTimeUtils.test.ts
+++ b/src/pages/components/utils/startTimeUtils.test.ts
@@ -1,0 +1,74 @@
+import {
+  formatStartTimeForQuery,
+  normalizeScheduledTime,
+  normalizeStartTimeToken,
+  parseStartTimeToken,
+} from './startTimeUtils'
+
+describe('normalizeScheduledTime', () => {
+  it('converts dashes to colons', () => {
+    expect(normalizeScheduledTime('08-30')).toBe('08:30')
+  })
+
+  it('pads single-digit hour', () => {
+    expect(normalizeScheduledTime('8:05')).toBe('08:05')
+  })
+
+  it('strips seconds from HH:MM:SS format', () => {
+    expect(normalizeScheduledTime('08:30:00')).toBe('08:30')
+  })
+
+  it('returns undefined for out-of-range hour', () => {
+    expect(normalizeScheduledTime('25:00')).toBeUndefined()
+  })
+
+  it('returns undefined for undefined input', () => {
+    expect(normalizeScheduledTime(undefined)).toBeUndefined()
+  })
+})
+
+describe('parseStartTimeToken', () => {
+  it('parses full token into an object with all three parts', () => {
+    expect(parseStartTimeToken('08:30|v123|l64')).toEqual({
+      scheduledTime: '08:30',
+      vehicleRef: 'v123',
+      lineRef: 'l64',
+    })
+  })
+
+  it('parses time-only token with undefined vehicleRef and lineRef', () => {
+    expect(parseStartTimeToken('08:30')).toEqual({
+      scheduledTime: '08:30',
+      vehicleRef: undefined,
+      lineRef: undefined,
+    })
+  })
+
+  it('returns undefined when the time part is invalid', () => {
+    expect(parseStartTimeToken('invalid|v123|l64')).toBeUndefined()
+  })
+})
+
+describe('normalizeStartTimeToken', () => {
+  it('normalizes dashes in the time part of a full token', () => {
+    expect(normalizeStartTimeToken('08-30|v123|l64')).toBe('08:30|v123|l64')
+  })
+
+  it('returns scheduledTime and vehicleRef when lineRef is absent', () => {
+    expect(normalizeStartTimeToken('08:30|v123')).toBe('08:30|v123')
+  })
+
+  it('returns only scheduledTime when vehicleRef and lineRef are absent', () => {
+    expect(normalizeStartTimeToken('08:30')).toBe('08:30')
+  })
+})
+
+describe('formatStartTimeForQuery', () => {
+  it('converts colons to dashes for URL query param', () => {
+    expect(formatStartTimeForQuery('08:30')).toBe('08-30')
+  })
+
+  it('returns empty string for undefined input', () => {
+    expect(formatStartTimeForQuery(undefined)).toBe('')
+  })
+})


### PR DESCRIPTION
## Description

Adds unit tests for `startTimeUtils.ts`, which handles parsing, normalization,
and formatting of ride start-time tokens used across the application.

### Functions covered

| Function | Tests |
|---|---|
| `normalizeScheduledTime` | dash→colon conversion, strips seconds, pads hour, out-of-range, undefined input |
| `parseStartTimeToken` | full token, time-only token, invalid time part |
| `normalizeStartTimeToken` | full token with dashes, vehicleRef only, time only |
| `formatStartTimeForQuery` | colon→dash for URL, empty string for undefined |

### Why these tests matter

These utilities are used in the ride-time navigation flow and sit at the boundary
between URL parameters and API queries. The tests help prevent regressions in
time parsing and normalization logic.
