### PR TITLE
ci: let the @claude workflow push branches and open PRs

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,20 +19,28 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) && (github.event.issue.user.login == 'NoamGaash' || github.event.issue.user.login == 'AvivAbachi' || github.event.issue.user.login == 'arielvino'))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      # Write access so Claude can push branches and open pull requests.
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
+      # NOTE: `packages: write` is intentionally omitted so the workflow token
+      # cannot push Docker images to the GitHub Container Registry.
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          # Shallow checkout for speed; Claude can run `git fetch --unshallow`
+          # on demand when an operation actually needs full history.
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
+        env:
+          # Allow Claude to run the Applitools visual regression tests in CI.
+          APPLITOOLS_API_KEY: ${{ secrets.APPLITOOLS_API_KEY }}
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
@@ -43,7 +51,14 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
+          # Allow Claude to run any command in CI (push branches, open PRs, run the
+          # full lint/test/build suite, etc.). Destructive / outward-publishing
+          # actions are blocked at two levels:
+          #   1. The workflow token has no `packages: write` and no registry or
+          #      cloud credentials are exposed to this step, so image / artifact
+          #      publishing is impossible regardless of the command run.
+          #   2. The deny-list below blocks Docker image pushes explicitly.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          claude_args: '--allowed-tools Bash(gh pr:*) Bash(npm *)'
+          claude_args: >-
+            --allowed-tools "Bash,Edit,Write,Read,Glob,Grep,WebFetch,WebSearch,TodoWrite"
+            --disallowed-tools "Bash(docker push:*),Bash(docker image push:*),Bash(docker buildx:*),Bash(podman push:*)"


### PR DESCRIPTION
## What

Broadens the `@claude` GitHub Action (`.github/workflows/claude.yml`) so it can carry a request through to a pushed branch and a pull request, and run the full CI suite — while keeping destructive / outward-publishing actions out of reach.

## Changes

- **Write token**: job `permissions` bumped to `contents: write`, `pull-requests: write`, `issues: write` so Claude can push branches, open PRs and comment back.
- **No image publishing**: `packages: write` is deliberately omitted and no registry/cloud credentials are exposed to the step, so the token cannot push Docker images to GHCR. A deny-list (`docker push`, `docker image push`, `docker buildx`, `podman push`) adds an explicit guardrail on top of that.
- **Run any command**: `--allowed-tools` widened from `Bash(gh pr:*) Bash(npm *)` to `Bash` + the edit/read tools, so Claude can run the whole lint / test / build flow.
- **Applitools**: `APPLITOOLS_API_KEY` is passed to the step so visual regression tests can run.

Checkout stays shallow (`fetch-depth: 1`); Claude can `git fetch --unshallow` on demand when an operation needs full history.

## Who can trigger

Unchanged — only `@claude` mentions from `NoamGaash`, `AvivAbachi`, or `arielvino` start the job. That human-authorization gate is the main control now that the token can write.

## Security notes

- The token scope (no `packages: write`) is the real boundary; no docker registry or AWS credentials are exposed to this step.
- Deploy/publish secrets (`AWS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `HASADNA_K`) live in other workflows and are **not** referenced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)