### PR TITLE
fix: anchor release-please baseline to v1.4.0 with bootstrap-sha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
-  "commit-search-depth": 500
+  "commit-search-depth": 500,
+  "bootstrap-sha": "108821a7b1656b6524eb86ececa3954040f55025"
 }


### PR DESCRIPTION
Without bootstrap-sha, release-please v17 finds no valid baseline (all 5 GitHub Releases predate the manifest) and falls through to treating all 1053 commits as unreleased → first-ever node release = 1.0.0.

`bootstrap-sha` tells release-please to scan only commits after v1.4.0's commit SHA (108821a7). Combined with the manifest already declaring current version 1.4.0, the next computed version will be 1.5.0.

Reference: #1643

Generated with [Claude Code](https://claude.ai/code)