### PR TITLE
fix: point hackathon starting-point links to live databus domain

### DIFF
--- a/src/pages/hackathon/challenges.ts
+++ b/src/pages/hackathon/challenges.ts
@@ -106,7 +106,10 @@ export const CHALLENGES: Challenge[] = [
     stack: ['React', 'TypeScript', 'routing'],
     domainExpertFriendly: false,
     startingPoints: [
-      { labelKey: 'links.line_profile', href: 'https://www.databus.org.il/profile/' },
+      {
+        labelKey: 'links.line_profile',
+        href: 'https://open-bus-map-search.hasadna.org.il/profile/4339841',
+      },
     ],
   },
   {
@@ -170,8 +173,11 @@ export const CHALLENGES: Challenge[] = [
     stack: ['React', 'Recharts', 'TypeScript'],
     domainExpertFriendly: true,
     startingPoints: [
-      { labelKey: 'links.gaps_page', href: 'https://www.databus.org.il/gaps' },
-      { labelKey: 'links.line_profile', href: 'https://www.databus.org.il/profile/' },
+      { labelKey: 'links.gaps_page', href: 'https://open-bus-map-search.hasadna.org.il/gaps' },
+      {
+        labelKey: 'links.line_profile',
+        href: 'https://open-bus-map-search.hasadna.org.il/profile/4339841',
+      },
     ],
   },
   {


### PR DESCRIPTION
## Problem

A hackathon registrant emailed to report that the "starting point" links on the hackathon page point to **`https://www.databus.org.il/...`** — an inactive virtual domain — so they 404. Example: the *"line profile page (example)"* link led to `https://www.databus.org.il/profile/`.

## Fix

In [src/pages/hackathon/challenges.ts](src/pages/hackathon/challenges.ts), repoint the three affected `startingPoints` links to the live app domain `https://open-bus-map-search.hasadna.org.il`:

- `gaps_page` → `https://open-bus-map-search.hasadna.org.il/gaps`
- `line_profile` (×2) → `https://open-bus-map-search.hasadna.org.il/profile/4339841`

The line-profile route is `profile/:gtfsRideGtfsRouteId`, so a bare `/profile/` hits the error page even on the live domain. I gave the example links a real route id (`4339841`, the same id used in our e2e tests) so they open an actual line.

All other links in the file already used correct domains and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)