### PR TITLE
fix: use actual v1.4.0 commit SHA for bootstrap-sha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
-  "bootstrap-sha": "e9731410f8e6616acca0aeee941d1abb9bc94e6e"
+  "bootstrap-sha": "108821a7b1656b6524eb86ececa3954040f55025"
 }


### PR DESCRIPTION
The previous bootstrap-sha (e9731410) was computed from a shallow clone and is not a real commit in this repo. Replace with the actual v1.4.0 commit SHA (108821a7), verified via GitHub API to be 288 commits from HEAD, well within the 500-commit scan window.

Reference: #1643

# Description

<Please describe the suggested changes>

## screenshots

<paste here>
