### PR TITLE
chore: run @claude GitHub action on Opus

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,5 +60,6 @@ jobs:
           #   2. The deny-list below blocks Docker image pushes explicitly.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           claude_args: >-
+            --model opus
             --allowed-tools "Bash,Edit,Write,Read,Glob,Grep,WebFetch,WebSearch,TodoWrite"
             --disallowed-tools "Bash(docker push:*),Bash(docker image push:*),Bash(docker buildx:*),Bash(podman push:*)"


### PR DESCRIPTION
## What

Adds `--model opus` to the `claude_args` of the `@claude` GitHub action in [.github/workflows/claude.yml](.github/workflows/claude.yml).

## Why

The action had **no model configured**, so it ran on `anthropics/claude-code-action@v1`'s default (the Sonnet tier). The bot is tagged for non-trivial debugging/PR work (e.g. the recent release-please investigation), where Opus's stronger reasoning is worth the cost.

## Why the `opus` alias (not a dated model id)

`--model opus` uses the **tier alias**, which always resolves to the latest Opus. So when a new Opus model launches, this keeps using the best available Opus **without needing another PR**. Pinning a dated id (e.g. `claude-opus-4-1`) would require a manual bump each time — the alias avoids that.

## Validation

- YAML parses cleanly; the folded `>-` scalar resolves to:
  `--model opus --allowed-tools "…" --disallowed-tools "…"`
- Prettier-clean.

Syntax per the [claude-code-action configuration docs](https://github.com/anthropics/claude-code-action/blob/main/docs/configuration.md) (model is set via `--model` inside `claude_args`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)