### PR TITLE
fix: use reachable bootstrap-sha for release-please baseline

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
-  "commit-search-depth": 500,
-  "bootstrap-sha": "108821a7b1656b6524eb86ececa3954040f55025"
+  "bootstrap-sha": "e9731410f8e6616acca0aeee941d1abb9bc94e6e"
 }


### PR DESCRIPTION
Previous bootstrap-sha (108821a7) is commit #288 from HEAD, just outside release-please's ~240-commit scan window. Replace with e9731410 (commit #200 from HEAD, well within range) so release-please can find the baseline.

With the manifest declaring v1.4.0 and bootstrap-sha reachable, the 21 feat: commits since position 200 will correctly compute the next version as 1.5.0.

# Description

<Please describe the suggested changes>

## screenshots

<paste here>
