### PR TITLE
test: add unit tests for mapColorByExecution and rotueUtils

### DIFF
--- a/src/pages/components/utils/index.test.ts
+++ b/src/pages/components/utils/index.test.ts
@@ -1,6 +1,6 @@
 import { Gap, parseTime } from 'src/api/gapsService'
 import { convertGapsToHourlyStruct as processData } from 'src/pages/gapsPatterns/useGapsList'
-import { HourlyData, sortByMode } from '.'
+import { HourlyData, mapColorByExecution, sortByMode } from '.'
 
 describe('sortByMode', () => {
   it('when mode param is "hour" - should be sorted properly', () => {
@@ -87,5 +87,23 @@ describe('sortByMode', () => {
       planned_hour: '05:00',
       planned_rides: 2,
     })
+  })
+})
+
+describe('mapColorByExecution', () => {
+  it('returns green when missed rides are exactly 5%', () => {
+    expect(mapColorByExecution(100, 95)).toBe('green')
+  })
+
+  it('returns orange when missed rides exceed 5%', () => {
+    expect(mapColorByExecution(100, 94)).toBe('orange')
+  })
+
+  it('returns orange when missed rides are exactly 50%', () => {
+    expect(mapColorByExecution(100, 50)).toBe('orange')
+  })
+
+  it('returns red when missed rides exceed 50%', () => {
+    expect(mapColorByExecution(100, 49)).toBe('red')
   })
 })

--- a/src/pages/components/utils/rotueUtils.test.ts
+++ b/src/pages/components/utils/rotueUtils.test.ts
@@ -1,0 +1,33 @@
+import { routeStartEnd, vehicleIDFormat } from './rotueUtils'
+
+describe('routeStartEnd', () => {
+  it('splits a standard route name into start, end, and suffix', () => {
+    expect(routeStartEnd('תל אביב<->ירושלים-5')).toEqual(['תל אביב', 'ירושלים', '5'])
+  })
+
+  it('returns empty strings when input is undefined', () => {
+    expect(routeStartEnd(undefined)).toEqual(['', '', ''])
+  })
+
+  it('returns empty strings when input does not match the expected pattern', () => {
+    expect(routeStartEnd('ירושלים')).toEqual(['', '', ''])
+  })
+})
+
+describe('vehicleIDFormat', () => {
+  it('returns undefined for undefined input', () => {
+    expect(vehicleIDFormat(undefined)).toBeUndefined()
+  })
+
+  it('formats a 7-digit vehicle id as XX-XXX-XX', () => {
+    expect(vehicleIDFormat(1234567)).toBe('12-345-67')
+  })
+
+  it('formats an 8-digit vehicle id as XXX-XX-XXX', () => {
+    expect(vehicleIDFormat(12345678)).toBe('123-45-678')
+  })
+
+  it('returns the value as a string when length is not 7 or 8', () => {
+    expect(vehicleIDFormat(12345)).toBe('12345')
+  })
+})


### PR DESCRIPTION
## Description

Added unit tests for two utility modules that had no test coverage:

**`src/pages/components/utils/index.test.ts`**
Added 4 tests for `mapColorByExecution` — covers the boundary conditions
of the green/orange/red thresholds (≤5%, >5%, ≤50%, >50% missed rides).

**`src/pages/components/utils/rotueUtils.test.ts`** *(new file)*
Added 7 tests across two functions:
- `routeStartEnd` — splits a route long name into start, end, and suffix;
  covers standard input, `undefined`, and non-matching strings
- `vehicleIDFormat` — formats a vehicle license plate number with dashes;
  covers `undefined`, 7-digit (old format), 8-digit (new format), and
  unrecognized length


