### PR TITLE
fix: configure release-please manifest mode with empty component

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,4 +15,5 @@ jobs:
     steps:
       - uses: googleapis/release-please-action@v5
         with:
-          release-type: node
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "node",
-  "bootstrap-sha": "108821a7b1656b6524eb86ececa3954040f55025"
+  "packages": {
+    ".": {
+      "release-type": "node",
+      "component": "",
+      "include-component-in-tag": false
+    }
+  }
 }


### PR DESCRIPTION
## The real root cause (verified, not assumed)

I ran release-please **17.9.0** locally in `--dry-run --debug` against the repo. The decisive log line is:

```
⚠ Found release tag with component '', but not configured in manifest   ×5
```

Our historical tags `v1.0.0`–`v1.4.0` were created with an **empty component** (`v{version}`, no prefix). But `release-please-config.json` used the *simple/action-input* shape (`{"release-type": "node", ...}`) instead of the **manifest schema**, which requires a `packages` map. With no `packages."."` entry, release-please derived the component for path `.` from the package name (`open-bus-map-search`) and could not match any `''` tag → **no baseline found** → it treated the entire history as unreleased and fell back to `1.0.0`.

This is why none of the earlier attempts worked — `bootstrap-sha`, `commit-search-depth`, `release-search-depth`, the search-depth/502 theory, and the manifest file alone all addressed the *wrong* layer. The version was always `1.0.0` because the baseline tag was never matched, not because the commit couldn't be reached.

## The fix

1. Rewrite `release-please-config.json` into proper **manifest schema**, mapping `.` to an **empty component** so it matches the real `v1.4.0` tag:

```json
{
  "packages": {
    ".": { "release-type": "node", "component": "", "include-component-in-tag": false }
  }
}
```

2. Switch the workflow to **manifest mode** (`config-file` + `manifest-file`, dropping the `release-type` input) so the Action runs the same code path I validated.

`.release-please-manifest.json` stays `{".": "1.4.0"}`.

## How to reproduce / validate (read-only, no merge required)

This was verified by running the **real release-please CLI in dry-run** against the live repo — it computes exactly what the GitHub Action would, but only prints instead of opening/updating a PR:

```bash
npx --yes release-please@17.9.0 release-pr \
  --repo-url=https://github.com/hasadna/open-bus-map-search \
  --target-branch=main \
  --token="$(gh auth token)" \
  --dry-run --debug
```

- `release-pr` is the same subcommand the Action invokes in manifest mode.
- `--repo-url` makes it read `release-please-config.json` + `.release-please-manifest.json` and the tag/commit history **from GitHub** (not local files), so it reflects reality.
- `--dry-run` prints `Would open N pull requests` instead of creating anything; `--debug` surfaces the baseline-matching internals (where the `component ''` warning showed up).

**Testing uncommitted config:** because `--repo-url` reads config from GitHub, push the candidate config to a throwaway branch and point `--target-branch` at it (then delete the branch). That's how this fix was confirmed before opening this PR.

### What a correct run looks like (dry-run against this branch)

```
❯ release for path: ., version: 1.4.0, sha: 108821a7…   ← baseline FOUND
✔ Splitting 291 commits by path                          ← only commits since v1.4.0
✔ updating from 1.4.0 to 1.5.0                            ← correct version
## [1.5.0](…/compare/v1.4.0...v1.5.0) (2026-06-12)
```

- **77 changelog entries**, all between #1192 and #1650 (everything after v1.4.0)
- **Zero** pre-v1.4.0 entries (verified #1037/#929/#992/#1096 absent)

Compare with the **current broken** config (`--target-branch=main`), which logs `Found release tag with component '', but not configured in manifest` ×5 and finds no baseline.

## After merge

The generated release branch name is `release-please--branches--main--components--open-bus-map-search` — the **same branch as #1204** — so the next workflow run will **update #1204 in place** to the clean `1.5.0` (no need to close it). Merging #1204 then creates the `v1.5.0` GitHub Release + tag with the manifest present in its tree, after which all future runs self-heal via the normal baseline scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)