### PR TITLE
fix: GTFS routes queried one calendar day early (UTC service-date off-by-one)

### DIFF
--- a/src/api/gtfsService.test.ts
+++ b/src/api/gtfsService.test.ts
@@ -1,0 +1,101 @@
+import dayjs, { ISRAEL_TIMEZONE } from 'src/dayjs'
+import { getAllRoutesList, getRoutesAsync, getRoutesByLineRef } from './gtfsService'
+
+jest.mock('src/api/apiConfig', () => ({
+  GTFS_API: { gtfsRoutesListGet: jest.fn() },
+}))
+
+const mockApi = jest.requireMock<{
+  GTFS_API: { gtfsRoutesListGet: jest.Mock }
+}>('src/api/apiConfig').GTFS_API
+
+// The generated client serializes date_from/date_to as Date.toISOString().slice(0, 10)
+// — the UTC calendar date. These tests assert the *serialized* date matches the Israeli
+// service day, which is the round-trip the off-by-one bug broke.
+const serializedDate = (d: Date) => d.toISOString().slice(0, 10)
+
+const firstCallParams = () =>
+  mockApi.gtfsRoutesListGet.mock.calls[0][0] as { dateFrom: Date; dateTo: Date; lineRefs?: string }
+
+function gtfsRoute(id: number, date: Date, overrides: Record<string, unknown> = {}) {
+  return {
+    id,
+    date,
+    lineRef: 1000,
+    operatorRef: 3,
+    routeShortName: '18',
+    routeLongName: 'A ⟵ B',
+    routeMkt: 'MKT1',
+    routeDirection: '1',
+    routeAlternative: 'A',
+    agencyName: 'Test',
+    routeType: 3,
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockApi.gtfsRoutesListGet.mockResolvedValue([])
+})
+
+describe('getAllRoutesList (operator page)', () => {
+  it('queries the Israeli service day, not the UTC day before it', async () => {
+    // dayjs.tz(date, IL).toDate() is the Israel-midnight instant the operator page passes
+    // (21:00Z the previous day in summer) — the exact input that used to query one day early.
+    const israelMidnight = dayjs.tz('2026-06-20', ISRAEL_TIMEZONE).toDate()
+
+    await getAllRoutesList('3', israelMidnight)
+
+    const params = firstCallParams()
+    expect(serializedDate(params.dateFrom)).toBe('2026-06-20')
+    expect(serializedDate(params.dateTo)).toBe('2026-06-20')
+  })
+
+  it('holds across the winter offset (+02:00)', async () => {
+    const israelMidnight = dayjs.tz('2026-01-15', ISRAEL_TIMEZONE).toDate()
+
+    await getAllRoutesList('3', israelMidnight)
+
+    const params = firstCallParams()
+    expect(serializedDate(params.dateFrom)).toBe('2026-01-15')
+    expect(serializedDate(params.dateTo)).toBe('2026-01-15')
+  })
+})
+
+describe('getRoutesByLineRef', () => {
+  it('queries the Israeli service day and forwards the lineRef', async () => {
+    const israelMidnight = dayjs.tz('2026-06-20', ISRAEL_TIMEZONE).toDate()
+
+    await getRoutesByLineRef('3', '12345', israelMidnight)
+
+    const params = firstCallParams()
+    expect(serializedDate(params.dateFrom)).toBe('2026-06-20')
+    expect(serializedDate(params.dateTo)).toBe('2026-06-20')
+    expect(params.lineRefs).toBe('12345')
+  })
+})
+
+describe('getRoutesAsync', () => {
+  it('queries the Israeli service day for date_from', async () => {
+    const day = dayjs.tz('2024-02-11', ISRAEL_TIMEZONE)
+
+    await getRoutesAsync(day, day, '3', '18')
+
+    const params = firstCallParams()
+    expect(serializedDate(params.dateFrom)).toBe('2024-02-11')
+    expect(serializedDate(params.dateTo)).toBe('2024-02-11')
+  })
+
+  it('returns the service-day routes (no compensating re-filter needed)', async () => {
+    // A route the server returned for the queried day flows straight through now that the
+    // query is correct — the previous-day re-filter that used to guard this is gone.
+    const day = dayjs.tz('2024-02-11', ISRAEL_TIMEZONE)
+    mockApi.gtfsRoutesListGet.mockResolvedValue([gtfsRoute(1, new Date('2024-02-11T12:00:00Z'))])
+
+    const routes = await getRoutesAsync(day, day, '3', '18')
+
+    expect(routes).toHaveLength(1)
+    expect(routes[0].routeIds).toContain(1)
+  })
+})

--- a/src/api/gtfsService.ts
+++ b/src/api/gtfsService.ts
@@ -1,5 +1,5 @@
 import { GTFS_API } from 'src/api/apiConfig'
-import dayjs, { toIsraelTimezone } from 'src/dayjs'
+import dayjs, { toGtfsServiceDate, toIsraelTimezone } from 'src/dayjs'
 import { BusRoute, fromGtfsRoute } from 'src/model/busRoute'
 import { BusStop, fromGtfsStop } from 'src/model/busStop'
 
@@ -10,25 +10,18 @@ export async function getRoutesAsync(
   lineNumber?: string,
   signal?: AbortSignal,
 ): Promise<BusRoute[]> {
-  const fromDate = toIsraelTimezone(from).format('YYYY-MM-DD')
-  const toDate = toIsraelTimezone(to).format('YYYY-MM-DD')
-
   const gtfsRoutes = await GTFS_API.gtfsRoutesListGet(
     {
       routeShortName: lineNumber,
       operatorRefs: operatorId,
-      dateFrom: from.startOf('day').toDate(),
-      dateTo: dayjs.min(to.endOf('day'), toIsraelTimezone()).toDate(),
+      dateFrom: toGtfsServiceDate(from),
+      dateTo: toGtfsServiceDate(dayjs.min(to.endOf('day'), toIsraelTimezone())),
       limit: 100,
     },
     { signal },
   )
   const routes = Object.values(
     gtfsRoutes
-      .filter((route) => {
-        const routeDate = toIsraelTimezone(route.date).format('YYYY-MM-DD')
-        return routeDate >= fromDate && routeDate <= toDate
-      })
       .map((route) => fromGtfsRoute(route))
       .reduce(
         (agg, line) => {
@@ -129,11 +122,12 @@ export async function getRouteById(routeId?: string, signal?: AbortSignal) {
 }
 
 export async function getAllRoutesList(operatorId: string, date: Date, signal?: AbortSignal) {
+  const serviceDate = toGtfsServiceDate(date)
   return await GTFS_API.gtfsRoutesListGet(
     {
       operatorRefs: operatorId,
-      dateFrom: date,
-      dateTo: date,
+      dateFrom: serviceDate,
+      dateTo: serviceDate,
       orderBy: 'route_long_name asc',
       limit: 15000,
     },
@@ -147,11 +141,12 @@ export async function getRoutesByLineRef(
   date: Date,
   signal?: AbortSignal,
 ) {
+  const serviceDate = toGtfsServiceDate(date)
   return await GTFS_API.gtfsRoutesListGet(
     {
       operatorRefs: operatorId,
-      dateFrom: date,
-      dateTo: date,
+      dateFrom: serviceDate,
+      dateTo: serviceDate,
       lineRefs,
       limit: 1,
     },

--- a/src/api/serviceDayRoutesService.ts
+++ b/src/api/serviceDayRoutesService.ts
@@ -3,17 +3,8 @@ import {
   GtfsRoutePydanticModel,
 } from '@hasadna/open-bus-api-client'
 import { GTFS_API } from 'src/api/apiConfig'
-import dayjs, { toIsraelTimezone } from 'src/dayjs'
+import dayjs, { toGtfsServiceDate, toIsraelTimezone } from 'src/dayjs'
 import { BusRoute, fromGtfsRoute } from 'src/model/busRoute'
-
-/**
- * Returns a Date at noon UTC for the given YYYY-MM-DD string so that
- * .toISOString().substring(0, 10) always yields the correct date string
- * regardless of local timezone offsets.
- */
-function utcNoonForDateStr(dateStr: string): Date {
-  return new Date(`${dateStr}T12:00:00Z`)
-}
 
 function rideToRoute(ride: GtfsRideWithRelatedPydanticModel): GtfsRoutePydanticModel | null {
   if (
@@ -57,8 +48,8 @@ export async function getServiceDayRoutes(
   const todayIL = toIsraelTimezone(serviceDate).startOf('day')
   const tomorrowIL = todayIL.add(1, 'day')
 
-  const todayUTC = utcNoonForDateStr(todayIL.format('YYYY-MM-DD'))
-  const tomorrowUTC = utcNoonForDateStr(tomorrowIL.format('YYYY-MM-DD'))
+  const todayUTC = toGtfsServiceDate(todayIL)
+  const tomorrowUTC = toGtfsServiceDate(tomorrowIL)
   const tomorrowMidnightUTC = tomorrowIL.toDate()
   const tomorrow04hUTC = tomorrowIL.add(4, 'hours').toDate()
 

--- a/src/dayjs.test.ts
+++ b/src/dayjs.test.ts
@@ -1,4 +1,27 @@
-import { parseIsraelLocalDatetime } from './dayjs'
+import dayjs, { ISRAEL_TIMEZONE, parseIsraelLocalDatetime, toGtfsServiceDate } from './dayjs'
+
+describe('toGtfsServiceDate', () => {
+  // The GTFS client serializes date_from/date_to as Date.toISOString().slice(0, 10),
+  // so the round-trip we actually care about is that UTC date string.
+  const serializedDate = (d: Date) => d.toISOString().slice(0, 10)
+
+  it('keeps an Israel-midnight Date on its own calendar day in summer (DST, +03:00)', () => {
+    // dayjs.tz(date, IL) is 21:00Z the previous day in summer — the off-by-one source.
+    const israelMidnight = dayjs.tz('2026-06-20', ISRAEL_TIMEZONE).toDate()
+    expect(serializedDate(israelMidnight)).toBe('2026-06-19') // the bug, before the fix
+    expect(serializedDate(toGtfsServiceDate(israelMidnight))).toBe('2026-06-20')
+  })
+
+  it('keeps an Israel-midnight Date on its own calendar day in winter (+02:00)', () => {
+    const israelMidnight = dayjs.tz('2026-01-15', ISRAEL_TIMEZONE).toDate()
+    expect(serializedDate(toGtfsServiceDate(israelMidnight))).toBe('2026-01-15')
+  })
+
+  it('maps a real instant to its Israeli service day, not the UTC day', () => {
+    // 2026-06-18T21:10Z is 00:10 the next day in Israel summer time.
+    expect(serializedDate(toGtfsServiceDate(new Date('2026-06-18T21:10:00Z')))).toBe('2026-06-19')
+  })
+})
 
 describe('parseIsraelLocalDatetime', () => {
   it('parses a shared-URL datetime as Israel-local time', () => {

--- a/src/dayjs.ts
+++ b/src/dayjs.ts
@@ -17,6 +17,17 @@ dayjs.tz.setDefault(ISRAEL_TIMEZONE)
 
 export const toIsraelTimezone = (value?: dayjs.ConfigType) => dayjs(value).tz(ISRAEL_TIMEZONE)
 
+/**
+ * Build the `Date` to hand the GTFS client for a `date_from`/`date_to` (service-day)
+ * filter. The generated client serializes those params as `Date.toISOString().slice(0, 10)`
+ * — i.e. the **UTC** calendar date. Israel is always east of UTC, so an Israel-midnight
+ * `Date` (e.g. `dayjs.tz(d, 'Asia/Jerusalem')`) is `21:00`/`22:00Z` the *previous* day and
+ * would query one day early year-round. Anchoring at noon UTC of the Israeli calendar day
+ * keeps the serialized date correct regardless of the offset.
+ */
+export const toGtfsServiceDate = (value?: dayjs.ConfigType): Date =>
+  new Date(`${toIsraelTimezone(value).format('YYYY-MM-DD')}T12:00:00Z`)
+
 /** Parse an Israel-local datetime string from untrusted input (e.g. a shared-URL
  *  param) into a Dayjs, or null if unparsable — dayjs.tz throws on bad input
  *  instead of returning an invalid instance. */

--- a/tests/HAR/timeline.har
+++ b/tests/HAR/timeline.har
@@ -1,30 +1,21 @@
 {
   "log": {
     "version": "1.2",
-    "creator": {
-      "name": "Playwright",
-      "version": "1.59.1"
-    },
-    "browser": {
-      "name": "chromium",
-      "version": "147.0.7727.15"
-    },
+    "creator": { "name": "Playwright", "version": "1.60.0" },
+    "browser": { "name": "chromium", "version": "148.0.7778.96" },
     "pages": [
       {
-        "startedDateTime": "2026-05-29T05:28:43.189Z",
-        "id": "page@8e3fdf1fd967def6ccb46271da7b203d",
+        "startedDateTime": "2026-06-25T16:27:15.045Z",
+        "id": "page@82312af85a77f70a8ed4a1492fbb3e03",
         "title": "דאטאבוס",
-        "pageTimings": {
-          "onContentLoad": 9470,
-          "onLoad": 9578
-        }
+        "pageTimings": { "onContentLoad": 48063, "onLoad": 48188 }
       }
     ],
     "entries": [
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:47.268Z",
-        "time": 279.39,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:21.159Z",
+        "time": 448.78399999999993,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_agencies/list?date_from=2024-02-11",
@@ -35,18 +26,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "date_from",
-              "value": "2024-02-11"
-            }
-          ],
-          "headersSize": 395,
+          "queryString": [{ "name": "date_from", "value": "2024-02-11" }],
+          "headersSize": 396,
           "bodySize": 0
         },
         "response": {
@@ -58,7 +50,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "8145" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:47 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:21 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -73,24 +65,31 @@
           "_transferSize": 8304
         },
         "cache": {},
-        "timings": { "dns": 18.572, "connect": 115.092, "ssl": 107.78, "send": 0, "wait": 34.066, "receive": 3.88 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": 22.019,
+          "connect": 116.366,
+          "ssl": 106.244,
+          "send": 0,
+          "wait": 200.387,
+          "receive": 3.768
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:48.693Z",
-        "time": 80.422,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:22.653Z",
+        "time": 1353.051,
         "request": {
           "method": "GET",
-          "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_routes/list?limit=100&date_from=2024-02-11&date_to=2024-02-12&operator_refs=3&route_short_name=1",
+          "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_routes/list?limit=100&date_from=2024-02-12&date_to=2024-02-12&operator_refs=3&route_short_name=1",
           "httpVersion": "HTTP/2.0",
           "cookies": [],
           "headers": [
@@ -98,32 +97,100 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
           "queryString": [
+            { "name": "limit", "value": "100" },
+            { "name": "date_from", "value": "2024-02-12" },
+            { "name": "date_to", "value": "2024-02-12" },
+            { "name": "operator_refs", "value": "3" },
+            { "name": "route_short_name", "value": "1" }
+          ],
+          "headersSize": 394,
+          "bodySize": 0
+        },
+        "response": {
+          "status": 200,
+          "statusText": "",
+          "httpVersion": "HTTP/2.0",
+          "cookies": [],
+          "headers": [
+            { "name": "access-control-allow-origin", "value": "*" },
+            { "name": "content-length", "value": "5501" },
+            { "name": "content-type", "value": "application/json" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
+            { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
+          ],
+          "content": {
+            "size": 5501,
+            "mimeType": "application/json",
+            "compression": 0,
+            "text": "[{\"id\":4335377,\"date\":\"2024-02-12\",\"line_ref\":2974,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"route_mkt\":\"33001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4335577,\"date\":\"2024-02-12\",\"line_ref\":4181,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"חניון אגד/הנפח-כרמיאל<->הנפח/היזם-כרמיאל-3#\",\"route_mkt\":\"14001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4335621,\"date\":\"2024-02-12\",\"line_ref\":4543,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"הנדיב/המייסדים-זכרון יעקב<->הנדיב/המייסדים-זכרון יעקב-3#\",\"route_mkt\":\"16001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4335622,\"date\":\"2024-02-12\",\"line_ref\":4547,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"בית ספר אלונים/הבנים-פרדס חנה כרכור<->יד לבנים/דרך הבנים-פרדס חנה כרכור-3#\",\"route_mkt\":\"17001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4335926,\"date\":\"2024-02-12\",\"line_ref\":7330,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"ת. מרכזית אילת/רציפים-אילת<->ת. מרכזית אילת/הורדה-אילת-3#\",\"route_mkt\":\"29001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4337184,\"date\":\"2024-02-12\",\"line_ref\":11888,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"הנדיב/המייסדים-זכרון יעקב<->הנדיב/המייסדים-זכרון יעקב-3ח\",\"route_mkt\":\"16001\",\"route_direction\":\"3\",\"route_alternative\":\"ח\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4337296,\"date\":\"2024-02-12\",\"line_ref\":12205,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"מתחם ביג/תדהר-פרדס חנה כרכור<->מתחם ביג/תדהר-פרדס חנה כרכור-3ז\",\"route_mkt\":\"17001\",\"route_direction\":\"3\",\"route_alternative\":\"ז\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4337473,\"date\":\"2024-02-12\",\"line_ref\":13435,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"תחנה תפעולית/ביטוח לאומי-ירושלים<->שדרות שז''ר/בנייני האומה-ירושלים-3#\",\"route_mkt\":\"34001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4337711,\"date\":\"2024-02-12\",\"line_ref\":15030,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"ת. מרכזית חוף הכרמל/רציפים עירוני-חיפה<->טכניון/הנדסה אזרחית-חיפה-1#\",\"route_mkt\":\"80001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4337720,\"date\":\"2024-02-12\",\"line_ref\":15047,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"טכניון/מעונות העמים-חיפה<->ת. מרכזית חוף הכרמל/הורדה-חיפה-2#\",\"route_mkt\":\"80001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4338898,\"date\":\"2024-02-12\",\"line_ref\":19748,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"האירוסים/פרג-רכסים<->בית ספר בית יעקב/הרב משקובסקי-רכסים-1#\",\"route_mkt\":\"30001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4338899,\"date\":\"2024-02-12\",\"line_ref\":19749,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"בית ספר בית יעקב/הרב משקובסקי-רכסים<->הנרקיסים/הורדים-רכסים-2#\",\"route_mkt\":\"30001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4339747,\"date\":\"2024-02-12\",\"line_ref\":27889,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"מנחם בגין/הר המוריה-דימונה<->מסוף אגד/קניון פרץ סנטר-דימונה-29\",\"route_mkt\":\"28001\",\"route_direction\":\"2\",\"route_alternative\":\"9\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4339888,\"date\":\"2024-02-12\",\"line_ref\":28215,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"מסוף אגד/קניון פרץ סנטר-דימונה<->מנחם בגין/הר המוריה-דימונה-19\",\"route_mkt\":\"28001\",\"route_direction\":\"1\",\"route_alternative\":\"9\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4341203,\"date\":\"2024-02-12\",\"line_ref\":37583,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3א\",\"route_mkt\":\"33001\",\"route_direction\":\"3\",\"route_alternative\":\"א\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4341249,\"date\":\"2024-02-12\",\"line_ref\":37686,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"ת. מרכזית חדרה-חדרה<->חפציבה מרכז/מבצע יונתן-חדרה-15\",\"route_mkt\":\"18001\",\"route_direction\":\"1\",\"route_alternative\":\"5\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4341250,\"date\":\"2024-02-12\",\"line_ref\":37687,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"חפציבה מרכז/מבצע יונתן-חדרה<->ת. מרכזית חדרה-חדרה-25\",\"route_mkt\":\"18001\",\"route_direction\":\"2\",\"route_alternative\":\"5\",\"agency_name\":\"אגד\",\"route_type\":\"3\"}]"
+          },
+          "headersSize": 0,
+          "bodySize": 5650,
+          "redirectURL": "",
+          "_transferSize": 5650
+        },
+        "cache": {},
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 1350.357,
+          "receive": 2.694
+        },
+        "serverIPAddress": "83.229.74.240",
+        "_serverPort": 443,
+        "_securityDetails": {
+          "protocol": "TLS 1.2",
+          "subjectName": "open-bus-stride-api.hasadna.org.il",
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
+        }
+      },
+      {
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.201Z",
+        "time": 51.595,
+        "request": {
+          "method": "GET",
+          "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_rides/list?limit=1&gtfs_route_id=4335377&start_time_from=2024-02-11T15%3A00%3A00.000Z&start_time_to=2024-02-13T15%3A00%3A00.000Z&order_by=start_time",
+          "httpVersion": "HTTP/2.0",
+          "cookies": [],
+          "headers": [
+            { "name": "Accept", "value": "*/*" },
+            { "name": "Accept-Language", "value": "he-IL" },
+            { "name": "Origin", "value": "http://localhost:3000" },
+            { "name": "Referer", "value": "http://localhost:3000/" },
             {
-              "name": "limit",
-              "value": "100"
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
             },
             {
-              "name": "date_from",
-              "value": "2024-02-11"
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
             },
-            {
-              "name": "date_to",
-              "value": "2024-02-12"
-            },
-            {
-              "name": "operator_refs",
-              "value": "3"
-            },
-            {
-              "name": "route_short_name",
-              "value": "1"
-            }
+            { "name": "sec-ch-ua-mobile", "value": "?0" },
+            { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
+          ],
+          "queryString": [
+            { "name": "limit", "value": "1" },
+            { "name": "gtfs_route_id", "value": "4335377" },
+            { "name": "start_time_from", "value": "2024-02-11T15:00:00.000Z" },
+            { "name": "start_time_to", "value": "2024-02-13T15:00:00.000Z" },
+            { "name": "order_by", "value": "start_time" }
           ],
           "headersSize": 393,
           "bodySize": 0
@@ -135,88 +202,9 @@
           "cookies": [],
           "headers": [
             { "name": "access-control-allow-origin", "value": "*" },
-            { "name": "content-length", "value": "11001" },
-            { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:48 GMT" },
-            { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
-          ],
-          "content": {
-            "size": 11001,
-            "mimeType": "application/json",
-            "compression": 0,
-            "text": "[{\"id\":4328750,\"date\":\"2024-02-11\",\"line_ref\":2974,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"route_mkt\":\"33001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4328951,\"date\":\"2024-02-11\",\"line_ref\":4181,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"חניון אגד/הנפח-כרמיאל<->הנפח/היזם-כרמיאל-3#\",\"route_mkt\":\"14001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4328992,\"date\":\"2024-02-11\",\"line_ref\":4543,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"הנדיב/המייסדים-זכרון יעקב<->הנדיב/המייסדים-זכרון יעקב-3#\",\"route_mkt\":\"16001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4328993,\"date\":\"2024-02-11\",\"line_ref\":4547,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"בית ספר אלונים/הבנים-פרדס חנה כרכור<->יד לבנים/דרך הבנים-פרדס חנה כרכור-3#\",\"route_mkt\":\"17001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4329311,\"date\":\"2024-02-11\",\"line_ref\":7330,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"ת. מרכזית אילת/רציפים-אילת<->ת. מרכזית אילת/הורדה-אילת-3#\",\"route_mkt\":\"29001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4330589,\"date\":\"2024-02-11\",\"line_ref\":11888,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"הנדיב/המייסדים-זכרון יעקב<->הנדיב/המייסדים-זכרון יעקב-3ח\",\"route_mkt\":\"16001\",\"route_direction\":\"3\",\"route_alternative\":\"ח\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4330703,\"date\":\"2024-02-11\",\"line_ref\":12205,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"מתחם ביג/תדהר-פרדס חנה כרכור<->מתחם ביג/תדהר-פרדס חנה כרכור-3ז\",\"route_mkt\":\"17001\",\"route_direction\":\"3\",\"route_alternative\":\"ז\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4330885,\"date\":\"2024-02-11\",\"line_ref\":13435,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"תחנה תפעולית/ביטוח לאומי-ירושלים<->שדרות שז''ר/בנייני האומה-ירושלים-3#\",\"route_mkt\":\"34001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4331115,\"date\":\"2024-02-11\",\"line_ref\":15030,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"ת. מרכזית חוף הכרמל/רציפים עירוני-חיפה<->טכניון/הנדסה אזרחית-חיפה-1#\",\"route_mkt\":\"80001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4331124,\"date\":\"2024-02-11\",\"line_ref\":15047,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"טכניון/מעונות העמים-חיפה<->ת. מרכזית חוף הכרמל/הורדה-חיפה-2#\",\"route_mkt\":\"80001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4332283,\"date\":\"2024-02-11\",\"line_ref\":19748,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"האירוסים/פרג-רכסים<->בית ספר בית יעקב/הרב משקובסקי-רכסים-1#\",\"route_mkt\":\"30001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4332284,\"date\":\"2024-02-11\",\"line_ref\":19749,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"בית ספר בית יעקב/הרב משקובסקי-רכסים<->הנרקיסים/הורדים-רכסים-2#\",\"route_mkt\":\"30001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4333148,\"date\":\"2024-02-11\",\"line_ref\":27889,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"מנחם בגין/הר המוריה-דימונה<->מסוף אגד/קניון פרץ סנטר-דימונה-29\",\"route_mkt\":\"28001\",\"route_direction\":\"2\",\"route_alternative\":\"9\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4333293,\"date\":\"2024-02-11\",\"line_ref\":28215,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"מסוף אגד/קניון פרץ סנטר-דימונה<->מנחם בגין/הר המוריה-דימונה-19\",\"route_mkt\":\"28001\",\"route_direction\":\"1\",\"route_alternative\":\"9\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4334637,\"date\":\"2024-02-11\",\"line_ref\":37583,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3א\",\"route_mkt\":\"33001\",\"route_direction\":\"3\",\"route_alternative\":\"א\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4334683,\"date\":\"2024-02-11\",\"line_ref\":37686,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"ת. מרכזית חדרה-חדרה<->חפציבה מרכז/מבצע יונתן-חדרה-15\",\"route_mkt\":\"18001\",\"route_direction\":\"1\",\"route_alternative\":\"5\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4334684,\"date\":\"2024-02-11\",\"line_ref\":37687,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"חפציבה מרכז/מבצע יונתן-חדרה<->ת. מרכזית חדרה-חדרה-25\",\"route_mkt\":\"18001\",\"route_direction\":\"2\",\"route_alternative\":\"5\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4335377,\"date\":\"2024-02-12\",\"line_ref\":2974,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"route_mkt\":\"33001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4335577,\"date\":\"2024-02-12\",\"line_ref\":4181,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"חניון אגד/הנפח-כרמיאל<->הנפח/היזם-כרמיאל-3#\",\"route_mkt\":\"14001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4335621,\"date\":\"2024-02-12\",\"line_ref\":4543,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"הנדיב/המייסדים-זכרון יעקב<->הנדיב/המייסדים-זכרון יעקב-3#\",\"route_mkt\":\"16001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4335622,\"date\":\"2024-02-12\",\"line_ref\":4547,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"בית ספר אלונים/הבנים-פרדס חנה כרכור<->יד לבנים/דרך הבנים-פרדס חנה כרכור-3#\",\"route_mkt\":\"17001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4335926,\"date\":\"2024-02-12\",\"line_ref\":7330,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"ת. מרכזית אילת/רציפים-אילת<->ת. מרכזית אילת/הורדה-אילת-3#\",\"route_mkt\":\"29001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4337184,\"date\":\"2024-02-12\",\"line_ref\":11888,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"הנדיב/המייסדים-זכרון יעקב<->הנדיב/המייסדים-זכרון יעקב-3ח\",\"route_mkt\":\"16001\",\"route_direction\":\"3\",\"route_alternative\":\"ח\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4337296,\"date\":\"2024-02-12\",\"line_ref\":12205,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"מתחם ביג/תדהר-פרדס חנה כרכור<->מתחם ביג/תדהר-פרדס חנה כרכור-3ז\",\"route_mkt\":\"17001\",\"route_direction\":\"3\",\"route_alternative\":\"ז\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4337473,\"date\":\"2024-02-12\",\"line_ref\":13435,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"תחנה תפעולית/ביטוח לאומי-ירושלים<->שדרות שז''ר/בנייני האומה-ירושלים-3#\",\"route_mkt\":\"34001\",\"route_direction\":\"3\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4337711,\"date\":\"2024-02-12\",\"line_ref\":15030,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"ת. מרכזית חוף הכרמל/רציפים עירוני-חיפה<->טכניון/הנדסה אזרחית-חיפה-1#\",\"route_mkt\":\"80001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4337720,\"date\":\"2024-02-12\",\"line_ref\":15047,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"טכניון/מעונות העמים-חיפה<->ת. מרכזית חוף הכרמל/הורדה-חיפה-2#\",\"route_mkt\":\"80001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4338898,\"date\":\"2024-02-12\",\"line_ref\":19748,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"האירוסים/פרג-רכסים<->בית ספר בית יעקב/הרב משקובסקי-רכסים-1#\",\"route_mkt\":\"30001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4338899,\"date\":\"2024-02-12\",\"line_ref\":19749,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"בית ספר בית יעקב/הרב משקובסקי-רכסים<->הנרקיסים/הורדים-רכסים-2#\",\"route_mkt\":\"30001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4339747,\"date\":\"2024-02-12\",\"line_ref\":27889,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"מנחם בגין/הר המוריה-דימונה<->מסוף אגד/קניון פרץ סנטר-דימונה-29\",\"route_mkt\":\"28001\",\"route_direction\":\"2\",\"route_alternative\":\"9\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4339888,\"date\":\"2024-02-12\",\"line_ref\":28215,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"מסוף אגד/קניון פרץ סנטר-דימונה<->מנחם בגין/הר המוריה-דימונה-19\",\"route_mkt\":\"28001\",\"route_direction\":\"1\",\"route_alternative\":\"9\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4341203,\"date\":\"2024-02-12\",\"line_ref\":37583,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3א\",\"route_mkt\":\"33001\",\"route_direction\":\"3\",\"route_alternative\":\"א\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4341249,\"date\":\"2024-02-12\",\"line_ref\":37686,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"ת. מרכזית חדרה-חדרה<->חפציבה מרכז/מבצע יונתן-חדרה-15\",\"route_mkt\":\"18001\",\"route_direction\":\"1\",\"route_alternative\":\"5\",\"agency_name\":\"אגד\",\"route_type\":\"3\"},{\"id\":4341250,\"date\":\"2024-02-12\",\"line_ref\":37687,\"operator_ref\":3,\"route_short_name\":\"1\",\"route_long_name\":\"חפציבה מרכז/מבצע יונתן-חדרה<->ת. מרכזית חדרה-חדרה-25\",\"route_mkt\":\"18001\",\"route_direction\":\"2\",\"route_alternative\":\"5\",\"agency_name\":\"אגד\",\"route_type\":\"3\"}]"
-          },
-          "headersSize": 0,
-          "bodySize": 11160,
-          "redirectURL": "",
-          "_transferSize": 11160
-        },
-        "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 77.981, "receive": 2.441 },
-        "serverIPAddress": "83.229.74.225",
-        "_serverPort": 443,
-        "_securityDetails": {
-          "protocol": "TLS 1.2",
-          "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
-        }
-      },
-      {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.175Z",
-        "time": 35.067,
-        "request": {
-          "method": "GET",
-          "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_rides/list?limit=1&gtfs_route_id=4335377&start_time_from=2024-02-11T15%3A00%3A00.000Z&start_time_to=2024-02-13T15%3A00%3A00.000Z&order_by=start_time",
-          "httpVersion": "HTTP/2.0",
-          "cookies": [],
-          "headers": [
-            { "name": "Accept", "value": "*/*" },
-            { "name": "Accept-Language", "value": "he-IL" },
-            { "name": "Origin", "value": "http://localhost:3000" },
-            { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
-            { "name": "sec-ch-ua-mobile", "value": "?0" },
-            { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
-          ],
-          "queryString": [
-            {
-              "name": "limit",
-              "value": "1"
-            },
-            {
-              "name": "gtfs_route_id",
-              "value": "4335377"
-            },
-            {
-              "name": "start_time_from",
-              "value": "2024-02-11T15:00:00.000Z"
-            },
-            {
-              "name": "start_time_to",
-              "value": "2024-02-13T15:00:00.000Z"
-            },
-            {
-              "name": "order_by",
-              "value": "start_time"
-            }
-          ],
-          "headersSize": 392,
-          "bodySize": 0
-        },
-        "response": {
-          "status": 200,
-          "statusText": "",
-          "httpVersion": "HTTP/2.0",
-          "cookies": [],
-          "headers": [
-            { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "578" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -231,21 +219,28 @@
           "_transferSize": 717
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 31.128, "receive": 3.939 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 48.329,
+          "receive": 3.266
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.218Z",
-        "time": 87.76599999999999,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.253Z",
+        "time": 314.46500000000003,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_ride_stops/list?gtfs_ride_ids=66913925",
@@ -256,18 +251,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "gtfs_ride_ids",
-              "value": "66913925"
-            }
-          ],
-          "headersSize": 397,
+          "queryString": [{ "name": "gtfs_ride_ids", "value": "66913925" }],
+          "headersSize": 398,
           "bodySize": 0
         },
         "response": {
@@ -279,7 +275,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "42226" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -289,26 +285,33 @@
             "text": "[{\"id\":2391080921,\"gtfs_stop_id\":21257954,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:30:00+00:00\",\"departure_time\":\"2024-02-12T03:30:00+00:00\",\"stop_sequence\":1,\"pickup_type\":0,\"drop_off_type\":1,\"shape_dist_traveled\":null,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":37431,\"gtfs_stop__lat\":31.797837,\"gtfs_stop__lon\":34.782544,\"gtfs_stop__name\":\"שדרות מנחם בגין/כביש 7\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080922,\"gtfs_stop_id\":21235443,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:30:36+00:00\",\"departure_time\":\"2024-02-12T03:30:36+00:00\",\"stop_sequence\":2,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":166,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38884,\"gtfs_stop__lat\":31.799224,\"gtfs_stop__lon\":34.782985,\"gtfs_stop__name\":\"מנחם בגין/יצחק רבין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080923,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:30:59+00:00\",\"departure_time\":\"2024-02-12T03:30:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080925,\"gtfs_stop_id\":21235449,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:31:59+00:00\",\"departure_time\":\"2024-02-12T03:31:59+00:00\",\"stop_sequence\":4,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":845,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38891,\"gtfs_stop__lat\":31.801182,\"gtfs_stop__lon\":34.787199,\"gtfs_stop__name\":\"צאלה/אלמוג\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080926,\"gtfs_stop_id\":21235445,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:32:31+00:00\",\"departure_time\":\"2024-02-12T03:32:31+00:00\",\"stop_sequence\":5,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":1016,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38886,\"gtfs_stop__lat\":31.802319,\"gtfs_stop__lon\":34.786735,\"gtfs_stop__name\":\"בית ספר גוונים/ארז\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080927,\"gtfs_stop_id\":21235446,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:33:48+00:00\",\"departure_time\":\"2024-02-12T03:33:48+00:00\",\"stop_sequence\":6,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":1329,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38887,\"gtfs_stop__lat\":31.804595,\"gtfs_stop__lon\":34.786623,\"gtfs_stop__name\":\"דרך האילנות/אלון\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080928,\"gtfs_stop_id\":21235447,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:33:59+00:00\",\"departure_time\":\"2024-02-12T03:33:59+00:00\",\"stop_sequence\":7,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":1484,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38888,\"gtfs_stop__lat\":31.805041,\"gtfs_stop__lon\":34.785098,\"gtfs_stop__name\":\"דרך האילנות/מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080929,\"gtfs_stop_id\":21251475,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:33:59+00:00\",\"departure_time\":\"2024-02-12T03:33:59+00:00\",\"stop_sequence\":8,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":1549,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":35877,\"gtfs_stop__lat\":31.8054,\"gtfs_stop__lon\":34.784988,\"gtfs_stop__name\":\"מנחם בגין/דרך האילנות\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080931,\"gtfs_stop_id\":21252349,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:34:59+00:00\",\"departure_time\":\"2024-02-12T03:34:59+00:00\",\"stop_sequence\":9,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":1930,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38005,\"gtfs_stop__lat\":31.808427,\"gtfs_stop__lon\":34.786679,\"gtfs_stop__name\":\"מנחם בגין/ציונה צרפת\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080932,\"gtfs_stop_id\":21251476,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:35:59+00:00\",\"departure_time\":\"2024-02-12T03:35:59+00:00\",\"stop_sequence\":10,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":2359,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":35878,\"gtfs_stop__lat\":31.811686,\"gtfs_stop__lon\":34.786674,\"gtfs_stop__name\":\"סטרומה/מנשה\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080933,\"gtfs_stop_id\":21251033,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:36:59+00:00\",\"departure_time\":\"2024-02-12T03:36:59+00:00\",\"stop_sequence\":11,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":2831,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":34946,\"gtfs_stop__lat\":31.813822,\"gtfs_stop__lon\":34.782568,\"gtfs_stop__name\":\"סטרומה/העצמאות\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080934,\"gtfs_stop_id\":21252348,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:38:59+00:00\",\"departure_time\":\"2024-02-12T03:38:59+00:00\",\"stop_sequence\":12,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":3357,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38002,\"gtfs_stop__lat\":31.816863,\"gtfs_stop__lon\":34.781688,\"gtfs_stop__name\":\"וייצמן/כצנלסון\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080935,\"gtfs_stop_id\":21235448,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:39:10+00:00\",\"departure_time\":\"2024-02-12T03:39:10+00:00\",\"stop_sequence\":13,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":3550,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38890,\"gtfs_stop__lat\":31.816579,\"gtfs_stop__lon\":34.779753,\"gtfs_stop__name\":\"וייצמן/מרבד הקסמים\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080937,\"gtfs_stop_id\":21251477,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:39:59+00:00\",\"departure_time\":\"2024-02-12T03:39:59+00:00\",\"stop_sequence\":14,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":3772,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":35880,\"gtfs_stop__lat\":31.817284,\"gtfs_stop__lon\":34.777623,\"gtfs_stop__name\":\"וייצמן/לילינבלום\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080938,\"gtfs_stop_id\":21246941,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:40:01+00:00\",\"departure_time\":\"2024-02-12T03:40:01+00:00\",\"stop_sequence\":15,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":3962,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":32315,\"gtfs_stop__lat\":31.815986,\"gtfs_stop__lon\":34.777464,\"gtfs_stop__name\":\"בית המועצה/פינס\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080939,\"gtfs_stop_id\":21256625,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:40:59+00:00\",\"departure_time\":\"2024-02-12T03:40:59+00:00\",\"stop_sequence\":16,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":4225,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":31863,\"gtfs_stop__lat\":31.813707,\"gtfs_stop__lon\":34.777205,\"gtfs_stop__name\":\"פינס/פיינברג\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080940,\"gtfs_stop_id\":21235450,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:41:11+00:00\",\"departure_time\":\"2024-02-12T03:41:11+00:00\",\"stop_sequence\":17,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":4372,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38894,\"gtfs_stop__lat\":31.813285,\"gtfs_stop__lon\":34.775928,\"gtfs_stop__name\":\"פיינברג/שכביץ\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080942,\"gtfs_stop_id\":21247316,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:42:44+00:00\",\"departure_time\":\"2024-02-12T03:42:44+00:00\",\"stop_sequence\":18,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":4764,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":32827,\"gtfs_stop__lat\":31.815285,\"gtfs_stop__lon\":34.774122,\"gtfs_stop__name\":\"בית הכנסת הגדול/הבילויים\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080944,\"gtfs_stop_id\":21246245,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:43:46+00:00\",\"departure_time\":\"2024-02-12T03:43:46+00:00\",\"stop_sequence\":19,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":5136,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":31083,\"gtfs_stop__lat\":31.815657,\"gtfs_stop__lon\":34.771112,\"gtfs_stop__name\":\"תחנה מרכזית גדרה\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080945,\"gtfs_stop_id\":21250842,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:44:59+00:00\",\"departure_time\":\"2024-02-12T03:44:59+00:00\",\"stop_sequence\":20,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":5748,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":34398,\"gtfs_stop__lat\":31.819077,\"gtfs_stop__lon\":34.775049,\"gtfs_stop__name\":\"אשר/וייצמן\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080946,\"gtfs_stop_id\":21250843,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:46:00+00:00\",\"departure_time\":\"2024-02-12T03:46:00+00:00\",\"stop_sequence\":21,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":6048,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":34399,\"gtfs_stop__lat\":31.821425,\"gtfs_stop__lon\":34.776082,\"gtfs_stop__name\":\"שפרינצק/אשר\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080947,\"gtfs_stop_id\":21250844,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:47:45+00:00\",\"departure_time\":\"2024-02-12T03:47:45+00:00\",\"stop_sequence\":22,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":6410,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":34400,\"gtfs_stop__lat\":31.821736,\"gtfs_stop__lon\":34.779743,\"gtfs_stop__name\":\"שפרינצק/דנציגר\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080948,\"gtfs_stop_id\":21251417,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:47:59+00:00\",\"departure_time\":\"2024-02-12T03:47:59+00:00\",\"stop_sequence\":23,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":6520,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":35757,\"gtfs_stop__lat\":31.821067,\"gtfs_stop__lon\":34.779847,\"gtfs_stop__name\":\"שפרינצק/שמעון\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080950,\"gtfs_stop_id\":21251472,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:49:48+00:00\",\"departure_time\":\"2024-02-12T03:49:48+00:00\",\"stop_sequence\":24,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":6971,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":35874,\"gtfs_stop__lat\":31.817886,\"gtfs_stop__lon\":34.779667,\"gtfs_stop__name\":\"מרבד הקסמים/בעלי המלאכה\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080951,\"gtfs_stop_id\":21251473,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:50:23+00:00\",\"departure_time\":\"2024-02-12T03:50:23+00:00\",\"stop_sequence\":25,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":7194,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":35875,\"gtfs_stop__lat\":31.816458,\"gtfs_stop__lon\":34.779564,\"gtfs_stop__name\":\"וייצמן/כצנלסון\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080953,\"gtfs_stop_id\":21251474,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:50:59+00:00\",\"departure_time\":\"2024-02-12T03:50:59+00:00\",\"stop_sequence\":26,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":7483,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":35876,\"gtfs_stop__lat\":31.817042,\"gtfs_stop__lon\":34.782367,\"gtfs_stop__name\":\"וייצמן/העצמאות\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080954,\"gtfs_stop_id\":21252353,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:52:11+00:00\",\"departure_time\":\"2024-02-12T03:52:11+00:00\",\"stop_sequence\":27,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":8019,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38012,\"gtfs_stop__lat\":31.816477,\"gtfs_stop__lon\":34.786396,\"gtfs_stop__name\":\"גמליאל/וייצמן\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080955,\"gtfs_stop_id\":21252352,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:53:33+00:00\",\"departure_time\":\"2024-02-12T03:53:33+00:00\",\"stop_sequence\":28,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":8321,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38010,\"gtfs_stop__lat\":31.814043,\"gtfs_stop__lon\":34.786146,\"gtfs_stop__name\":\"אפרים/סטרומה\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080957,\"gtfs_stop_id\":21252351,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:54:18+00:00\",\"departure_time\":\"2024-02-12T03:54:18+00:00\",\"stop_sequence\":29,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":8557,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38009,\"gtfs_stop__lat\":31.81233,\"gtfs_stop__lon\":34.784827,\"gtfs_stop__name\":\"דרך הפרחים/ציפורן\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080958,\"gtfs_stop_id\":21252350,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:54:51+00:00\",\"departure_time\":\"2024-02-12T03:54:51+00:00\",\"stop_sequence\":30,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":8710,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38008,\"gtfs_stop__lat\":31.810951,\"gtfs_stop__lon\":34.784966,\"gtfs_stop__name\":\"דרך הפרחים/אירוס\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080960,\"gtfs_stop_id\":21235441,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:55:01+00:00\",\"departure_time\":\"2024-02-12T03:55:01+00:00\",\"stop_sequence\":31,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":8930,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38881,\"gtfs_stop__lat\":31.809325,\"gtfs_stop__lon\":34.784347,\"gtfs_stop__name\":\"דרך הפרחים/יסמין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080961,\"gtfs_stop_id\":21251509,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:56:59+00:00\",\"departure_time\":\"2024-02-12T03:56:59+00:00\",\"stop_sequence\":32,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":9542,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":35967,\"gtfs_stop__lat\":31.808517,\"gtfs_stop__lon\":34.77938,\"gtfs_stop__name\":\"בית חולים הרצפלד/דרך ארץ\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080962,\"gtfs_stop_id\":21246943,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:57:25+00:00\",\"departure_time\":\"2024-02-12T03:57:25+00:00\",\"stop_sequence\":33,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":9745,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":32318,\"gtfs_stop__lat\":31.807914,\"gtfs_stop__lon\":34.777941,\"gtfs_stop__name\":\"בית חולים הרצפלד\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080964,\"gtfs_stop_id\":21252347,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:58:04+00:00\",\"departure_time\":\"2024-02-12T03:58:04+00:00\",\"stop_sequence\":34,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":10106,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38001,\"gtfs_stop__lat\":31.805319,\"gtfs_stop__lon\":34.777621,\"gtfs_stop__name\":\"בן גוריון/עופרים\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080965,\"gtfs_stop_id\":21257943,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:59:01+00:00\",\"departure_time\":\"2024-02-12T03:59:01+00:00\",\"stop_sequence\":35,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":10546,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":37417,\"gtfs_stop__lat\":31.804336,\"gtfs_stop__lon\":34.781967,\"gtfs_stop__name\":\"שדרות בן גוריון/דרך הנחלים\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080967,\"gtfs_stop_id\":21257937,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T03:59:59+00:00\",\"departure_time\":\"2024-02-12T03:59:59+00:00\",\"stop_sequence\":36,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":10878,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":37423,\"gtfs_stop__lat\":31.804163,\"gtfs_stop__lon\":34.78354,\"gtfs_stop__name\":\"מרכז מסחרי המושבה/שדרות בן גוריון\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080968,\"gtfs_stop_id\":21257945,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T04:00:59+00:00\",\"departure_time\":\"2024-02-12T04:00:59+00:00\",\"stop_sequence\":37,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":11367,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":37415,\"gtfs_stop__lat\":31.80525,\"gtfs_stop__lon\":34.77862,\"gtfs_stop__name\":\"שדרות בן גוריון/פינס\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080969,\"gtfs_stop_id\":21252632,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T04:01:59+00:00\",\"departure_time\":\"2024-02-12T04:01:59+00:00\",\"stop_sequence\":38,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":11651,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38478,\"gtfs_stop__lat\":31.804831,\"gtfs_stop__lon\":34.776637,\"gtfs_stop__name\":\"פינס/בן גוריון\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080971,\"gtfs_stop_id\":21235442,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T04:04:21+00:00\",\"departure_time\":\"2024-02-12T04:04:21+00:00\",\"stop_sequence\":39,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":12304,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38883,\"gtfs_stop__lat\":31.80037,\"gtfs_stop__lon\":34.778239,\"gtfs_stop__name\":\"יצחק רבין/פנחס ספיר\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080972,\"gtfs_stop_id\":21257399,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T04:05:46+00:00\",\"departure_time\":\"2024-02-12T04:05:46+00:00\",\"stop_sequence\":40,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":12615,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":33041,\"gtfs_stop__lat\":31.799195,\"gtfs_stop__lon\":34.781224,\"gtfs_stop__name\":\"דרך יצחק רבין/לשם\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080974,\"gtfs_stop_id\":21257953,\"gtfs_ride_id\":66913925,\"arrival_time\":\"2024-02-12T04:06:23+00:00\",\"departure_time\":\"2024-02-12T04:06:23+00:00\",\"stop_sequence\":41,\"pickup_type\":1,\"drop_off_type\":0,\"shape_dist_traveled\":12857,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650630_110224\",\"gtfs_ride__start_time\":\"2024-02-12T03:30:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T04:06:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":37432,\"gtfs_stop__lat\":31.797844,\"gtfs_stop__lon\":34.78231,\"gtfs_stop__name\":\"שדרות מנחם בגין/כביש 7\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"}]"
           },
           "headersSize": 0,
-          "bodySize": 42475,
+          "bodySize": 42457,
           "redirectURL": "",
-          "_transferSize": 42475
+          "_transferSize": 42457
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 68.689, "receive": 19.077 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 268.759,
+          "receive": 45.706
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.311Z",
-        "time": 28.105,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.571Z",
+        "time": 52.412,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21257954",
@@ -319,18 +322,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21257954"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21257954" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -342,7 +346,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "147" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -357,21 +361,28 @@
           "_transferSize": 286
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 22.477, "receive": 5.628 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 47.803,
+          "receive": 4.609
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.311Z",
-        "time": 35.253,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.571Z",
+        "time": 78.762,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21235443",
@@ -382,18 +393,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21235443"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21235443" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -405,7 +417,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "143" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -420,21 +432,28 @@
           "_transferSize": 282
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 28.393, "receive": 6.86 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 73.428,
+          "receive": 5.334
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.312Z",
-        "time": 34.685,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.571Z",
+        "time": 96.017,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21235444",
@@ -445,18 +464,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21235444"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21235444" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -468,7 +488,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "156" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -483,21 +503,28 @@
           "_transferSize": 295
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 27.49, "receive": 7.195 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 84.814,
+          "receive": 11.203
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.312Z",
-        "time": 37.827,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.572Z",
+        "time": 78.616,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21235449",
@@ -508,18 +535,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21235449"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21235449" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -531,7 +559,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "127" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -546,21 +574,28 @@
           "_transferSize": 266
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 28.557, "receive": 9.27 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 73.24,
+          "receive": 5.376
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.312Z",
-        "time": 32.485,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.572Z",
+        "time": 78.92099999999999,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21235445",
@@ -571,18 +606,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21235445"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21235445" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -594,7 +630,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "141" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -609,21 +645,28 @@
           "_transferSize": 280
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 25.309, "receive": 7.176 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 73.08,
+          "receive": 5.841
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.312Z",
-        "time": 35.614,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.573Z",
+        "time": 96.623,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21235446",
@@ -634,18 +677,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21235446"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21235446" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -657,7 +701,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "138" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -672,21 +716,28 @@
           "_transferSize": 277
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 26.519, "receive": 9.095 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 89.836,
+          "receive": 6.787
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.312Z",
-        "time": 38.36,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.573Z",
+        "time": 112.92500000000001,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21235447",
@@ -697,18 +748,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21235447"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21235447" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -720,7 +772,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "147" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -735,21 +787,28 @@
           "_transferSize": 286
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 26.571, "receive": 11.789 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 100.748,
+          "receive": 12.177
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.312Z",
-        "time": 42.996,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.573Z",
+        "time": 88.443,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21251475",
@@ -760,18 +819,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21251475"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21251475" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -783,7 +843,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "145" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -798,21 +858,28 @@
           "_transferSize": 284
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 30.533, "receive": 12.463 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 80.58,
+          "receive": 7.863
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.312Z",
-        "time": 43.221000000000004,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.573Z",
+        "time": 82.333,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21252349",
@@ -823,18 +890,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21252349"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21252349" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -846,7 +914,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "145" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -861,21 +929,28 @@
           "_transferSize": 284
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 30.893, "receive": 12.328 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 76.416,
+          "receive": 5.917
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.312Z",
-        "time": 43,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.573Z",
+        "time": 88.579,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21251476",
@@ -886,18 +961,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21251476"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21251476" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -909,7 +985,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "129" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -924,21 +1000,28 @@
           "_transferSize": 268
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 30.528, "receive": 12.472 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 80.448,
+          "receive": 8.131
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.313Z",
-        "time": 43.608,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.574Z",
+        "time": 91.301,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21251033",
@@ -949,18 +1032,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21251033"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21251033" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -972,7 +1056,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "135" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -987,21 +1071,28 @@
           "_transferSize": 274
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 33.934, "receive": 9.674 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 80.431,
+          "receive": 10.87
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.313Z",
-        "time": 38.762,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.574Z",
+        "time": 81.257,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21252348",
@@ -1012,18 +1103,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21252348"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21252348" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -1035,7 +1127,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "135" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -1050,21 +1142,28 @@
           "_transferSize": 274
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 28.919, "receive": 9.843 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 74.345,
+          "receive": 6.912
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.313Z",
-        "time": 42.71,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.574Z",
+        "time": 112.08999999999999,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21235448",
@@ -1075,18 +1174,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21235448"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21235448" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -1098,7 +1198,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "142" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -1113,21 +1213,28 @@
           "_transferSize": 281
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 30.363, "receive": 12.347 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 99.463,
+          "receive": 12.627
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.313Z",
-        "time": 38.769999999999996,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.574Z",
+        "time": 111.972,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21251477",
@@ -1138,18 +1245,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21251477"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21251477" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -1161,7 +1269,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "139" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -1176,21 +1284,28 @@
           "_transferSize": 278
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 29.064, "receive": 9.706 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 99.25,
+          "receive": 12.722
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.313Z",
-        "time": 43.102,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.574Z",
+        "time": 91.221,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21246941",
@@ -1201,18 +1316,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21246941"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21246941" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -1224,7 +1340,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "136" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -1239,21 +1355,28 @@
           "_transferSize": 275
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 33.739, "receive": 9.363 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 79.366,
+          "receive": 11.855
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.313Z",
-        "time": 42.870999999999995,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.575Z",
+        "time": 95.136,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21256625",
@@ -1264,18 +1387,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21256625"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21256625" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -1287,7 +1411,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "131" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -1302,21 +1426,28 @@
           "_transferSize": 270
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 33.662, "receive": 9.209 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 81.993,
+          "receive": 13.143
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.313Z",
-        "time": 42.956,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.575Z",
+        "time": 91.378,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21235450",
@@ -1327,18 +1458,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21235450"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21235450" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -1350,7 +1482,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "133" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -1365,21 +1497,28 @@
           "_transferSize": 272
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 33.642, "receive": 9.314 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 79.14,
+          "receive": 12.238
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.313Z",
-        "time": 42.811,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.575Z",
+        "time": 112.025,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21247316",
@@ -1390,18 +1529,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21247316"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21247316" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -1413,7 +1553,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "153" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -1428,21 +1568,28 @@
           "_transferSize": 292
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 33.537, "receive": 9.274 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 98.656,
+          "receive": 13.369
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.313Z",
-        "time": 43.255,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.575Z",
+        "time": 82.571,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21246245",
@@ -1453,18 +1600,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21246245"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21246245" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -1476,7 +1624,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "138" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -1491,21 +1639,28 @@
           "_transferSize": 277
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 33.633, "receive": 9.622 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 75.617,
+          "receive": 6.954
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.313Z",
-        "time": 57.263,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.575Z",
+        "time": 112.32300000000001,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21250842",
@@ -1516,18 +1671,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21250842"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21250842" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -1539,7 +1695,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "127" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -1554,21 +1710,28 @@
           "_transferSize": 266
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 42.089, "receive": 15.174 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 98.379,
+          "receive": 13.944
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.313Z",
-        "time": 42.967,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.575Z",
+        "time": 80.017,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21250843",
@@ -1579,18 +1742,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21250843"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21250843" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -1602,7 +1766,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "129" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -1617,21 +1781,28 @@
           "_transferSize": 268
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 33.515, "receive": 9.452 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 72.795,
+          "receive": 7.222
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.313Z",
-        "time": 44.555,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.576Z",
+        "time": 90.86500000000001,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21250844",
@@ -1642,18 +1813,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21250844"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21250844" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -1665,7 +1837,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "135" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -1680,21 +1852,28 @@
           "_transferSize": 274
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 39.458, "receive": 5.097 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 78.158,
+          "receive": 12.707
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.313Z",
-        "time": 42.992,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.576Z",
+        "time": 91.00800000000001,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21251417",
@@ -1705,18 +1884,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21251417"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21251417" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -1728,7 +1908,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "133" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -1743,21 +1923,28 @@
           "_transferSize": 272
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 33.727, "receive": 9.265 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 78.066,
+          "receive": 12.942
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.313Z",
-        "time": 57.757,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.576Z",
+        "time": 111.557,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21251472",
@@ -1768,18 +1955,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21251472"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21251472" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -1791,7 +1979,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "151" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -1806,21 +1994,28 @@
           "_transferSize": 290
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 46.884, "receive": 10.873 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 97.458,
+          "receive": 14.099
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.313Z",
-        "time": 46.762,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.576Z",
+        "time": 95.836,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21251473",
@@ -1831,18 +2026,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21251473"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21251473" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -1854,7 +2050,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "135" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -1869,21 +2065,28 @@
           "_transferSize": 274
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 39.995, "receive": 6.767 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 86.404,
+          "receive": 9.432
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.313Z",
-        "time": 57.661,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.576Z",
+        "time": 95.561,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21251474",
@@ -1894,18 +2097,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21251474"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21251474" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -1917,7 +2121,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "135" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -1932,21 +2136,28 @@
           "_transferSize": 274
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 46.762, "receive": 10.899 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 80.742,
+          "receive": 14.819
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.314Z",
-        "time": 56.691,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.577Z",
+        "time": 95.798,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21252353",
@@ -1957,18 +2168,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21252353"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21252353" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -1980,7 +2192,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "133" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -1995,21 +2207,28 @@
           "_transferSize": 272
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 41.57, "receive": 15.121 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 83.737,
+          "receive": 12.061
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.314Z",
-        "time": 57.065,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.577Z",
+        "time": 95.661,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21252352",
@@ -2020,18 +2239,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21252352"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21252352" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -2043,7 +2263,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "131" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -2058,21 +2278,28 @@
           "_transferSize": 270
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 41.488, "receive": 15.577 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 83.094,
+          "receive": 12.567
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.314Z",
-        "time": 45.653,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.577Z",
+        "time": 112.519,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21252351",
@@ -2083,18 +2310,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21252351"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21252351" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -2106,7 +2334,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "139" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -2121,21 +2349,28 @@
           "_transferSize": 278
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 39.579, "receive": 6.074 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 96.79,
+          "receive": 15.729
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.314Z",
-        "time": 57.987,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.577Z",
+        "time": 95.269,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21252350",
@@ -2146,18 +2381,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21252350"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21252350" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -2169,7 +2405,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "138" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -2184,21 +2420,28 @@
           "_transferSize": 277
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 46.442, "receive": 11.545 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 79.738,
+          "receive": 15.531
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.314Z",
-        "time": 56.675,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.578Z",
+        "time": 95.46,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21235441",
@@ -2209,18 +2452,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21235441"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21235441" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -2232,7 +2476,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "138" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -2247,21 +2491,28 @@
           "_transferSize": 277
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 41.228, "receive": 15.447 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 79.52,
+          "receive": 15.94
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.314Z",
-        "time": 57.827999999999996,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.578Z",
+        "time": 95.48,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21251509",
@@ -2272,18 +2523,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21251509"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21251509" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -2295,7 +2547,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "151" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -2310,21 +2562,28 @@
           "_transferSize": 290
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 46.324, "receive": 11.504 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 79.429,
+          "receive": 16.051
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.314Z",
-        "time": 56.98,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.578Z",
+        "time": 112.43100000000001,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21246943",
@@ -2335,18 +2594,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21246943"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21246943" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -2358,7 +2618,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "138" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -2373,21 +2633,28 @@
           "_transferSize": 277
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 41.19, "receive": 15.79 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 96.004,
+          "receive": 16.427
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.314Z",
-        "time": 57.872,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.578Z",
+        "time": 95.44500000000001,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21252347",
@@ -2398,18 +2665,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21252347"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21252347" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -2421,7 +2689,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "138" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -2436,21 +2704,28 @@
           "_transferSize": 277
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 46.19, "receive": 11.682 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 81.932,
+          "receive": 13.513
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.314Z",
-        "time": 52.291999999999994,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.578Z",
+        "time": 111.766,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21257943",
@@ -2461,18 +2736,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21257943"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21257943" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -2484,7 +2760,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "156" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -2499,21 +2775,28 @@
           "_transferSize": 295
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 40.977, "receive": 11.315 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 95.346,
+          "receive": 16.42
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.314Z",
-        "time": 58.63,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.579Z",
+        "time": 103.715,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21257937",
@@ -2524,18 +2807,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21257937"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21257937" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -2547,7 +2831,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "168" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -2562,21 +2846,28 @@
           "_transferSize": 307
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 46.292, "receive": 12.338 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 83.711,
+          "receive": 20.004
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.314Z",
-        "time": 58.706,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.579Z",
+        "time": 111.604,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21257945",
@@ -2587,18 +2878,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21257945"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21257945" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -2610,7 +2902,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "143" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -2625,21 +2917,28 @@
           "_transferSize": 282
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 46.271, "receive": 12.435 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 94.655,
+          "receive": 16.949
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.314Z",
-        "time": 57.379,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.579Z",
+        "time": 111.37,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21252632",
@@ -2650,18 +2949,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21252632"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21252632" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -2673,7 +2973,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "134" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -2688,21 +2988,28 @@
           "_transferSize": 273
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 41.025, "receive": 16.354 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 94.379,
+          "receive": 16.991
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.314Z",
-        "time": 58.426,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.579Z",
+        "time": 111.155,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21235442",
@@ -2713,18 +3020,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21235442"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21235442" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -2736,7 +3044,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "142" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -2751,21 +3059,28 @@
           "_transferSize": 281
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 46.097, "receive": 12.329 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 94.158,
+          "receive": 16.997
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.314Z",
-        "time": 58.577,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.579Z",
+        "time": 112.042,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21257399",
@@ -2776,18 +3091,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21257399"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21257399" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -2799,7 +3115,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "139" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -2814,21 +3130,28 @@
           "_transferSize": 278
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 46.111, "receive": 12.466 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 94.331,
+          "receive": 17.711
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.314Z",
-        "time": 58.479,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:24.580Z",
+        "time": 111.74000000000001,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_stops/get?id=21257953",
@@ -2839,18 +3162,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "id",
-              "value": "21257953"
-            }
-          ],
-          "headersSize": 391,
+          "queryString": [{ "name": "id", "value": "21257953" }],
+          "headersSize": 392,
           "bodySize": 0
         },
         "response": {
@@ -2862,7 +3186,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "146" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:24 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -2877,21 +3201,28 @@
           "_transferSize": 285
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 46.05, "receive": 12.429 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 94.162,
+          "receive": 17.578
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.594Z",
-        "time": 36.856,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:25.186Z",
+        "time": 126.71000000000001,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_ride_stops/list?arrival_time_from=2024-02-12T11%3A00%3A00.000Z&arrival_time_to=2024-02-12T19%3A00%3A00.000Z&gtfs_stop_ids=21235444&gtfs_ride__gtfs_route_id=4335377&order_by=arrival_time%20asc",
@@ -2902,34 +3233,25 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
           "queryString": [
-            {
-              "name": "arrival_time_from",
-              "value": "2024-02-12T11:00:00.000Z"
-            },
-            {
-              "name": "arrival_time_to",
-              "value": "2024-02-12T19:00:00.000Z"
-            },
-            {
-              "name": "gtfs_stop_ids",
-              "value": "21235444"
-            },
-            {
-              "name": "gtfs_ride__gtfs_route_id",
-              "value": "4335377"
-            },
-            {
-              "name": "order_by",
-              "value": "arrival_time asc"
-            }
+            { "name": "arrival_time_from", "value": "2024-02-12T11:00:00.000Z" },
+            { "name": "arrival_time_to", "value": "2024-02-12T19:00:00.000Z" },
+            { "name": "gtfs_stop_ids", "value": "21235444" },
+            { "name": "gtfs_ride__gtfs_route_id", "value": "4335377" },
+            { "name": "order_by", "value": "arrival_time asc" }
           ],
-          "headersSize": 397,
+          "headersSize": 398,
           "bodySize": 0
         },
         "response": {
@@ -2941,7 +3263,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "25054" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:49 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:27:25 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -2951,29 +3273,36 @@
             "text": "[{\"id\":2391080676,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66915433,\"arrival_time\":\"2024-02-12T11:00:59+00:00\",\"departure_time\":\"2024-02-12T11:00:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"2899869_110224\",\"gtfs_ride__start_time\":\"2024-02-12T11:00:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T11:36:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080265,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66915436,\"arrival_time\":\"2024-02-12T11:20:59+00:00\",\"departure_time\":\"2024-02-12T11:20:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"43644400_110224\",\"gtfs_ride__start_time\":\"2024-02-12T11:20:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T11:56:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080717,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66915434,\"arrival_time\":\"2024-02-12T11:40:59+00:00\",\"departure_time\":\"2024-02-12T11:40:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"2899870_110224\",\"gtfs_ride__start_time\":\"2024-02-12T11:40:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T12:16:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080762,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66908335,\"arrival_time\":\"2024-02-12T12:00:59+00:00\",\"departure_time\":\"2024-02-12T12:00:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"41343281_110224\",\"gtfs_ride__start_time\":\"2024-02-12T12:00:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T12:36:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080814,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66914345,\"arrival_time\":\"2024-02-12T12:20:59+00:00\",\"departure_time\":\"2024-02-12T12:20:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650653_110224\",\"gtfs_ride__start_time\":\"2024-02-12T12:20:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T12:56:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080306,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66915437,\"arrival_time\":\"2024-02-12T12:40:59+00:00\",\"departure_time\":\"2024-02-12T12:40:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"43644402_110224\",\"gtfs_ride__start_time\":\"2024-02-12T12:40:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T13:16:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080511,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66865755,\"arrival_time\":\"2024-02-12T13:00:59+00:00\",\"departure_time\":\"2024-02-12T13:00:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650655_110224\",\"gtfs_ride__start_time\":\"2024-02-12T13:00:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T13:36:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080347,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66913927,\"arrival_time\":\"2024-02-12T13:20:59+00:00\",\"departure_time\":\"2024-02-12T13:20:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"43644403_110224\",\"gtfs_ride__start_time\":\"2024-02-12T13:20:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T13:56:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391081134,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66914343,\"arrival_time\":\"2024-02-12T13:40:59+00:00\",\"departure_time\":\"2024-02-12T13:40:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"34054297_110224\",\"gtfs_ride__start_time\":\"2024-02-12T13:40:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T14:16:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080389,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66914344,\"arrival_time\":\"2024-02-12T14:00:59+00:00\",\"departure_time\":\"2024-02-12T14:00:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"43644404_110224\",\"gtfs_ride__start_time\":\"2024-02-12T14:00:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T14:36:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391081466,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66913186,\"arrival_time\":\"2024-02-12T14:20:59+00:00\",\"departure_time\":\"2024-02-12T14:20:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650659_110224\",\"gtfs_ride__start_time\":\"2024-02-12T14:20:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T14:56:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080430,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66865754,\"arrival_time\":\"2024-02-12T14:40:59+00:00\",\"departure_time\":\"2024-02-12T14:40:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"43644405_110224\",\"gtfs_ride__start_time\":\"2024-02-12T14:40:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T15:16:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391079995,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66913184,\"arrival_time\":\"2024-02-12T15:00:59+00:00\",\"departure_time\":\"2024-02-12T15:00:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"20251297_110224\",\"gtfs_ride__start_time\":\"2024-02-12T15:00:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T15:36:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391081052,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66914114,\"arrival_time\":\"2024-02-12T15:20:59+00:00\",\"departure_time\":\"2024-02-12T15:20:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"34054175_110224\",\"gtfs_ride__start_time\":\"2024-02-12T15:20:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T15:56:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391081547,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66915467,\"arrival_time\":\"2024-02-12T15:40:59+00:00\",\"departure_time\":\"2024-02-12T15:40:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650663_110224\",\"gtfs_ride__start_time\":\"2024-02-12T15:40:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T16:16:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080471,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66915466,\"arrival_time\":\"2024-02-12T16:00:59+00:00\",\"departure_time\":\"2024-02-12T16:00:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"43644407_110224\",\"gtfs_ride__start_time\":\"2024-02-12T16:00:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T16:36:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391081609,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66865756,\"arrival_time\":\"2024-02-12T16:20:59+00:00\",\"departure_time\":\"2024-02-12T16:20:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650665_110224\",\"gtfs_ride__start_time\":\"2024-02-12T16:20:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T16:56:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391081175,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66908338,\"arrival_time\":\"2024-02-12T16:40:59+00:00\",\"departure_time\":\"2024-02-12T16:40:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"34054298_110224\",\"gtfs_ride__start_time\":\"2024-02-12T16:40:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T17:16:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391079683,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66913928,\"arrival_time\":\"2024-02-12T17:00:59+00:00\",\"departure_time\":\"2024-02-12T17:00:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650667_110224\",\"gtfs_ride__start_time\":\"2024-02-12T17:00:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T17:36:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391079863,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66908337,\"arrival_time\":\"2024-02-12T17:20:59+00:00\",\"departure_time\":\"2024-02-12T17:20:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"20251181_110224\",\"gtfs_ride__start_time\":\"2024-02-12T17:20:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T17:56:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391079724,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66914346,\"arrival_time\":\"2024-02-12T17:40:59+00:00\",\"departure_time\":\"2024-02-12T17:40:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650669_110224\",\"gtfs_ride__start_time\":\"2024-02-12T17:40:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T18:16:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391079790,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66969323,\"arrival_time\":\"2024-02-12T18:00:59+00:00\",\"departure_time\":\"2024-02-12T18:00:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"1187838_110224\",\"gtfs_ride__start_time\":\"2024-02-12T18:00:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T18:36:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391080532,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66915627,\"arrival_time\":\"2024-02-12T18:20:59+00:00\",\"departure_time\":\"2024-02-12T18:20:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"56650671_110224\",\"gtfs_ride__start_time\":\"2024-02-12T18:20:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T18:56:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"},{\"id\":2391079751,\"gtfs_stop_id\":21235444,\"gtfs_ride_id\":66913926,\"arrival_time\":\"2024-02-12T18:40:59+00:00\",\"departure_time\":\"2024-02-12T18:40:59+00:00\",\"stop_sequence\":3,\"pickup_type\":0,\"drop_off_type\":0,\"shape_dist_traveled\":391,\"gtfs_ride__gtfs_route_id\":4335377,\"gtfs_ride__journey_ref\":\"30446931_110224\",\"gtfs_ride__start_time\":\"2024-02-12T18:40:00+00:00\",\"gtfs_ride__end_time\":\"2024-02-12T19:16:23+00:00\",\"gtfs_stop__date\":\"2024-02-12\",\"gtfs_stop__code\":38885,\"gtfs_stop__lat\":31.800543,\"gtfs_stop__lon\":34.784065,\"gtfs_stop__name\":\"חיים הרצוג/שדרות מנחם בגין\",\"gtfs_stop__city\":\"גדרה\",\"gtfs_route__date\":\"2024-02-12\",\"gtfs_route__line_ref\":2974,\"gtfs_route__operator_ref\":3,\"gtfs_route__route_short_name\":\"1\",\"gtfs_route__route_long_name\":\"שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#\",\"gtfs_route__route_mkt\":\"33001\",\"gtfs_route__route_direction\":\"3\",\"gtfs_route__route_alternative\":\"#\",\"gtfs_route__agency_name\":\"אגד\",\"gtfs_route__route_type\":\"3\"}]"
           },
           "headersSize": 0,
-          "bodySize": 25258,
+          "bodySize": 25249,
           "redirectURL": "",
-          "_transferSize": 25258
+          "_transferSize": 25249
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 27.195, "receive": 9.661 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 120.438,
+          "receive": 6.272
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:49.594Z",
-        "time": 1540.59,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:27:25.186Z",
+        "time": 36374.469999999994,
         "request": {
           "method": "GET",
-          "url": "https://open-bus-stride-api.hasadna.org.il/siri_vehicle_locations/list?limit=1024&recorded_at_time_from=2024-02-12T11%3A00%3A00.000Z&recorded_at_time_to=2024-02-12T19%3A00%3A00.000Z&lon__greater_or_equal=34.778774173892295&lon__lower_or_equal=34.78935582610771&lat__greater_or_equal=31.796046391970396&lat__lower_or_equal=31.80503960802959&order_by=distance_from_siri_ride_stop_meters%20desc&siri_routes__line_ref=2974",
+          "url": "https://open-bus-stride-api.hasadna.org.il/siri_vehicle_locations/list?limit=1024&recorded_at_time_from=2024-02-12T11%3A00%3A00.000Z&recorded_at_time_to=2024-02-12T19%3A00%3A00.000Z&lon__greater_or_equal=34.77877417389229&lon__lower_or_equal=34.7893558261077&lat__greater_or_equal=31.79604639197041&lat__lower_or_equal=31.805039608029592&order_by=distance_from_siri_ride_stop_meters%20desc&siri_routes__line_ref=2974",
           "httpVersion": "HTTP/2.0",
           "cookies": [],
           "headers": [
@@ -2981,50 +3310,29 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
           "queryString": [
-            {
-              "name": "limit",
-              "value": "1024"
-            },
-            {
-              "name": "recorded_at_time_from",
-              "value": "2024-02-12T11:00:00.000Z"
-            },
-            {
-              "name": "recorded_at_time_to",
-              "value": "2024-02-12T19:00:00.000Z"
-            },
-            {
-              "name": "lon__greater_or_equal",
-              "value": "34.778774173892295"
-            },
-            {
-              "name": "lon__lower_or_equal",
-              "value": "34.78935582610771"
-            },
-            {
-              "name": "lat__greater_or_equal",
-              "value": "31.796046391970396"
-            },
-            {
-              "name": "lat__lower_or_equal",
-              "value": "31.80503960802959"
-            },
-            {
-              "name": "order_by",
-              "value": "distance_from_siri_ride_stop_meters desc"
-            },
-            {
-              "name": "siri_routes__line_ref",
-              "value": "2974"
-            }
+            { "name": "limit", "value": "1024" },
+            { "name": "recorded_at_time_from", "value": "2024-02-12T11:00:00.000Z" },
+            { "name": "recorded_at_time_to", "value": "2024-02-12T19:00:00.000Z" },
+            { "name": "lon__greater_or_equal", "value": "34.77877417389229" },
+            { "name": "lon__lower_or_equal", "value": "34.7893558261077" },
+            { "name": "lat__greater_or_equal", "value": "31.79604639197041" },
+            { "name": "lat__lower_or_equal", "value": "31.805039608029592" },
+            { "name": "order_by", "value": "distance_from_siri_ride_stop_meters desc" },
+            { "name": "siri_routes__line_ref", "value": "2974" }
           ],
-          "headersSize": 404,
+          "headersSize": 405,
           "bodySize": 0
         },
         "response": {
@@ -3036,7 +3344,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "228585" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:51 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:28:01 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -3046,26 +3354,33 @@
             "text": "[{\"id\":3369531983,\"siri_snapshot_id\":1066441,\"siri_ride_stop_id\":1602575185,\"recorded_at_time\":\"2024-02-12T12:15:00+00:00\",\"lon\":34.782562,\"lat\":31.797918,\"bearing\":30,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":null,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/18\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62090708,\"siri_ride__journey_ref\":\"2024-02-12-56650701\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366057999,\"siri_ride__last_vehicle_location_id\":3366284443,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66914345},{\"id\":3369155294,\"siri_snapshot_id\":1066399,\"siri_ride_stop_id\":1603926412,\"recorded_at_time\":\"2024-02-12T14:35:00+00:00\",\"lon\":34.782368,\"lat\":31.798204,\"bearing\":40,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":null,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/35\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62107835,\"siri_ride__journey_ref\":\"2024-02-12-43644429\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366734007,\"siri_ride__last_vehicle_location_id\":3366942424,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865754},{\"id\":3367956771,\"siri_snapshot_id\":1066222,\"siri_ride_stop_id\":1603416453,\"recorded_at_time\":\"2024-02-12T18:35:00+00:00\",\"lon\":34.7826,\"lat\":31.798264,\"bearing\":16,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":null,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/38\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62132363,\"siri_ride__journey_ref\":\"2024-02-12-30446956\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3367951825,\"siri_ride__last_vehicle_location_id\":3368092063,\"siri_ride__duration_minutes\":31,\"siri_ride__gtfs_ride_id\":66913926},{\"id\":3369623915,\"siri_snapshot_id\":1066462,\"siri_ride_stop_id\":1604102125,\"recorded_at_time\":\"2024-02-12T11:31:24+00:00\",\"lon\":34.78299,\"lat\":31.804316,\"bearing\":284,\"velocity\":0,\"distance_from_journey_start\":12481,\"distance_from_siri_ride_stop_meters\":604,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/31\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62081159,\"siri_ride__journey_ref\":\"2024-02-12-2899889\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3365694760,\"siri_ride__last_vehicle_location_id\":3365852824,\"siri_ride__duration_minutes\":41,\"siri_ride__gtfs_ride_id\":66915433},{\"id\":3367461264,\"siri_snapshot_id\":1066137,\"siri_ride_stop_id\":1603189041,\"recorded_at_time\":\"2024-02-12T16:59:25+00:00\",\"lon\":34.779625,\"lat\":31.804989,\"bearing\":284,\"velocity\":40,\"distance_from_journey_start\":11223,\"distance_from_siri_ride_stop_meters\":382,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/59\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62118844,\"siri_ride__journey_ref\":\"2024-02-12-56650713\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367236418,\"siri_ride__last_vehicle_location_id\":3368801057,\"siri_ride__duration_minutes\":46,\"siri_ride__gtfs_ride_id\":66865756},{\"id\":3367966502,\"siri_snapshot_id\":1066224,\"siri_ride_stop_id\":1603416453,\"recorded_at_time\":\"2024-02-12T18:40:06+00:00\",\"lon\":34.78521,\"lat\":31.800394,\"bearing\":102,\"velocity\":36,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":380,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/40\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62132363,\"siri_ride__journey_ref\":\"2024-02-12-30446956\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3367951825,\"siri_ride__last_vehicle_location_id\":3368092063,\"siri_ride__duration_minutes\":31,\"siri_ride__gtfs_ride_id\":66913926},{\"id\":3366261476,\"siri_snapshot_id\":1065978,\"siri_ride_stop_id\":1602656676,\"recorded_at_time\":\"2024-02-12T13:00:46+00:00\",\"lon\":34.783417,\"lat\":31.800688,\"bearing\":17,\"velocity\":25,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":327,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/01\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62095384,\"siri_ride__journey_ref\":\"2024-02-12-56650703\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366231072,\"siri_ride__last_vehicle_location_id\":3366466956,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66865755},{\"id\":3367051184,\"siri_snapshot_id\":1066079,\"siri_ride_stop_id\":1603005925,\"recorded_at_time\":\"2024-02-12T15:42:39+00:00\",\"lon\":34.787182,\"lat\":31.800119,\"bearing\":338,\"velocity\":0,\"distance_from_journey_start\":656,\"distance_from_siri_ride_stop_meters\":299,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/43\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62114011,\"siri_ride__journey_ref\":\"2024-02-12-56650711\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366998711,\"siri_ride__last_vehicle_location_id\":3367236416,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915467},{\"id\":3365728733,\"siri_snapshot_id\":1065903,\"siri_ride_stop_id\":1602419595,\"recorded_at_time\":\"2024-02-12T11:04:27+00:00\",\"lon\":34.784172,\"lat\":31.803711,\"bearing\":6,\"velocity\":14,\"distance_from_journey_start\":1317,\"distance_from_siri_ride_stop_meters\":288,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/04\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62081159,\"siri_ride__journey_ref\":\"2024-02-12-2899889\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3365694760,\"siri_ride__last_vehicle_location_id\":3365852824,\"siri_ride__duration_minutes\":41,\"siri_ride__gtfs_ride_id\":66915433},{\"id\":3366861761,\"siri_snapshot_id\":1066055,\"siri_ride_stop_id\":1602916198,\"recorded_at_time\":\"2024-02-12T15:04:23+00:00\",\"lon\":34.780659,\"lat\":31.804745,\"bearing\":284,\"velocity\":0,\"distance_from_journey_start\":11158,\"distance_from_siri_ride_stop_meters\":280,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/04\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62105505,\"siri_ride__journey_ref\":\"2024-02-12-56650707\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366646680,\"siri_ride__last_vehicle_location_id\":3366886081,\"siri_ride__duration_minutes\":44,\"siri_ride__gtfs_ride_id\":66913186},{\"id\":3368838573,\"siri_snapshot_id\":1066497,\"siri_ride_stop_id\":1603830765,\"recorded_at_time\":\"2024-02-12T16:23:02+00:00\",\"lon\":34.786865,\"lat\":31.80006,\"bearing\":112,\"velocity\":0,\"distance_from_journey_start\":666,\"distance_from_siri_ride_stop_meters\":271,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/23\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62118844,\"siri_ride__journey_ref\":\"2024-02-12-56650713\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367236418,\"siri_ride__last_vehicle_location_id\":3368801057,\"siri_ride__duration_minutes\":46,\"siri_ride__gtfs_ride_id\":66865756},{\"id\":3366918268,\"siri_snapshot_id\":1066062,\"siri_ride_stop_id\":1602946791,\"recorded_at_time\":\"2024-02-12T15:17:20+00:00\",\"lon\":34.780853,\"lat\":31.804712,\"bearing\":284,\"velocity\":32,\"distance_from_journey_start\":11096,\"distance_from_siri_ride_stop_meters\":262,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/17\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62107835,\"siri_ride__journey_ref\":\"2024-02-12-43644429\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366734007,\"siri_ride__last_vehicle_location_id\":3366942424,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865754},{\"id\":3369236406,\"siri_snapshot_id\":1066430,\"siri_ride_stop_id\":1603966429,\"recorded_at_time\":\"2024-02-12T14:02:37+00:00\",\"lon\":34.78088,\"lat\":31.804737,\"bearing\":284,\"velocity\":36,\"distance_from_journey_start\":11093,\"distance_from_siri_ride_stop_meters\":260,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/03\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62098002,\"siri_ride__journey_ref\":\"2024-02-12-43644427\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366322683,\"siri_ride__last_vehicle_location_id\":3366557956,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66913927},{\"id\":3367567256,\"siri_snapshot_id\":1066153,\"siri_ride_stop_id\":1603239252,\"recorded_at_time\":\"2024-02-12T17:22:35+00:00\",\"lon\":34.78672,\"lat\":31.80002,\"bearing\":112,\"velocity\":0,\"distance_from_journey_start\":666,\"distance_from_siri_ride_stop_meters\":258,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/23\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62125092,\"siri_ride__journey_ref\":\"2024-02-12-20251298\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367541360,\"siri_ride__last_vehicle_location_id\":3367742721,\"siri_ride__duration_minutes\":42,\"siri_ride__gtfs_ride_id\":66908337},{\"id\":3367885138,\"siri_snapshot_id\":1066208,\"siri_ride_stop_id\":1603383228,\"recorded_at_time\":\"2024-02-12T18:22:13+00:00\",\"lon\":34.786652,\"lat\":31.800085,\"bearing\":100,\"velocity\":0,\"distance_from_journey_start\":588,\"distance_from_siri_ride_stop_meters\":250,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/22\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62130650,\"siri_ride__journey_ref\":\"2024-02-12-56650719\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367846067,\"siri_ride__last_vehicle_location_id\":3368033593,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66915627},{\"id\":3367622355,\"siri_snapshot_id\":1066162,\"siri_ride_stop_id\":1603268120,\"recorded_at_time\":\"2024-02-12T17:35:42+00:00\",\"lon\":34.780174,\"lat\":31.804808,\"bearing\":102,\"velocity\":36,\"distance_from_journey_start\":10316,\"distance_from_siri_ride_stop_meters\":248,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/36\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62122848,\"siri_ride__journey_ref\":\"2024-02-12-56650715\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3367433965,\"siri_ride__last_vehicle_location_id\":3367651364,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66913928},{\"id\":3367206335,\"siri_snapshot_id\":1066100,\"siri_ride_stop_id\":1603075140,\"recorded_at_time\":\"2024-02-12T16:13:37+00:00\",\"lon\":34.780155,\"lat\":31.80485,\"bearing\":105,\"velocity\":32,\"distance_from_journey_start\":10342,\"distance_from_siri_ride_stop_meters\":246,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/14\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62114011,\"siri_ride__journey_ref\":\"2024-02-12-56650711\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366998711,\"siri_ride__last_vehicle_location_id\":3367236416,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915467},{\"id\":3366276850,\"siri_snapshot_id\":1065980,\"siri_ride_stop_id\":1602672874,\"recorded_at_time\":\"2024-02-12T13:03:25+00:00\",\"lon\":34.787373,\"lat\":31.803389,\"bearing\":27,\"velocity\":32,\"distance_from_journey_start\":1107,\"distance_from_siri_ride_stop_meters\":245,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/03\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62095384,\"siri_ride__journey_ref\":\"2024-02-12-56650703\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366231072,\"siri_ride__last_vehicle_location_id\":3366466956,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66865755},{\"id\":3369560073,\"siri_snapshot_id\":1066356,\"siri_ride_stop_id\":1604078525,\"recorded_at_time\":\"2024-02-12T12:02:03+00:00\",\"lon\":34.786575,\"lat\":31.800091,\"bearing\":104,\"velocity\":40,\"distance_from_journey_start\":391,\"distance_from_siri_ride_stop_meters\":243,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/03\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62088183,\"siri_ride__journey_ref\":\"2024-02-12-43644425\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3365955898,\"siri_ride__last_vehicle_location_id\":3366143786,\"siri_ride__duration_minutes\":40,\"siri_ride__gtfs_ride_id\":66908335},{\"id\":3366385188,\"siri_snapshot_id\":1065994,\"siri_ride_stop_id\":1602720934,\"recorded_at_time\":\"2024-02-12T13:23:33+00:00\",\"lon\":34.78656,\"lat\":31.800135,\"bearing\":102,\"velocity\":29,\"distance_from_journey_start\":616,\"distance_from_siri_ride_stop_meters\":241,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/23\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62098002,\"siri_ride__journey_ref\":\"2024-02-12-43644427\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366322683,\"siri_ride__last_vehicle_location_id\":3366557956,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66913927},{\"id\":3366829156,\"siri_snapshot_id\":1066051,\"siri_ride_stop_id\":1602908103,\"recorded_at_time\":\"2024-02-12T15:00:24+00:00\",\"lon\":34.783112,\"lat\":31.799879,\"bearing\":13,\"velocity\":47,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":233,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/00\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62109786,\"siri_ride__journey_ref\":\"2024-02-12-20251227\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:00:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3366821054,\"siri_ride__last_vehicle_location_id\":3368950129,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66913184},{\"id\":3366338419,\"siri_snapshot_id\":1065988,\"siri_ride_stop_id\":1602699876,\"recorded_at_time\":\"2024-02-12T13:17:26+00:00\",\"lon\":34.779964,\"lat\":31.804888,\"bearing\":105,\"velocity\":29,\"distance_from_journey_start\":10318,\"distance_from_siri_ride_stop_meters\":227,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/17\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62093019,\"siri_ride__journey_ref\":\"2024-02-12-43644426\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366143788,\"siri_ride__last_vehicle_location_id\":3366392873,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66915437},{\"id\":3369486183,\"siri_snapshot_id\":1066375,\"siri_ride_stop_id\":1604050516,\"recorded_at_time\":\"2024-02-12T12:23:58+00:00\",\"lon\":34.786194,\"lat\":31.800146,\"bearing\":103,\"velocity\":40,\"distance_from_journey_start\":551,\"distance_from_siri_ride_stop_meters\":206,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/24\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62090708,\"siri_ride__journey_ref\":\"2024-02-12-56650701\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366057999,\"siri_ride__last_vehicle_location_id\":3366284443,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66914345},{\"id\":3369565057,\"siri_snapshot_id\":1066312,\"siri_ride_stop_id\":1604081195,\"recorded_at_time\":\"2024-02-12T12:01:43+00:00\",\"lon\":34.784325,\"lat\":31.800566,\"bearing\":40,\"velocity\":0,\"distance_from_journey_start\":323,\"distance_from_siri_ride_stop_meters\":196,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/02\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62088183,\"siri_ride__journey_ref\":\"2024-02-12-43644425\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3365955898,\"siri_ride__last_vehicle_location_id\":3366143786,\"siri_ride__duration_minutes\":40,\"siri_ride__gtfs_ride_id\":66908335},{\"id\":3365755944,\"siri_snapshot_id\":1065907,\"siri_ride_stop_id\":1602428707,\"recorded_at_time\":\"2024-02-12T11:08:21+00:00\",\"lon\":34.781849,\"lat\":31.804558,\"bearing\":282,\"velocity\":43,\"distance_from_journey_start\":10988,\"distance_from_siri_ride_stop_meters\":166,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/08\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62079158,\"siri_ride__journey_ref\":\"2024-02-12-43644423\",\"siri_ride__scheduled_start_time\":\"2024-02-12T10:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365593797,\"siri_ride__last_vehicle_location_id\":3365762678,\"siri_ride__duration_minutes\":34,\"siri_ride__gtfs_ride_id\":66913185},{\"id\":3366734007,\"siri_snapshot_id\":1066039,\"siri_ride_stop_id\":1602869672,\"recorded_at_time\":\"2024-02-12T14:42:08+00:00\",\"lon\":34.785767,\"lat\":31.800255,\"bearing\":103,\"velocity\":40,\"distance_from_journey_start\":556,\"distance_from_siri_ride_stop_meters\":164,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/42\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62107835,\"siri_ride__journey_ref\":\"2024-02-12-43644429\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366734007,\"siri_ride__last_vehicle_location_id\":3366942424,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865754},{\"id\":3365948949,\"siri_snapshot_id\":1065935,\"siri_ride_stop_id\":1602523395,\"recorded_at_time\":\"2024-02-12T11:54:15+00:00\",\"lon\":34.781857,\"lat\":31.80452,\"bearing\":282,\"velocity\":40,\"distance_from_journey_start\":11003,\"distance_from_siri_ride_stop_meters\":164,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/55\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62083192,\"siri_ride__journey_ref\":\"2024-02-12-43644424\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3365769509,\"siri_ride__last_vehicle_location_id\":3365970525,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915436},{\"id\":3368972130,\"siri_snapshot_id\":1066484,\"siri_ride_stop_id\":1603878697,\"recorded_at_time\":\"2024-02-12T15:31:24+00:00\",\"lon\":34.781902,\"lat\":31.804552,\"bearing\":285,\"velocity\":36,\"distance_from_journey_start\":10963,\"distance_from_siri_ride_stop_meters\":161,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/31\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62109786,\"siri_ride__journey_ref\":\"2024-02-12-20251227\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:00:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3366821054,\"siri_ride__last_vehicle_location_id\":3368950129,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66913184},{\"id\":3367327013,\"siri_snapshot_id\":1066117,\"siri_ride_stop_id\":1603129287,\"recorded_at_time\":\"2024-02-12T16:39:23+00:00\",\"lon\":34.781967,\"lat\":31.80463,\"bearing\":286,\"velocity\":32,\"distance_from_journey_start\":10968,\"distance_from_siri_ride_stop_meters\":158,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/39\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62116498,\"siri_ride__journey_ref\":\"2024-02-12-43644431\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367109256,\"siri_ride__last_vehicle_location_id\":3367347477,\"siri_ride__duration_minutes\":47,\"siri_ride__gtfs_ride_id\":66915466},{\"id\":3367634095,\"siri_snapshot_id\":1066164,\"siri_ride_stop_id\":1603271070,\"recorded_at_time\":\"2024-02-12T17:37:42+00:00\",\"lon\":34.781944,\"lat\":31.804478,\"bearing\":283,\"velocity\":29,\"distance_from_journey_start\":10978,\"distance_from_siri_ride_stop_meters\":155,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/38\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62122848,\"siri_ride__journey_ref\":\"2024-02-12-56650715\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3367433965,\"siri_ride__last_vehicle_location_id\":3367651364,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66913928},{\"id\":3366253700,\"siri_snapshot_id\":1065977,\"siri_ride_stop_id\":1602663098,\"recorded_at_time\":\"2024-02-12T13:00:20+00:00\",\"lon\":34.782001,\"lat\":31.804539,\"bearing\":284,\"velocity\":29,\"distance_from_journey_start\":10968,\"distance_from_siri_ride_stop_meters\":152,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/00\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62090708,\"siri_ride__journey_ref\":\"2024-02-12-56650701\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366057999,\"siri_ride__last_vehicle_location_id\":3366284443,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66914345},{\"id\":3365708378,\"siri_snapshot_id\":1065900,\"siri_ride_stop_id\":1602413830,\"recorded_at_time\":\"2024-02-12T11:01:25+00:00\",\"lon\":34.785667,\"lat\":31.800407,\"bearing\":102,\"velocity\":36,\"distance_from_journey_start\":500,\"distance_from_siri_ride_stop_meters\":152,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/01\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62081159,\"siri_ride__journey_ref\":\"2024-02-12-2899889\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3365694760,\"siri_ride__last_vehicle_location_id\":3365852824,\"siri_ride__duration_minutes\":41,\"siri_ride__gtfs_ride_id\":66915433},{\"id\":3369545135,\"siri_snapshot_id\":1066327,\"siri_ride_stop_id\":1604072703,\"recorded_at_time\":\"2024-02-12T12:03:59+00:00\",\"lon\":34.786839,\"lat\":31.80249,\"bearing\":358,\"velocity\":0,\"distance_from_journey_start\":945,\"distance_from_siri_ride_stop_meters\":149,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/05\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62088183,\"siri_ride__journey_ref\":\"2024-02-12-43644425\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3365955898,\"siri_ride__last_vehicle_location_id\":3366143786,\"siri_ride__duration_minutes\":40,\"siri_ride__gtfs_ride_id\":66908335},{\"id\":3367154345,\"siri_snapshot_id\":1066093,\"siri_ride_stop_id\":1603054146,\"recorded_at_time\":\"2024-02-12T16:01:41+00:00\",\"lon\":34.785614,\"lat\":31.800285,\"bearing\":103,\"velocity\":29,\"distance_from_journey_start\":501,\"distance_from_siri_ride_stop_meters\":149,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/02\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62116498,\"siri_ride__journey_ref\":\"2024-02-12-43644431\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367109256,\"siri_ride__last_vehicle_location_id\":3367347477,\"siri_ride__duration_minutes\":47,\"siri_ride__gtfs_ride_id\":66915466},{\"id\":3369300381,\"siri_snapshot_id\":1066425,\"siri_ride_stop_id\":1603986656,\"recorded_at_time\":\"2024-02-12T13:43:18+00:00\",\"lon\":34.785603,\"lat\":31.800303,\"bearing\":103,\"velocity\":43,\"distance_from_journey_start\":481,\"distance_from_siri_ride_stop_meters\":148,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/44\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62100388,\"siri_ride__journey_ref\":\"2024-02-12-34054223\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366429684,\"siri_ride__last_vehicle_location_id\":3366662832,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66914343},{\"id\":3369179302,\"siri_snapshot_id\":1066415,\"siri_ride_stop_id\":1603948950,\"recorded_at_time\":\"2024-02-12T14:19:41+00:00\",\"lon\":34.779018,\"lat\":31.805008,\"bearing\":107,\"velocity\":32,\"distance_from_journey_start\":10176,\"distance_from_siri_ride_stop_meters\":137,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/20\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62100388,\"siri_ride__journey_ref\":\"2024-02-12-34054223\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366429684,\"siri_ride__last_vehicle_location_id\":3366662832,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66914343},{\"id\":3369283931,\"siri_snapshot_id\":1066331,\"siri_ride_stop_id\":1603981058,\"recorded_at_time\":\"2024-02-12T13:45:23+00:00\",\"lon\":34.787331,\"lat\":31.803389,\"bearing\":27,\"velocity\":29,\"distance_from_journey_start\":1081,\"distance_from_siri_ride_stop_meters\":131,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/46\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62100388,\"siri_ride__journey_ref\":\"2024-02-12-34054223\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366429684,\"siri_ride__last_vehicle_location_id\":3366662832,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66914343},{\"id\":3365818086,\"siri_snapshot_id\":1065916,\"siri_ride_stop_id\":1602464059,\"recorded_at_time\":\"2024-02-12T11:23:42+00:00\",\"lon\":34.787315,\"lat\":31.803377,\"bearing\":29,\"velocity\":36,\"distance_from_journey_start\":1110,\"distance_from_siri_ride_stop_meters\":130,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/23\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62083192,\"siri_ride__journey_ref\":\"2024-02-12-43644424\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3365769509,\"siri_ride__last_vehicle_location_id\":3365970525,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915436},{\"id\":3366654792,\"siri_snapshot_id\":1066029,\"siri_ride_stop_id\":1602832897,\"recorded_at_time\":\"2024-02-12T14:23:40+00:00\",\"lon\":34.787319,\"lat\":31.803328,\"bearing\":10,\"velocity\":11,\"distance_from_journey_start\":1111,\"distance_from_siri_ride_stop_meters\":125,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/24\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62105505,\"siri_ride__journey_ref\":\"2024-02-12-56650707\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366646680,\"siri_ride__last_vehicle_location_id\":3366886081,\"siri_ride__duration_minutes\":44,\"siri_ride__gtfs_ride_id\":66913186},{\"id\":3366253702,\"siri_snapshot_id\":1065977,\"siri_ride_stop_id\":1602656676,\"recorded_at_time\":\"2024-02-12T13:00:23+00:00\",\"lon\":34.782982,\"lat\":31.798878,\"bearing\":30,\"velocity\":18,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":123,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/00\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62095384,\"siri_ride__journey_ref\":\"2024-02-12-56650703\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366231072,\"siri_ride__last_vehicle_location_id\":3366466956,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66865755},{\"id\":3368033593,\"siri_snapshot_id\":1066238,\"siri_ride_stop_id\":1603457710,\"recorded_at_time\":\"2024-02-12T18:54:17+00:00\",\"lon\":34.779453,\"lat\":31.800035,\"bearing\":114,\"velocity\":40,\"distance_from_journey_start\":12369,\"distance_from_siri_ride_stop_meters\":121,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/54\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62130650,\"siri_ride__journey_ref\":\"2024-02-12-56650719\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367846067,\"siri_ride__last_vehicle_location_id\":3368033593,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66915627},{\"id\":3366726163,\"siri_snapshot_id\":1066038,\"siri_ride_stop_id\":1602864727,\"recorded_at_time\":\"2024-02-12T14:33:01+00:00\",\"lon\":34.782318,\"lat\":31.804388,\"bearing\":285,\"velocity\":40,\"distance_from_journey_start\":10933,\"distance_from_siri_ride_stop_meters\":118,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/33\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62102598,\"siri_ride__journey_ref\":\"2024-02-12-43644428\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366542194,\"siri_ride__last_vehicle_location_id\":3366726163,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66914344},{\"id\":3367554435,\"siri_snapshot_id\":1066151,\"siri_ride_stop_id\":1603229340,\"recorded_at_time\":\"2024-02-12T17:20:42+00:00\",\"lon\":34.782917,\"lat\":31.798822,\"bearing\":24,\"velocity\":14,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":115,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/21\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62125092,\"siri_ride__journey_ref\":\"2024-02-12-20251298\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367541360,\"siri_ride__last_vehicle_location_id\":3367742721,\"siri_ride__duration_minutes\":42,\"siri_ride__gtfs_ride_id\":66908337},{\"id\":3366886081,\"siri_snapshot_id\":1066058,\"siri_ride_stop_id\":1602935818,\"recorded_at_time\":\"2024-02-12T15:07:18+00:00\",\"lon\":34.779366,\"lat\":31.800013,\"bearing\":114,\"velocity\":36,\"distance_from_journey_start\":12379,\"distance_from_siri_ride_stop_meters\":114,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/07\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62105505,\"siri_ride__journey_ref\":\"2024-02-12-56650707\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366646680,\"siri_ride__last_vehicle_location_id\":3366886081,\"siri_ride__duration_minutes\":44,\"siri_ride__gtfs_ride_id\":66913186},{\"id\":3367651366,\"siri_snapshot_id\":1066167,\"siri_ride_stop_id\":1603268122,\"recorded_at_time\":\"2024-02-12T17:40:31+00:00\",\"lon\":34.782967,\"lat\":31.798794,\"bearing\":38,\"velocity\":18,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":113,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/41\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62126949,\"siri_ride__journey_ref\":\"2024-02-12-56650717\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367622357,\"siri_ride__last_vehicle_location_id\":3367863041,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66914346},{\"id\":3367146748,\"siri_snapshot_id\":1066092,\"siri_ride_stop_id\":1603036441,\"recorded_at_time\":\"2024-02-12T16:00:26+00:00\",\"lon\":34.78297,\"lat\":31.798782,\"bearing\":24,\"velocity\":22,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":112,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/01\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62116498,\"siri_ride__journey_ref\":\"2024-02-12-43644431\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367109256,\"siri_ride__last_vehicle_location_id\":3367347477,\"siri_ride__duration_minutes\":47,\"siri_ride__gtfs_ride_id\":66915466},{\"id\":3365852824,\"siri_snapshot_id\":1065921,\"siri_ride_stop_id\":1602481279,\"recorded_at_time\":\"2024-02-12T11:36:21+00:00\",\"lon\":34.78231,\"lat\":31.798952,\"bearing\":111,\"velocity\":29,\"distance_from_journey_start\":12690,\"distance_from_siri_ride_stop_meters\":106,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/37\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62081159,\"siri_ride__journey_ref\":\"2024-02-12-2899889\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3365694760,\"siri_ride__last_vehicle_location_id\":3365852824,\"siri_ride__duration_minutes\":41,\"siri_ride__gtfs_ride_id\":66915433},{\"id\":3369243601,\"siri_snapshot_id\":1066313,\"siri_ride_stop_id\":1603969346,\"recorded_at_time\":\"2024-02-12T14:01:39+00:00\",\"lon\":34.785122,\"lat\":31.800341,\"bearing\":105,\"velocity\":32,\"distance_from_journey_start\":459,\"distance_from_siri_ride_stop_meters\":103,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/02\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62102598,\"siri_ride__journey_ref\":\"2024-02-12-43644428\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366542194,\"siri_ride__last_vehicle_location_id\":3366726163,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66914344},{\"id\":3367777735,\"siri_snapshot_id\":1066189,\"siri_ride_stop_id\":1603337885,\"recorded_at_time\":\"2024-02-12T18:02:54+00:00\",\"lon\":34.787292,\"lat\":31.803871,\"bearing\":356,\"velocity\":32,\"distance_from_journey_start\":1329,\"distance_from_siri_ride_stop_meters\":102,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/03\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62128966,\"siri_ride__journey_ref\":\"2024-02-12-1187857\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319402\",\"siri_ride__first_vehicle_location_id\":3367736806,\"siri_ride__last_vehicle_location_id\":3367932239,\"siri_ride__duration_minutes\":36,\"siri_ride__gtfs_ride_id\":66969323},{\"id\":3366080705,\"siri_snapshot_id\":1065953,\"siri_ride_stop_id\":1602587747,\"recorded_at_time\":\"2024-02-12T12:25:58+00:00\",\"lon\":34.787285,\"lat\":31.803873,\"bearing\":4,\"velocity\":32,\"distance_from_journey_start\":1329,\"distance_from_siri_ride_stop_meters\":102,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/26\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62090708,\"siri_ride__journey_ref\":\"2024-02-12-56650701\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366057999,\"siri_ride__last_vehicle_location_id\":3366284443,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66914345},{\"id\":3368950129,\"siri_snapshot_id\":1066471,\"siri_ride_stop_id\":1603869420,\"recorded_at_time\":\"2024-02-12T15:34:17+00:00\",\"lon\":34.780289,\"lat\":31.799637,\"bearing\":115,\"velocity\":36,\"distance_from_journey_start\":12615,\"distance_from_siri_ride_stop_meters\":101,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/35\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62109786,\"siri_ride__journey_ref\":\"2024-02-12-20251227\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:00:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3366821054,\"siri_ride__last_vehicle_location_id\":3368950129,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66913184},{\"id\":3367461266,\"siri_snapshot_id\":1066137,\"siri_ride_stop_id\":1603180084,\"recorded_at_time\":\"2024-02-12T16:55:20+00:00\",\"lon\":34.782513,\"lat\":31.798746,\"bearing\":212,\"velocity\":22,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":101,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/59\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62122848,\"siri_ride__journey_ref\":\"2024-02-12-56650715\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3367433965,\"siri_ride__last_vehicle_location_id\":3367651364,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66913928},{\"id\":3367454479,\"siri_snapshot_id\":1066136,\"siri_ride_stop_id\":1603180084,\"recorded_at_time\":\"2024-02-12T16:55:20+00:00\",\"lon\":34.782513,\"lat\":31.798746,\"bearing\":212,\"velocity\":22,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":101,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/58\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62122848,\"siri_ride__journey_ref\":\"2024-02-12-56650715\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3367433965,\"siri_ride__last_vehicle_location_id\":3367651364,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66913928},{\"id\":3367447670,\"siri_snapshot_id\":1066135,\"siri_ride_stop_id\":1603180084,\"recorded_at_time\":\"2024-02-12T16:55:20+00:00\",\"lon\":34.782513,\"lat\":31.798746,\"bearing\":212,\"velocity\":22,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":101,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/57\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62122848,\"siri_ride__journey_ref\":\"2024-02-12-56650715\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3367433965,\"siri_ride__last_vehicle_location_id\":3367651364,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66913928},{\"id\":3367440839,\"siri_snapshot_id\":1066134,\"siri_ride_stop_id\":1603180084,\"recorded_at_time\":\"2024-02-12T16:55:20+00:00\",\"lon\":34.782513,\"lat\":31.798746,\"bearing\":212,\"velocity\":22,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":101,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/56\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62122848,\"siri_ride__journey_ref\":\"2024-02-12-56650715\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3367433965,\"siri_ride__last_vehicle_location_id\":3367651364,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66913928},{\"id\":3367433965,\"siri_snapshot_id\":1066133,\"siri_ride_stop_id\":1603180084,\"recorded_at_time\":\"2024-02-12T16:55:20+00:00\",\"lon\":34.782513,\"lat\":31.798746,\"bearing\":212,\"velocity\":22,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":101,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/55\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62122848,\"siri_ride__journey_ref\":\"2024-02-12-56650715\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3367433965,\"siri_ride__last_vehicle_location_id\":3367651364,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66913928},{\"id\":3367347479,\"siri_snapshot_id\":1066120,\"siri_ride_stop_id\":1603142628,\"recorded_at_time\":\"2024-02-12T16:42:25+00:00\",\"lon\":34.787189,\"lat\":31.800274,\"bearing\":0,\"velocity\":14,\"distance_from_journey_start\":845,\"distance_from_siri_ride_stop_meters\":101,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/42\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62121032,\"siri_ride__journey_ref\":\"2024-02-12-34054266\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:40:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367320317,\"siri_ride__last_vehicle_location_id\":3368786847,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66908338},{\"id\":3367932239,\"siri_snapshot_id\":1066217,\"siri_ride_stop_id\":1603406868,\"recorded_at_time\":\"2024-02-12T18:31:11+00:00\",\"lon\":34.780312,\"lat\":31.799644,\"bearing\":114,\"velocity\":36,\"distance_from_journey_start\":12615,\"distance_from_siri_ride_stop_meters\":100,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/31\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62128966,\"siri_ride__journey_ref\":\"2024-02-12-1187857\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319402\",\"siri_ride__first_vehicle_location_id\":3367736806,\"siri_ride__last_vehicle_location_id\":3367932239,\"siri_ride__duration_minutes\":36,\"siri_ride__gtfs_ride_id\":66969323},{\"id\":3367087888,\"siri_snapshot_id\":1066084,\"siri_ride_stop_id\":1603027376,\"recorded_at_time\":\"2024-02-12T15:52:35+00:00\",\"lon\":34.779633,\"lat\":31.804996,\"bearing\":284,\"velocity\":36,\"distance_from_journey_start\":11367,\"distance_from_siri_ride_stop_meters\":100,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/53\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62111816,\"siri_ride__journey_ref\":\"2024-02-12-34054265\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:20:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3366910133,\"siri_ride__last_vehicle_location_id\":3367095004,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66914114},{\"id\":3367065907,\"siri_snapshot_id\":1066081,\"siri_ride_stop_id\":1603015510,\"recorded_at_time\":\"2024-02-12T15:44:26+00:00\",\"lon\":34.787292,\"lat\":31.803907,\"bearing\":350,\"velocity\":32,\"distance_from_journey_start\":1329,\"distance_from_siri_ride_stop_meters\":99,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/45\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62114011,\"siri_ride__journey_ref\":\"2024-02-12-56650711\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366998711,\"siri_ride__last_vehicle_location_id\":3367236416,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915467},{\"id\":3369107746,\"siri_snapshot_id\":1066479,\"siri_ride_stop_id\":1602869672,\"recorded_at_time\":\"2024-02-12T14:41:06+00:00\",\"lon\":34.78318,\"lat\":31.800083,\"bearing\":12,\"velocity\":32,\"distance_from_journey_start\":391,\"distance_from_siri_ride_stop_meters\":98,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/41\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62107835,\"siri_ride__journey_ref\":\"2024-02-12-43644429\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366734007,\"siri_ride__last_vehicle_location_id\":3366942424,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865754},{\"id\":3367917321,\"siri_snapshot_id\":1066214,\"siri_ride_stop_id\":1603398104,\"recorded_at_time\":\"2024-02-12T18:27:10+00:00\",\"lon\":34.782539,\"lat\":31.804302,\"bearing\":104,\"velocity\":40,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":96,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/28\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62128966,\"siri_ride__journey_ref\":\"2024-02-12-1187857\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319402\",\"siri_ride__first_vehicle_location_id\":3367736806,\"siri_ride__last_vehicle_location_id\":3367932239,\"siri_ride__duration_minutes\":36,\"siri_ride__gtfs_ride_id\":66969323},{\"id\":3367912362,\"siri_snapshot_id\":1066213,\"siri_ride_stop_id\":1603398104,\"recorded_at_time\":\"2024-02-12T18:27:10+00:00\",\"lon\":34.782539,\"lat\":31.804302,\"bearing\":104,\"velocity\":40,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":96,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/27\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62128966,\"siri_ride__journey_ref\":\"2024-02-12-1187857\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319402\",\"siri_ride__first_vehicle_location_id\":3367736806,\"siri_ride__last_vehicle_location_id\":3367932239,\"siri_ride__duration_minutes\":36,\"siri_ride__gtfs_ride_id\":66969323},{\"id\":3367783486,\"siri_snapshot_id\":1066190,\"siri_ride_stop_id\":1603340442,\"recorded_at_time\":\"2024-02-12T18:03:22+00:00\",\"lon\":34.786053,\"lat\":31.804749,\"bearing\":288,\"velocity\":25,\"distance_from_journey_start\":1484,\"distance_from_siri_ride_stop_meters\":96,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/04\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62128966,\"siri_ride__journey_ref\":\"2024-02-12-1187857\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319402\",\"siri_ride__first_vehicle_location_id\":3367736806,\"siri_ride__last_vehicle_location_id\":3367932239,\"siri_ride__duration_minutes\":36,\"siri_ride__gtfs_ride_id\":66969323},{\"id\":3367043730,\"siri_snapshot_id\":1066078,\"siri_ride_stop_id\":1603005925,\"recorded_at_time\":\"2024-02-12T15:41:33+00:00\",\"lon\":34.783226,\"lat\":31.80006,\"bearing\":16,\"velocity\":25,\"distance_from_journey_start\":391,\"distance_from_siri_ride_stop_meters\":96,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/42\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62114011,\"siri_ride__journey_ref\":\"2024-02-12-56650711\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366998711,\"siri_ride__last_vehicle_location_id\":3367236416,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915467},{\"id\":3366437212,\"siri_snapshot_id\":1066001,\"siri_ride_stop_id\":1602744366,\"recorded_at_time\":\"2024-02-12T13:36:33+00:00\",\"lon\":34.779591,\"lat\":31.805008,\"bearing\":285,\"velocity\":40,\"distance_from_journey_start\":11367,\"distance_from_siri_ride_stop_meters\":96,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/36\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62095384,\"siri_ride__journey_ref\":\"2024-02-12-56650703\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366231072,\"siri_ride__last_vehicle_location_id\":3366466956,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66865755},{\"id\":3366361761,\"siri_snapshot_id\":1065991,\"siri_ride_stop_id\":1602712030,\"recorded_at_time\":\"2024-02-12T13:20:23+00:00\",\"lon\":34.779594,\"lat\":31.805035,\"bearing\":282,\"velocity\":36,\"distance_from_journey_start\":11367,\"distance_from_siri_ride_stop_meters\":95,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/20\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62093019,\"siri_ride__journey_ref\":\"2024-02-12-43644426\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366143788,\"siri_ride__last_vehicle_location_id\":3366392873,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66915437},{\"id\":3366073050,\"siri_snapshot_id\":1065952,\"siri_ride_stop_id\":1602582862,\"recorded_at_time\":\"2024-02-12T12:25:00+00:00\",\"lon\":34.780361,\"lat\":31.799633,\"bearing\":112,\"velocity\":25,\"distance_from_journey_start\":12615,\"distance_from_siri_ride_stop_meters\":95,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/25\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62085440,\"siri_ride__journey_ref\":\"2024-02-12-2899890\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365845986,\"siri_ride__last_vehicle_location_id\":3366073050,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66915434},{\"id\":3369656328,\"siri_snapshot_id\":1066366,\"siri_ride_stop_id\":1602441678,\"recorded_at_time\":\"2024-02-12T11:15:03+00:00\",\"lon\":34.782131,\"lat\":31.797064,\"bearing\":18,\"velocity\":25,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":94,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/15\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62083192,\"siri_ride__journey_ref\":\"2024-02-12-43644424\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3365769509,\"siri_ride__last_vehicle_location_id\":3365970525,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915436},{\"id\":3365790408,\"siri_snapshot_id\":1065912,\"siri_ride_stop_id\":1602441678,\"recorded_at_time\":\"2024-02-12T11:15:03+00:00\",\"lon\":34.782131,\"lat\":31.797064,\"bearing\":18,\"velocity\":25,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":94,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/19\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62083192,\"siri_ride__journey_ref\":\"2024-02-12-43644424\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3365769509,\"siri_ride__last_vehicle_location_id\":3365970525,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915436},{\"id\":3365783481,\"siri_snapshot_id\":1065911,\"siri_ride_stop_id\":1602441678,\"recorded_at_time\":\"2024-02-12T11:15:03+00:00\",\"lon\":34.782131,\"lat\":31.797064,\"bearing\":18,\"velocity\":25,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":94,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/18\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62083192,\"siri_ride__journey_ref\":\"2024-02-12-43644424\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3365769509,\"siri_ride__last_vehicle_location_id\":3365970525,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915436},{\"id\":3365776525,\"siri_snapshot_id\":1065910,\"siri_ride_stop_id\":1602441678,\"recorded_at_time\":\"2024-02-12T11:15:03+00:00\",\"lon\":34.782131,\"lat\":31.797064,\"bearing\":18,\"velocity\":25,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":94,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/17\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62083192,\"siri_ride__journey_ref\":\"2024-02-12-43644424\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3365769509,\"siri_ride__last_vehicle_location_id\":3365970525,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915436},{\"id\":3365769509,\"siri_snapshot_id\":1065909,\"siri_ride_stop_id\":1602441678,\"recorded_at_time\":\"2024-02-12T11:15:03+00:00\",\"lon\":34.782131,\"lat\":31.797064,\"bearing\":18,\"velocity\":25,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":94,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/16\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62083192,\"siri_ride__journey_ref\":\"2024-02-12-43644424\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3365769509,\"siri_ride__last_vehicle_location_id\":3365970525,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915436},{\"id\":3367971538,\"siri_snapshot_id\":1066225,\"siri_ride_stop_id\":1603427154,\"recorded_at_time\":\"2024-02-12T18:41:18+00:00\",\"lon\":34.786934,\"lat\":31.80151,\"bearing\":339,\"velocity\":29,\"distance_from_journey_start\":1016,\"distance_from_siri_ride_stop_meters\":92,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/41\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62132363,\"siri_ride__journey_ref\":\"2024-02-12-30446956\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3367951825,\"siri_ride__last_vehicle_location_id\":3368092063,\"siri_ride__duration_minutes\":31,\"siri_ride__gtfs_ride_id\":66913926},{\"id\":3369574284,\"siri_snapshot_id\":1066299,\"siri_ride_stop_id\":1602529472,\"recorded_at_time\":\"2024-02-12T12:00:22+00:00\",\"lon\":34.782772,\"lat\":31.798637,\"bearing\":24,\"velocity\":23,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":91,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/01\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62088183,\"siri_ride__journey_ref\":\"2024-02-12-43644425\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3365955898,\"siri_ride__last_vehicle_location_id\":3366143786,\"siri_ride__duration_minutes\":40,\"siri_ride__gtfs_ride_id\":66908335},{\"id\":3367258647,\"siri_snapshot_id\":1066107,\"siri_ride_stop_id\":1603101692,\"recorded_at_time\":\"2024-02-12T16:26:01+00:00\",\"lon\":34.786003,\"lat\":31.804777,\"bearing\":290,\"velocity\":25,\"distance_from_journey_start\":1484,\"distance_from_siri_ride_stop_meters\":91,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/26\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62118844,\"siri_ride__journey_ref\":\"2024-02-12-56650713\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367236418,\"siri_ride__last_vehicle_location_id\":3368801057,\"siri_ride__duration_minutes\":46,\"siri_ride__gtfs_ride_id\":66865756},{\"id\":3366459496,\"siri_snapshot_id\":1066004,\"siri_ride_stop_id\":1602753003,\"recorded_at_time\":\"2024-02-12T13:39:25+00:00\",\"lon\":34.77914,\"lat\":31.800104,\"bearing\":114,\"velocity\":29,\"distance_from_journey_start\":12369,\"distance_from_siri_ride_stop_meters\":90,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/40\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62095384,\"siri_ride__journey_ref\":\"2024-02-12-56650703\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366231072,\"siri_ride__last_vehicle_location_id\":3366466956,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66865755},{\"id\":3368024593,\"siri_snapshot_id\":1066236,\"siri_ride_stop_id\":1603453317,\"recorded_at_time\":\"2024-02-12T18:52:22+00:00\",\"lon\":34.779514,\"lat\":31.805021,\"bearing\":284,\"velocity\":47,\"distance_from_journey_start\":11367,\"distance_from_siri_ride_stop_meters\":88,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/52\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62130650,\"siri_ride__journey_ref\":\"2024-02-12-56650719\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367846067,\"siri_ride__last_vehicle_location_id\":3368033593,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66915627},{\"id\":3365900922,\"siri_snapshot_id\":1065928,\"siri_ride_stop_id\":1602502933,\"recorded_at_time\":\"2024-02-12T11:43:34+00:00\",\"lon\":34.787231,\"lat\":31.800394,\"bearing\":78,\"velocity\":22,\"distance_from_journey_start\":845,\"distance_from_siri_ride_stop_meters\":87,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/44\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62085440,\"siri_ride__journey_ref\":\"2024-02-12-2899890\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365845986,\"siri_ride__last_vehicle_location_id\":3366073050,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66915434},{\"id\":3366942426,\"siri_snapshot_id\":1066065,\"siri_ride_stop_id\":1602946793,\"recorded_at_time\":\"2024-02-12T15:20:09+00:00\",\"lon\":34.782696,\"lat\":31.79858,\"bearing\":16,\"velocity\":23,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":84,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/20\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62111816,\"siri_ride__journey_ref\":\"2024-02-12-34054265\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:20:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3366910133,\"siri_ride__last_vehicle_location_id\":3367095004,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66914114},{\"id\":3369505433,\"siri_snapshot_id\":1066429,\"siri_ride_stop_id\":1604056716,\"recorded_at_time\":\"2024-02-12T12:20:38+00:00\",\"lon\":34.782684,\"lat\":31.804272,\"bearing\":104,\"velocity\":47,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":82,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/21\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62085440,\"siri_ride__journey_ref\":\"2024-02-12-2899890\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365845986,\"siri_ride__last_vehicle_location_id\":3366073050,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66915434},{\"id\":3368987682,\"siri_snapshot_id\":1066509,\"siri_ride_stop_id\":1603884391,\"recorded_at_time\":\"2024-02-12T15:29:19+00:00\",\"lon\":34.78117,\"lat\":31.804609,\"bearing\":104,\"velocity\":36,\"distance_from_journey_start\":10546,\"distance_from_siri_ride_stop_meters\":81,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/29\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62109786,\"siri_ride__journey_ref\":\"2024-02-12-20251227\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:00:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3366821054,\"siri_ride__last_vehicle_location_id\":3368950129,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66913184},{\"id\":3366718394,\"siri_snapshot_id\":1066037,\"siri_ride_stop_id\":1602861189,\"recorded_at_time\":\"2024-02-12T14:31:26+00:00\",\"lon\":34.78117,\"lat\":31.804596,\"bearing\":105,\"velocity\":43,\"distance_from_journey_start\":10546,\"distance_from_siri_ride_stop_meters\":81,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/32\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62102598,\"siri_ride__journey_ref\":\"2024-02-12-43644428\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366542194,\"siri_ride__last_vehicle_location_id\":3366726163,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66914344},{\"id\":3367447668,\"siri_snapshot_id\":1066135,\"siri_ride_stop_id\":1603186123,\"recorded_at_time\":\"2024-02-12T16:57:19+00:00\",\"lon\":34.781208,\"lat\":31.804634,\"bearing\":104,\"velocity\":36,\"distance_from_journey_start\":10546,\"distance_from_siri_ride_stop_meters\":79,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/57\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62118844,\"siri_ride__journey_ref\":\"2024-02-12-56650713\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367236418,\"siri_ride__last_vehicle_location_id\":3368801057,\"siri_ride__duration_minutes\":46,\"siri_ride__gtfs_ride_id\":66865756},{\"id\":3366741978,\"siri_snapshot_id\":1066040,\"siri_ride_stop_id\":1602874927,\"recorded_at_time\":\"2024-02-12T14:43:06+00:00\",\"lon\":34.786774,\"lat\":31.801611,\"bearing\":328,\"velocity\":25,\"distance_from_journey_start\":1016,\"distance_from_siri_ride_stop_meters\":79,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/43\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62107835,\"siri_ride__journey_ref\":\"2024-02-12-43644429\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366734007,\"siri_ride__last_vehicle_location_id\":3366942424,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865754},{\"id\":3366158298,\"siri_snapshot_id\":1065964,\"siri_ride_stop_id\":1602623977,\"recorded_at_time\":\"2024-02-12T12:41:53+00:00\",\"lon\":34.783249,\"lat\":31.800413,\"bearing\":20,\"velocity\":4,\"distance_from_journey_start\":391,\"distance_from_siri_ride_stop_meters\":79,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/42\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62093019,\"siri_ride__journey_ref\":\"2024-02-12-43644426\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366143788,\"siri_ride__last_vehicle_location_id\":3366392873,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66915437},{\"id\":3368815558,\"siri_snapshot_id\":1066514,\"siri_ride_stop_id\":1603823609,\"recorded_at_time\":\"2024-02-12T16:37:09+00:00\",\"lon\":34.781284,\"lat\":31.804705,\"bearing\":104,\"velocity\":36,\"distance_from_journey_start\":10546,\"distance_from_siri_ride_stop_meters\":77,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/37\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62116498,\"siri_ride__journey_ref\":\"2024-02-12-43644431\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367109256,\"siri_ride__last_vehicle_location_id\":3367347477,\"siri_ride__duration_minutes\":47,\"siri_ride__gtfs_ride_id\":66915466},{\"id\":3367243748,\"siri_snapshot_id\":1066105,\"siri_ride_stop_id\":1603093823,\"recorded_at_time\":\"2024-02-12T16:24:09+00:00\",\"lon\":34.786892,\"lat\":31.801638,\"bearing\":337,\"velocity\":18,\"distance_from_journey_start\":1016,\"distance_from_siri_ride_stop_meters\":77,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/24\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62118844,\"siri_ride__journey_ref\":\"2024-02-12-56650713\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367236418,\"siri_ride__last_vehicle_location_id\":3368801057,\"siri_ride__duration_minutes\":46,\"siri_ride__gtfs_ride_id\":66865756},{\"id\":3366179984,\"siri_snapshot_id\":1065967,\"siri_ride_stop_id\":1602633222,\"recorded_at_time\":\"2024-02-12T12:45:03+00:00\",\"lon\":34.78722,\"lat\":31.804127,\"bearing\":357,\"velocity\":32,\"distance_from_journey_start\":1329,\"distance_from_siri_ride_stop_meters\":77,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/45\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62093019,\"siri_ride__journey_ref\":\"2024-02-12-43644426\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366143788,\"siri_ride__last_vehicle_location_id\":3366392873,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66915437},{\"id\":3366646680,\"siri_snapshot_id\":1066028,\"siri_ride_stop_id\":1602832897,\"recorded_at_time\":\"2024-02-12T14:22:58+00:00\",\"lon\":34.786751,\"lat\":31.801653,\"bearing\":328,\"velocity\":22,\"distance_from_journey_start\":1016,\"distance_from_siri_ride_stop_meters\":74,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/23\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62105505,\"siri_ride__journey_ref\":\"2024-02-12-56650707\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366646680,\"siri_ride__last_vehicle_location_id\":3366886081,\"siri_ride__duration_minutes\":44,\"siri_ride__gtfs_ride_id\":66913186},{\"id\":3367514697,\"siri_snapshot_id\":1066145,\"siri_ride_stop_id\":1603216962,\"recorded_at_time\":\"2024-02-12T17:10:21+00:00\",\"lon\":34.781254,\"lat\":31.804581,\"bearing\":104,\"velocity\":40,\"distance_from_journey_start\":10546,\"distance_from_siri_ride_stop_meters\":73,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/10\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62121032,\"siri_ride__journey_ref\":\"2024-02-12-34054266\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:40:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367320317,\"siri_ride__last_vehicle_location_id\":3368786847,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66908338},{\"id\":3367474710,\"siri_snapshot_id\":1066139,\"siri_ride_stop_id\":1603199597,\"recorded_at_time\":\"2024-02-12T17:04:31+00:00\",\"lon\":34.787201,\"lat\":31.804174,\"bearing\":356,\"velocity\":29,\"distance_from_journey_start\":1329,\"distance_from_siri_ride_stop_meters\":72,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/04\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62122848,\"siri_ride__journey_ref\":\"2024-02-12-56650715\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3367433965,\"siri_ride__last_vehicle_location_id\":3367651364,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66913928},{\"id\":3366910131,\"siri_snapshot_id\":1066061,\"siri_ride_stop_id\":1602946791,\"recorded_at_time\":\"2024-02-12T15:16:12+00:00\",\"lon\":34.784203,\"lat\":31.803844,\"bearing\":110,\"velocity\":18,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":72,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/16\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62107835,\"siri_ride__journey_ref\":\"2024-02-12-43644429\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366734007,\"siri_ride__last_vehicle_location_id\":3366942424,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865754},{\"id\":3369171049,\"siri_snapshot_id\":1066419,\"siri_ride_stop_id\":1603945146,\"recorded_at_time\":\"2024-02-12T14:21:38+00:00\",\"lon\":34.784798,\"lat\":31.800421,\"bearing\":102,\"velocity\":40,\"distance_from_journey_start\":426,\"distance_from_siri_ride_stop_meters\":71,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/22\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62105505,\"siri_ride__journey_ref\":\"2024-02-12-56650707\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366646680,\"siri_ride__last_vehicle_location_id\":3366886081,\"siri_ride__duration_minutes\":44,\"siri_ride__gtfs_ride_id\":66913186},{\"id\":3366966588,\"siri_snapshot_id\":1066068,\"siri_ride_stop_id\":1602970856,\"recorded_at_time\":\"2024-02-12T15:23:23+00:00\",\"lon\":34.787216,\"lat\":31.804201,\"bearing\":356,\"velocity\":32,\"distance_from_journey_start\":1329,\"distance_from_siri_ride_stop_meters\":71,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/23\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62111816,\"siri_ride__journey_ref\":\"2024-02-12-34054265\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:20:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3366910133,\"siri_ride__last_vehicle_location_id\":3367095004,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66914114},{\"id\":3367560885,\"siri_snapshot_id\":1066152,\"siri_ride_stop_id\":1603239252,\"recorded_at_time\":\"2024-02-12T17:21:31+00:00\",\"lon\":34.78336,\"lat\":31.800657,\"bearing\":24,\"velocity\":22,\"distance_from_journey_start\":391,\"distance_from_siri_ride_stop_meters\":68,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/22\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62125092,\"siri_ride__journey_ref\":\"2024-02-12-20251298\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367541360,\"siri_ride__last_vehicle_location_id\":3367742721,\"siri_ride__duration_minutes\":42,\"siri_ride__gtfs_ride_id\":66908337},{\"id\":3367213811,\"siri_snapshot_id\":1066101,\"siri_ride_stop_id\":1603081537,\"recorded_at_time\":\"2024-02-12T16:14:54+00:00\",\"lon\":34.784252,\"lat\":31.80411,\"bearing\":132,\"velocity\":0,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":68,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/15\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62114011,\"siri_ride__journey_ref\":\"2024-02-12-56650711\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366998711,\"siri_ride__last_vehicle_location_id\":3367236416,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915467},{\"id\":3366246070,\"siri_snapshot_id\":1065976,\"siri_ride_stop_id\":1602663098,\"recorded_at_time\":\"2024-02-12T12:59:21+00:00\",\"lon\":34.784241,\"lat\":31.804155,\"bearing\":136,\"velocity\":0,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":66,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/59\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62090708,\"siri_ride__journey_ref\":\"2024-02-12-56650701\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366057999,\"siri_ride__last_vehicle_location_id\":3366284443,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66914345},{\"id\":3365907864,\"siri_snapshot_id\":1065929,\"siri_ride_stop_id\":1602505754,\"recorded_at_time\":\"2024-02-12T11:44:22+00:00\",\"lon\":34.787109,\"lat\":31.802813,\"bearing\":40,\"velocity\":29,\"distance_from_journey_start\":1016,\"distance_from_siri_ride_stop_meters\":65,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/45\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62085440,\"siri_ride__journey_ref\":\"2024-02-12-2899890\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365845986,\"siri_ride__last_vehicle_location_id\":3366073050,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66915434},{\"id\":3369228412,\"siri_snapshot_id\":1066354,\"siri_ride_stop_id\":1603963504,\"recorded_at_time\":\"2024-02-12T14:03:32+00:00\",\"lon\":34.787102,\"lat\":31.802799,\"bearing\":40,\"velocity\":7,\"distance_from_journey_start\":1076,\"distance_from_siri_ride_stop_meters\":64,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/04\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62102598,\"siri_ride__journey_ref\":\"2024-02-12-43644428\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366542194,\"siri_ride__last_vehicle_location_id\":3366726163,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66914344},{\"id\":3368852106,\"siri_snapshot_id\":1066488,\"siri_ride_stop_id\":1603834077,\"recorded_at_time\":\"2024-02-12T16:21:41+00:00\",\"lon\":34.783085,\"lat\":31.799793,\"bearing\":12,\"velocity\":0,\"distance_from_journey_start\":186,\"distance_from_siri_ride_stop_meters\":64,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/22\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62118844,\"siri_ride__journey_ref\":\"2024-02-12-56650713\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367236418,\"siri_ride__last_vehicle_location_id\":3368801057,\"siri_ride__duration_minutes\":46,\"siri_ride__gtfs_ride_id\":66865756},{\"id\":3369359506,\"siri_snapshot_id\":1066358,\"siri_ride_stop_id\":1604007106,\"recorded_at_time\":\"2024-02-12T13:25:33+00:00\",\"lon\":34.787189,\"lat\":31.80431,\"bearing\":342,\"velocity\":22,\"distance_from_journey_start\":1329,\"distance_from_siri_ride_stop_meters\":62,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/25\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62098002,\"siri_ride__journey_ref\":\"2024-02-12-43644427\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366322683,\"siri_ride__last_vehicle_location_id\":3366557956,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66913927},{\"id\":3369186561,\"siri_snapshot_id\":1066438,\"siri_ride_stop_id\":1603948952,\"recorded_at_time\":\"2024-02-12T14:20:38+00:00\",\"lon\":34.782654,\"lat\":31.798388,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":62,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/21\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62105505,\"siri_ride__journey_ref\":\"2024-02-12-56650707\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366646680,\"siri_ride__last_vehicle_location_id\":3366886081,\"siri_ride__duration_minutes\":44,\"siri_ride__gtfs_ride_id\":66913186},{\"id\":3365749165,\"siri_snapshot_id\":1065906,\"siri_ride_stop_id\":1602428707,\"recorded_at_time\":\"2024-02-12T11:07:25+00:00\",\"lon\":34.782936,\"lat\":31.804377,\"bearing\":278,\"velocity\":0,\"distance_from_journey_start\":10928,\"distance_from_siri_ride_stop_meters\":62,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/07\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62079158,\"siri_ride__journey_ref\":\"2024-02-12-43644423\",\"siri_ride__scheduled_start_time\":\"2024-02-12T10:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365593797,\"siri_ride__last_vehicle_location_id\":3365762678,\"siri_ride__duration_minutes\":34,\"siri_ride__gtfs_ride_id\":66913185},{\"id\":3367579798,\"siri_snapshot_id\":1066155,\"siri_ride_stop_id\":1603247230,\"recorded_at_time\":\"2024-02-12T17:24:35+00:00\",\"lon\":34.787178,\"lat\":31.804308,\"bearing\":352,\"velocity\":22,\"distance_from_journey_start\":1329,\"distance_from_siri_ride_stop_meters\":61,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/25\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62125092,\"siri_ride__journey_ref\":\"2024-02-12-20251298\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367541360,\"siri_ride__last_vehicle_location_id\":3367742721,\"siri_ride__duration_minutes\":42,\"siri_ride__gtfs_ride_id\":66908337},{\"id\":3367251081,\"siri_snapshot_id\":1066106,\"siri_ride_stop_id\":1603093823,\"recorded_at_time\":\"2024-02-12T16:24:59+00:00\",\"lon\":34.787079,\"lat\":31.802786,\"bearing\":46,\"velocity\":0,\"distance_from_journey_start\":1061,\"distance_from_siri_ride_stop_meters\":61,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/25\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62118844,\"siri_ride__journey_ref\":\"2024-02-12-56650713\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367236418,\"siri_ride__last_vehicle_location_id\":3368801057,\"siri_ride__duration_minutes\":46,\"siri_ride__gtfs_ride_id\":66865756},{\"id\":3367890545,\"siri_snapshot_id\":1066209,\"siri_ride_stop_id\":1603388223,\"recorded_at_time\":\"2024-02-12T18:23:20+00:00\",\"lon\":34.78706,\"lat\":31.802786,\"bearing\":40,\"velocity\":32,\"distance_from_journey_start\":1055,\"distance_from_siri_ride_stop_meters\":60,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/23\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62130650,\"siri_ride__journey_ref\":\"2024-02-12-56650719\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367846067,\"siri_ride__last_vehicle_location_id\":3368033593,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66915627},{\"id\":3366172722,\"siri_snapshot_id\":1065966,\"siri_ride_stop_id\":1602630128,\"recorded_at_time\":\"2024-02-12T12:43:59+00:00\",\"lon\":34.787281,\"lat\":31.800652,\"bearing\":60,\"velocity\":7,\"distance_from_journey_start\":845,\"distance_from_siri_ride_stop_meters\":59,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/44\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62093019,\"siri_ride__journey_ref\":\"2024-02-12-43644426\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366143788,\"siri_ride__last_vehicle_location_id\":3366392873,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66915437},{\"id\":3369236408,\"siri_snapshot_id\":1066430,\"siri_ride_stop_id\":1603966430,\"recorded_at_time\":\"2024-02-12T14:02:19+00:00\",\"lon\":34.787312,\"lat\":31.800674,\"bearing\":24,\"velocity\":25,\"distance_from_journey_start\":845,\"distance_from_siri_ride_stop_meters\":57,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/03\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62102598,\"siri_ride__journey_ref\":\"2024-02-12-43644428\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366542194,\"siri_ride__last_vehicle_location_id\":3366726163,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66914344},{\"id\":3367657242,\"siri_snapshot_id\":1066168,\"siri_ride_stop_id\":1603284113,\"recorded_at_time\":\"2024-02-12T17:41:40+00:00\",\"lon\":34.784653,\"lat\":31.800444,\"bearing\":100,\"velocity\":29,\"distance_from_journey_start\":391,\"distance_from_siri_ride_stop_meters\":57,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/42\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62126949,\"siri_ride__journey_ref\":\"2024-02-12-56650717\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367622357,\"siri_ride__last_vehicle_location_id\":3367863041,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66914346},{\"id\":3367468029,\"siri_snapshot_id\":1066138,\"siri_ride_stop_id\":1603195364,\"recorded_at_time\":\"2024-02-12T17:03:13+00:00\",\"lon\":34.7873,\"lat\":31.800676,\"bearing\":55,\"velocity\":25,\"distance_from_journey_start\":845,\"distance_from_siri_ride_stop_meters\":57,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/03\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62122848,\"siri_ride__journey_ref\":\"2024-02-12-56650715\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3367433965,\"siri_ride__last_vehicle_location_id\":3367651364,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66913928},{\"id\":3369471751,\"siri_snapshot_id\":1066389,\"siri_ride_stop_id\":1604046106,\"recorded_at_time\":\"2024-02-12T12:36:43+00:00\",\"lon\":34.782959,\"lat\":31.804277,\"bearing\":292,\"velocity\":0,\"distance_from_journey_start\":10898,\"distance_from_siri_ride_stop_meters\":56,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/37\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62088183,\"siri_ride__journey_ref\":\"2024-02-12-43644425\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3365955898,\"siri_ride__last_vehicle_location_id\":3366143786,\"siri_ride__duration_minutes\":40,\"siri_ride__gtfs_ride_id\":66908335},{\"id\":3366143786,\"siri_snapshot_id\":1065962,\"siri_ride_stop_id\":1602614920,\"recorded_at_time\":\"2024-02-12T12:35:01+00:00\",\"lon\":34.781414,\"lat\":31.80451,\"bearing\":116,\"velocity\":25,\"distance_from_journey_start\":10546,\"distance_from_siri_ride_stop_meters\":56,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/35\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62088183,\"siri_ride__journey_ref\":\"2024-02-12-43644425\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3365955898,\"siri_ride__last_vehicle_location_id\":3366143786,\"siri_ride__duration_minutes\":40,\"siri_ride__gtfs_ride_id\":66908335},{\"id\":3369304208,\"siri_snapshot_id\":1066400,\"siri_ride_stop_id\":1603986656,\"recorded_at_time\":\"2024-02-12T13:42:17+00:00\",\"lon\":34.783504,\"lat\":31.800655,\"bearing\":18,\"velocity\":4,\"distance_from_journey_start\":391,\"distance_from_siri_ride_stop_meters\":55,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/43\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62100388,\"siri_ride__journey_ref\":\"2024-02-12-34054223\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366429684,\"siri_ride__last_vehicle_location_id\":3366662832,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66914343},{\"id\":3367663055,\"siri_snapshot_id\":1066169,\"siri_ride_stop_id\":1603286852,\"recorded_at_time\":\"2024-02-12T17:42:29+00:00\",\"lon\":34.787384,\"lat\":31.800724,\"bearing\":39,\"velocity\":18,\"distance_from_journey_start\":845,\"distance_from_siri_ride_stop_meters\":54,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/43\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62126949,\"siri_ride__journey_ref\":\"2024-02-12-56650717\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367622357,\"siri_ride__last_vehicle_location_id\":3367863041,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66914346},{\"id\":3367766033,\"siri_snapshot_id\":1066187,\"siri_ride_stop_id\":1603332934,\"recorded_at_time\":\"2024-02-12T18:00:36+00:00\",\"lon\":34.783031,\"lat\":31.799686,\"bearing\":12,\"velocity\":36,\"distance_from_journey_start\":166,\"distance_from_siri_ride_stop_meters\":51,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/01\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62128966,\"siri_ride__journey_ref\":\"2024-02-12-1187857\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319402\",\"siri_ride__first_vehicle_location_id\":3367736806,\"siri_ride__last_vehicle_location_id\":3367932239,\"siri_ride__duration_minutes\":36,\"siri_ride__gtfs_ride_id\":66969323},{\"id\":3366837378,\"siri_snapshot_id\":1066052,\"siri_ride_stop_id\":1602916200,\"recorded_at_time\":\"2024-02-12T15:01:19+00:00\",\"lon\":34.784607,\"lat\":31.800545,\"bearing\":101,\"velocity\":29,\"distance_from_journey_start\":416,\"distance_from_siri_ride_stop_meters\":51,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/01\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62109786,\"siri_ride__journey_ref\":\"2024-02-12-20251227\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:00:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3366821054,\"siri_ride__last_vehicle_location_id\":3368950129,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66913184},{\"id\":3366429682,\"siri_snapshot_id\":1066000,\"siri_ride_stop_id\":1602740516,\"recorded_at_time\":\"2024-02-12T13:35:17+00:00\",\"lon\":34.784077,\"lat\":31.804157,\"bearing\":104,\"velocity\":0,\"distance_from_journey_start\":10918,\"distance_from_siri_ride_stop_meters\":51,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/35\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62095384,\"siri_ride__journey_ref\":\"2024-02-12-56650703\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366231072,\"siri_ride__last_vehicle_location_id\":3366466956,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66865755},{\"id\":3366151028,\"siri_snapshot_id\":1065963,\"siri_ride_stop_id\":1602614922,\"recorded_at_time\":\"2024-02-12T12:40:53+00:00\",\"lon\":34.7826,\"lat\":31.798273,\"bearing\":34,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":49,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/41\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62093019,\"siri_ride__journey_ref\":\"2024-02-12-43644426\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366143788,\"siri_ride__last_vehicle_location_id\":3366392873,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66915437},{\"id\":3377243454,\"siri_snapshot_id\":1066503,\"siri_ride_stop_id\":1603416453,\"recorded_at_time\":\"2024-02-12T18:35:00+00:00\",\"lon\":34.7826,\"lat\":31.798264,\"bearing\":16,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":48,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/37\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62132363,\"siri_ride__journey_ref\":\"2024-02-12-30446956\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3367951825,\"siri_ride__last_vehicle_location_id\":3368092063,\"siri_ride__duration_minutes\":31,\"siri_ride__gtfs_ride_id\":66913926},{\"id\":3377238516,\"siri_snapshot_id\":1066483,\"siri_ride_stop_id\":1603416453,\"recorded_at_time\":\"2024-02-12T18:35:00+00:00\",\"lon\":34.7826,\"lat\":31.798264,\"bearing\":16,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":48,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/36\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62132363,\"siri_ride__journey_ref\":\"2024-02-12-30446956\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3367951825,\"siri_ride__last_vehicle_location_id\":3368092063,\"siri_ride__duration_minutes\":31,\"siri_ride__gtfs_ride_id\":66913926},{\"id\":3369243598,\"siri_snapshot_id\":1066313,\"siri_ride_stop_id\":1603966429,\"recorded_at_time\":\"2024-02-12T14:01:12+00:00\",\"lon\":34.783916,\"lat\":31.803869,\"bearing\":104,\"velocity\":0,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":48,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/02\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62098002,\"siri_ride__journey_ref\":\"2024-02-12-43644427\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366322683,\"siri_ride__last_vehicle_location_id\":3366557956,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66913927},{\"id\":3368905885,\"siri_snapshot_id\":1066490,\"siri_ride_stop_id\":1603854085,\"recorded_at_time\":\"2024-02-12T16:02:22+00:00\",\"lon\":34.787346,\"lat\":31.800766,\"bearing\":20,\"velocity\":22,\"distance_from_journey_start\":845,\"distance_from_siri_ride_stop_meters\":48,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/03\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62116498,\"siri_ride__journey_ref\":\"2024-02-12-43644431\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367109256,\"siri_ride__last_vehicle_location_id\":3367347477,\"siri_ride__duration_minutes\":47,\"siri_ride__gtfs_ride_id\":66915466},{\"id\":3367961611,\"siri_snapshot_id\":1066223,\"siri_ride_stop_id\":1603416453,\"recorded_at_time\":\"2024-02-12T18:35:00+00:00\",\"lon\":34.7826,\"lat\":31.798264,\"bearing\":16,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":48,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/39\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62132363,\"siri_ride__journey_ref\":\"2024-02-12-30446956\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3367951825,\"siri_ride__last_vehicle_location_id\":3368092063,\"siri_ride__duration_minutes\":31,\"siri_ride__gtfs_ride_id\":66913926},{\"id\":3367951825,\"siri_snapshot_id\":1066221,\"siri_ride_stop_id\":1603416453,\"recorded_at_time\":\"2024-02-12T18:35:00+00:00\",\"lon\":34.7826,\"lat\":31.798264,\"bearing\":16,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":48,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/35\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62132363,\"siri_ride__journey_ref\":\"2024-02-12-30446956\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3367951825,\"siri_ride__last_vehicle_location_id\":3368092063,\"siri_ride__duration_minutes\":31,\"siri_ride__gtfs_ride_id\":66913926},{\"id\":3365811238,\"siri_snapshot_id\":1065915,\"siri_ride_stop_id\":1602461041,\"recorded_at_time\":\"2024-02-12T11:22:15+00:00\",\"lon\":34.787361,\"lat\":31.800772,\"bearing\":26,\"velocity\":25,\"distance_from_journey_start\":845,\"distance_from_siri_ride_stop_meters\":48,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/22\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62083192,\"siri_ride__journey_ref\":\"2024-02-12-43644424\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3365769509,\"siri_ride__last_vehicle_location_id\":3365970525,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915436},{\"id\":3365804333,\"siri_snapshot_id\":1065914,\"siri_ride_stop_id\":1602458124,\"recorded_at_time\":\"2024-02-12T11:21:21+00:00\",\"lon\":34.783573,\"lat\":31.800655,\"bearing\":52,\"velocity\":11,\"distance_from_journey_start\":391,\"distance_from_siri_ride_stop_meters\":48,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/21\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62083192,\"siri_ride__journey_ref\":\"2024-02-12-43644424\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3365769509,\"siri_ride__last_vehicle_location_id\":3365970525,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915436},{\"id\":3365722004,\"siri_snapshot_id\":1065902,\"siri_ride_stop_id\":1602419595,\"recorded_at_time\":\"2024-02-12T11:03:16+00:00\",\"lon\":34.786236,\"lat\":31.802355,\"bearing\":322,\"velocity\":0,\"distance_from_journey_start\":1025,\"distance_from_siri_ride_stop_meters\":47,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/03\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62081159,\"siri_ride__journey_ref\":\"2024-02-12-2899889\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3365694760,\"siri_ride__last_vehicle_location_id\":3365852824,\"siri_ride__duration_minutes\":41,\"siri_ride__gtfs_ride_id\":66915433},{\"id\":3367521452,\"siri_snapshot_id\":1066146,\"siri_ride_stop_id\":1603219916,\"recorded_at_time\":\"2024-02-12T17:11:21+00:00\",\"lon\":34.783062,\"lat\":31.80423,\"bearing\":282,\"velocity\":25,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":46,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/11\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62121032,\"siri_ride__journey_ref\":\"2024-02-12-34054266\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:40:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367320317,\"siri_ride__last_vehicle_location_id\":3368786847,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66908338},{\"id\":3366853689,\"siri_snapshot_id\":1066054,\"siri_ride_stop_id\":1602916198,\"recorded_at_time\":\"2024-02-12T15:03:24+00:00\",\"lon\":34.783066,\"lat\":31.804235,\"bearing\":284,\"velocity\":0,\"distance_from_journey_start\":10908,\"distance_from_siri_ride_stop_meters\":46,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/03\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62105505,\"siri_ride__journey_ref\":\"2024-02-12-56650707\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366646680,\"siri_ride__last_vehicle_location_id\":3366886081,\"siri_ride__duration_minutes\":44,\"siri_ride__gtfs_ride_id\":66913186},{\"id\":3366369634,\"siri_snapshot_id\":1065992,\"siri_ride_stop_id\":1602715221,\"recorded_at_time\":\"2024-02-12T13:21:39+00:00\",\"lon\":34.782936,\"lat\":31.798807,\"bearing\":44,\"velocity\":14,\"distance_from_journey_start\":166,\"distance_from_siri_ride_stop_meters\":46,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/21\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62098002,\"siri_ride__journey_ref\":\"2024-02-12-43644427\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366322683,\"siri_ride__last_vehicle_location_id\":3366557956,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66913927},{\"id\":3368980050,\"siri_snapshot_id\":1066505,\"siri_ride_stop_id\":1603878697,\"recorded_at_time\":\"2024-02-12T15:30:05+00:00\",\"lon\":34.783939,\"lat\":31.803949,\"bearing\":100,\"velocity\":0,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":45,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/30\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62109786,\"siri_ride__journey_ref\":\"2024-02-12-20251227\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:00:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3366821054,\"siri_ride__last_vehicle_location_id\":3368950129,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66913184},{\"id\":3365715215,\"siri_snapshot_id\":1065901,\"siri_ride_stop_id\":1602416669,\"recorded_at_time\":\"2024-02-12T11:02:08+00:00\",\"lon\":34.787395,\"lat\":31.800814,\"bearing\":51,\"velocity\":11,\"distance_from_journey_start\":845,\"distance_from_siri_ride_stop_meters\":45,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/02\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62081159,\"siri_ride__journey_ref\":\"2024-02-12-2899889\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3365694760,\"siri_ride__last_vehicle_location_id\":3365852824,\"siri_ride__duration_minutes\":41,\"siri_ride__gtfs_ride_id\":66915433},{\"id\":3369144897,\"siri_snapshot_id\":1066393,\"siri_ride_stop_id\":1603926412,\"recorded_at_time\":\"2024-02-12T14:35:00+00:00\",\"lon\":34.782368,\"lat\":31.798204,\"bearing\":40,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":44,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/36\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62107835,\"siri_ride__journey_ref\":\"2024-02-12-43644429\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366734007,\"siri_ride__last_vehicle_location_id\":3366942424,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865754},{\"id\":3369140178,\"siri_snapshot_id\":1066309,\"siri_ride_stop_id\":1603926412,\"recorded_at_time\":\"2024-02-12T14:35:00+00:00\",\"lon\":34.782368,\"lat\":31.798204,\"bearing\":40,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":44,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/37\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62107835,\"siri_ride__journey_ref\":\"2024-02-12-43644429\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366734007,\"siri_ride__last_vehicle_location_id\":3366942424,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865754},{\"id\":3369128095,\"siri_snapshot_id\":1066288,\"siri_ride_stop_id\":1603926412,\"recorded_at_time\":\"2024-02-12T14:35:00+00:00\",\"lon\":34.782368,\"lat\":31.798204,\"bearing\":40,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":44,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/38\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62107835,\"siri_ride__journey_ref\":\"2024-02-12-43644429\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366734007,\"siri_ride__last_vehicle_location_id\":3366942424,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865754},{\"id\":3369125494,\"siri_snapshot_id\":1066434,\"siri_ride_stop_id\":1603926412,\"recorded_at_time\":\"2024-02-12T14:35:00+00:00\",\"lon\":34.782368,\"lat\":31.798204,\"bearing\":40,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":44,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/39\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62107835,\"siri_ride__journey_ref\":\"2024-02-12-43644429\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366734007,\"siri_ride__last_vehicle_location_id\":3366942424,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865754},{\"id\":3369502348,\"siri_snapshot_id\":1066279,\"siri_ride_stop_id\":1604056716,\"recorded_at_time\":\"2024-02-12T12:21:28+00:00\",\"lon\":34.783092,\"lat\":31.804243,\"bearing\":292,\"velocity\":18,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":43,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/22\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62085440,\"siri_ride__journey_ref\":\"2024-02-12-2899890\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365845986,\"siri_ride__last_vehicle_location_id\":3366073050,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66915434},{\"id\":3366474608,\"siri_snapshot_id\":1066006,\"siri_ride_stop_id\":1602760464,\"recorded_at_time\":\"2024-02-12T13:46:23+00:00\",\"lon\":34.78619,\"lat\":31.804712,\"bearing\":297,\"velocity\":0,\"distance_from_journey_start\":1349,\"distance_from_siri_ride_stop_meters\":43,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/47\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62100388,\"siri_ride__journey_ref\":\"2024-02-12-34054223\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366429684,\"siri_ride__last_vehicle_location_id\":3366662832,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66914343},{\"id\":3366377447,\"siri_snapshot_id\":1065993,\"siri_ride_stop_id\":1602715221,\"recorded_at_time\":\"2024-02-12T13:22:20+00:00\",\"lon\":34.783012,\"lat\":31.799614,\"bearing\":6,\"velocity\":0,\"distance_from_journey_start\":191,\"distance_from_siri_ride_stop_meters\":43,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/22\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62098002,\"siri_ride__journey_ref\":\"2024-02-12-43644427\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366322683,\"siri_ride__last_vehicle_location_id\":3366557956,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66913927},{\"id\":3366353943,\"siri_snapshot_id\":1065990,\"siri_ride_stop_id\":1602709058,\"recorded_at_time\":\"2024-02-12T13:19:26+00:00\",\"lon\":34.783112,\"lat\":31.804291,\"bearing\":297,\"velocity\":22,\"distance_from_journey_start\":10983,\"distance_from_siri_ride_stop_meters\":43,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/19\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62093019,\"siri_ride__journey_ref\":\"2024-02-12-43644426\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366143788,\"siri_ride__last_vehicle_location_id\":3366392873,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66915437},{\"id\":3366269194,\"siri_snapshot_id\":1065979,\"siri_ride_stop_id\":1602672874,\"recorded_at_time\":\"2024-02-12T13:02:04+00:00\",\"lon\":34.787415,\"lat\":31.800844,\"bearing\":81,\"velocity\":4,\"distance_from_journey_start\":845,\"distance_from_siri_ride_stop_meters\":43,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/02\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62095384,\"siri_ride__journey_ref\":\"2024-02-12-56650703\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366231072,\"siri_ride__last_vehicle_location_id\":3366466956,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66865755},{\"id\":3369171047,\"siri_snapshot_id\":1066419,\"siri_ride_stop_id\":1603945144,\"recorded_at_time\":\"2024-02-12T14:21:29+00:00\",\"lon\":34.7831,\"lat\":31.804237,\"bearing\":288,\"velocity\":22,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":42,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/22\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62100388,\"siri_ride__journey_ref\":\"2024-02-12-34054223\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366429684,\"siri_ride__last_vehicle_location_id\":3366662832,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66914343},{\"id\":3367221392,\"siri_snapshot_id\":1066102,\"siri_ride_stop_id\":1603081537,\"recorded_at_time\":\"2024-02-12T16:15:22+00:00\",\"lon\":34.783115,\"lat\":31.804272,\"bearing\":288,\"velocity\":25,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":42,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/16\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62114011,\"siri_ride__journey_ref\":\"2024-02-12-56650711\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366998711,\"siri_ride__last_vehicle_location_id\":3367236416,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915467},{\"id\":3367080693,\"siri_snapshot_id\":1066083,\"siri_ride_stop_id\":1603022829,\"recorded_at_time\":\"2024-02-12T15:51:36+00:00\",\"lon\":34.783115,\"lat\":31.80427,\"bearing\":284,\"velocity\":29,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":42,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/52\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62111816,\"siri_ride__journey_ref\":\"2024-02-12-34054265\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:20:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3366910133,\"siri_ride__last_vehicle_location_id\":3367095004,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66914114},{\"id\":3367028666,\"siri_snapshot_id\":1066076,\"siri_ride_stop_id\":1602985140,\"recorded_at_time\":\"2024-02-12T15:35:02+00:00\",\"lon\":34.782288,\"lat\":31.798141,\"bearing\":356,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":42,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/40\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62114011,\"siri_ride__journey_ref\":\"2024-02-12-56650711\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366998711,\"siri_ride__last_vehicle_location_id\":3367236416,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915467},{\"id\":3367021242,\"siri_snapshot_id\":1066075,\"siri_ride_stop_id\":1602985140,\"recorded_at_time\":\"2024-02-12T15:35:02+00:00\",\"lon\":34.782288,\"lat\":31.798141,\"bearing\":356,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":42,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/39\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62114011,\"siri_ride__journey_ref\":\"2024-02-12-56650711\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366998711,\"siri_ride__last_vehicle_location_id\":3367236416,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915467},{\"id\":3367013778,\"siri_snapshot_id\":1066074,\"siri_ride_stop_id\":1602985140,\"recorded_at_time\":\"2024-02-12T15:35:02+00:00\",\"lon\":34.782288,\"lat\":31.798141,\"bearing\":356,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":42,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/38\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62114011,\"siri_ride__journey_ref\":\"2024-02-12-56650711\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366998711,\"siri_ride__last_vehicle_location_id\":3367236416,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915467},{\"id\":3367006264,\"siri_snapshot_id\":1066073,\"siri_ride_stop_id\":1602985140,\"recorded_at_time\":\"2024-02-12T15:35:02+00:00\",\"lon\":34.782288,\"lat\":31.798141,\"bearing\":356,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":42,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/37\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62114011,\"siri_ride__journey_ref\":\"2024-02-12-56650711\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366998711,\"siri_ride__last_vehicle_location_id\":3367236416,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915467},{\"id\":3366998711,\"siri_snapshot_id\":1066072,\"siri_ride_stop_id\":1602985140,\"recorded_at_time\":\"2024-02-12T15:35:02+00:00\",\"lon\":34.782288,\"lat\":31.798141,\"bearing\":356,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":42,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/36\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62114011,\"siri_ride__journey_ref\":\"2024-02-12-56650711\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366998711,\"siri_ride__last_vehicle_location_id\":3367236416,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915467},{\"id\":3366392875,\"siri_snapshot_id\":1065995,\"siri_ride_stop_id\":1602723975,\"recorded_at_time\":\"2024-02-12T13:24:25+00:00\",\"lon\":34.786903,\"lat\":31.801466,\"bearing\":318,\"velocity\":18,\"distance_from_journey_start\":845,\"distance_from_siri_ride_stop_meters\":42,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/24\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62098002,\"siri_ride__journey_ref\":\"2024-02-12-43644427\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366322683,\"siri_ride__last_vehicle_location_id\":3366557956,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66913927},{\"id\":3365942229,\"siri_snapshot_id\":1065934,\"siri_ride_stop_id\":1602523395,\"recorded_at_time\":\"2024-02-12T11:53:36+00:00\",\"lon\":34.783127,\"lat\":31.804296,\"bearing\":294,\"velocity\":25,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":42,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/54\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62083192,\"siri_ride__journey_ref\":\"2024-02-12-43644424\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3365769509,\"siri_ride__last_vehicle_location_id\":3365970525,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915436},{\"id\":3367333768,\"siri_snapshot_id\":1066118,\"siri_ride_stop_id\":1603129289,\"recorded_at_time\":\"2024-02-12T16:40:08+00:00\",\"lon\":34.782185,\"lat\":31.79805,\"bearing\":4,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":41,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/40\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62121032,\"siri_ride__journey_ref\":\"2024-02-12-34054266\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:40:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367320317,\"siri_ride__last_vehicle_location_id\":3368786847,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66908338},{\"id\":3369689816,\"siri_snapshot_id\":1066285,\"siri_ride_stop_id\":1604127803,\"recorded_at_time\":\"2024-02-12T11:11:16+00:00\",\"lon\":34.781639,\"lat\":31.799244,\"bearing\":112,\"velocity\":0,\"distance_from_journey_start\":12620,\"distance_from_siri_ride_stop_meters\":40,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/11\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62079158,\"siri_ride__journey_ref\":\"2024-02-12-43644423\",\"siri_ride__scheduled_start_time\":\"2024-02-12T10:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365593797,\"siri_ride__last_vehicle_location_id\":3365762678,\"siri_ride__duration_minutes\":34,\"siri_ride__gtfs_ride_id\":66913185},{\"id\":3368797819,\"siri_snapshot_id\":1066504,\"siri_ride_stop_id\":1603816905,\"recorded_at_time\":\"2024-02-12T17:02:23+00:00\",\"lon\":34.784485,\"lat\":31.800522,\"bearing\":104,\"velocity\":29,\"distance_from_journey_start\":466,\"distance_from_siri_ride_stop_meters\":40,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/02\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62122848,\"siri_ride__journey_ref\":\"2024-02-12-56650715\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3367433965,\"siri_ride__last_vehicle_location_id\":3367651364,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66913928},{\"id\":3367846065,\"siri_snapshot_id\":1066201,\"siri_ride_stop_id\":1603365847,\"recorded_at_time\":\"2024-02-12T18:14:29+00:00\",\"lon\":34.783966,\"lat\":31.80415,\"bearing\":92,\"velocity\":0,\"distance_from_journey_start\":10913,\"distance_from_siri_ride_stop_meters\":40,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/15\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62126949,\"siri_ride__journey_ref\":\"2024-02-12-56650717\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367622357,\"siri_ride__last_vehicle_location_id\":3367863041,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66914346},{\"id\":3367645597,\"siri_snapshot_id\":1066166,\"siri_ride_stop_id\":1603268122,\"recorded_at_time\":\"2024-02-12T17:35:00+00:00\",\"lon\":34.782417,\"lat\":31.79818,\"bearing\":2,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":40,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/40\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62126949,\"siri_ride__journey_ref\":\"2024-02-12-56650717\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367622357,\"siri_ride__last_vehicle_location_id\":3367863041,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66914346},{\"id\":3367639880,\"siri_snapshot_id\":1066165,\"siri_ride_stop_id\":1603268122,\"recorded_at_time\":\"2024-02-12T17:35:00+00:00\",\"lon\":34.782417,\"lat\":31.79818,\"bearing\":2,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":40,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/39\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62126949,\"siri_ride__journey_ref\":\"2024-02-12-56650717\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367622357,\"siri_ride__last_vehicle_location_id\":3367863041,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66914346},{\"id\":3367634097,\"siri_snapshot_id\":1066164,\"siri_ride_stop_id\":1603268122,\"recorded_at_time\":\"2024-02-12T17:35:00+00:00\",\"lon\":34.782417,\"lat\":31.79818,\"bearing\":2,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":40,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/38\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62126949,\"siri_ride__journey_ref\":\"2024-02-12-56650717\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367622357,\"siri_ride__last_vehicle_location_id\":3367863041,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66914346},{\"id\":3367628257,\"siri_snapshot_id\":1066163,\"siri_ride_stop_id\":1603268122,\"recorded_at_time\":\"2024-02-12T17:35:00+00:00\",\"lon\":34.782417,\"lat\":31.79818,\"bearing\":2,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":40,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/37\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62126949,\"siri_ride__journey_ref\":\"2024-02-12-56650717\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367622357,\"siri_ride__last_vehicle_location_id\":3367863041,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66914346},{\"id\":3367622357,\"siri_snapshot_id\":1066162,\"siri_ride_stop_id\":1603268122,\"recorded_at_time\":\"2024-02-12T17:35:00+00:00\",\"lon\":34.782417,\"lat\":31.79818,\"bearing\":2,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":40,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/36\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62126949,\"siri_ride__journey_ref\":\"2024-02-12-56650717\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367622357,\"siri_ride__last_vehicle_location_id\":3367863041,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66914346},{\"id\":3365797344,\"siri_snapshot_id\":1065913,\"siri_ride_stop_id\":1602441678,\"recorded_at_time\":\"2024-02-12T11:20:08+00:00\",\"lon\":34.782604,\"lat\":31.798187,\"bearing\":16,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":39,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/20\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62083192,\"siri_ride__journey_ref\":\"2024-02-12-43644424\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3365769509,\"siri_ride__last_vehicle_location_id\":3365970525,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915436},{\"id\":3369478550,\"siri_snapshot_id\":1066289,\"siri_ride_stop_id\":1602614922,\"recorded_at_time\":\"2024-02-12T12:35:01+00:00\",\"lon\":34.782375,\"lat\":31.797523,\"bearing\":34,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":38,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/36\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62093019,\"siri_ride__journey_ref\":\"2024-02-12-43644426\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366143788,\"siri_ride__last_vehicle_location_id\":3366392873,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66915437},{\"id\":3369471753,\"siri_snapshot_id\":1066389,\"siri_ride_stop_id\":1602614922,\"recorded_at_time\":\"2024-02-12T12:35:01+00:00\",\"lon\":34.782375,\"lat\":31.797523,\"bearing\":34,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":38,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/37\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62093019,\"siri_ride__journey_ref\":\"2024-02-12-43644426\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366143788,\"siri_ride__last_vehicle_location_id\":3366392873,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66915437},{\"id\":3369464634,\"siri_snapshot_id\":1066384,\"siri_ride_stop_id\":1602614922,\"recorded_at_time\":\"2024-02-12T12:35:01+00:00\",\"lon\":34.782375,\"lat\":31.797523,\"bearing\":34,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":38,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/38\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62093019,\"siri_ride__journey_ref\":\"2024-02-12-43644426\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366143788,\"siri_ride__last_vehicle_location_id\":3366392873,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66915437},{\"id\":3369455717,\"siri_snapshot_id\":1066342,\"siri_ride_stop_id\":1602614922,\"recorded_at_time\":\"2024-02-12T12:35:01+00:00\",\"lon\":34.782375,\"lat\":31.797523,\"bearing\":34,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":38,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/39\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62093019,\"siri_ride__journey_ref\":\"2024-02-12-43644426\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366143788,\"siri_ride__last_vehicle_location_id\":3366392873,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66915437},{\"id\":3367760210,\"siri_snapshot_id\":1066186,\"siri_ride_stop_id\":1603321337,\"recorded_at_time\":\"2024-02-12T17:55:00+00:00\",\"lon\":34.782665,\"lat\":31.798168,\"bearing\":206,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":38,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/00\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62128966,\"siri_ride__journey_ref\":\"2024-02-12-1187857\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319402\",\"siri_ride__first_vehicle_location_id\":3367736806,\"siri_ride__last_vehicle_location_id\":3367932239,\"siri_ride__duration_minutes\":36,\"siri_ride__gtfs_ride_id\":66969323},{\"id\":3367754425,\"siri_snapshot_id\":1066185,\"siri_ride_stop_id\":1603321337,\"recorded_at_time\":\"2024-02-12T17:55:00+00:00\",\"lon\":34.782665,\"lat\":31.798168,\"bearing\":206,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":38,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/59\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62128966,\"siri_ride__journey_ref\":\"2024-02-12-1187857\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319402\",\"siri_ride__first_vehicle_location_id\":3367736806,\"siri_ride__last_vehicle_location_id\":3367932239,\"siri_ride__duration_minutes\":36,\"siri_ride__gtfs_ride_id\":66969323},{\"id\":3367748598,\"siri_snapshot_id\":1066184,\"siri_ride_stop_id\":1603321337,\"recorded_at_time\":\"2024-02-12T17:55:00+00:00\",\"lon\":34.782665,\"lat\":31.798168,\"bearing\":206,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":38,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/58\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62128966,\"siri_ride__journey_ref\":\"2024-02-12-1187857\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319402\",\"siri_ride__first_vehicle_location_id\":3367736806,\"siri_ride__last_vehicle_location_id\":3367932239,\"siri_ride__duration_minutes\":36,\"siri_ride__gtfs_ride_id\":66969323},{\"id\":3367742723,\"siri_snapshot_id\":1066183,\"siri_ride_stop_id\":1603321337,\"recorded_at_time\":\"2024-02-12T17:55:00+00:00\",\"lon\":34.782665,\"lat\":31.798168,\"bearing\":206,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":38,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/57\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62128966,\"siri_ride__journey_ref\":\"2024-02-12-1187857\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319402\",\"siri_ride__first_vehicle_location_id\":3367736806,\"siri_ride__last_vehicle_location_id\":3367932239,\"siri_ride__duration_minutes\":36,\"siri_ride__gtfs_ride_id\":66969323},{\"id\":3367736806,\"siri_snapshot_id\":1066182,\"siri_ride_stop_id\":1603321337,\"recorded_at_time\":\"2024-02-12T17:55:00+00:00\",\"lon\":34.782665,\"lat\":31.798168,\"bearing\":206,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":38,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/56\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62128966,\"siri_ride__journey_ref\":\"2024-02-12-1187857\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319402\",\"siri_ride__first_vehicle_location_id\":3367736806,\"siri_ride__last_vehicle_location_id\":3367932239,\"siri_ride__duration_minutes\":36,\"siri_ride__gtfs_ride_id\":66969323},{\"id\":3366165518,\"siri_snapshot_id\":1065965,\"siri_ride_stop_id\":1602623977,\"recorded_at_time\":\"2024-02-12T12:42:53+00:00\",\"lon\":34.784451,\"lat\":31.800627,\"bearing\":96,\"velocity\":0,\"distance_from_journey_start\":409,\"distance_from_siri_ride_stop_meters\":38,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/43\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62093019,\"siri_ride__journey_ref\":\"2024-02-12-43644426\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366143788,\"siri_ride__last_vehicle_location_id\":3366392873,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66915437},{\"id\":3366143788,\"siri_snapshot_id\":1065962,\"siri_ride_stop_id\":1602614922,\"recorded_at_time\":\"2024-02-12T12:35:01+00:00\",\"lon\":34.782375,\"lat\":31.797523,\"bearing\":34,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":38,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/35\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62093019,\"siri_ride__journey_ref\":\"2024-02-12-43644426\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366143788,\"siri_ride__last_vehicle_location_id\":3366392873,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66915437},{\"id\":3365873165,\"siri_snapshot_id\":1065924,\"siri_ride_stop_id\":1602476497,\"recorded_at_time\":\"2024-02-12T11:35:01+00:00\",\"lon\":34.782421,\"lat\":31.79752,\"bearing\":36,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":37,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/40\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62085440,\"siri_ride__journey_ref\":\"2024-02-12-2899890\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365845986,\"siri_ride__last_vehicle_location_id\":3366073050,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66915434},{\"id\":3365866415,\"siri_snapshot_id\":1065923,\"siri_ride_stop_id\":1602476497,\"recorded_at_time\":\"2024-02-12T11:35:01+00:00\",\"lon\":34.782421,\"lat\":31.79752,\"bearing\":36,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":37,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/39\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62085440,\"siri_ride__journey_ref\":\"2024-02-12-2899890\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365845986,\"siri_ride__last_vehicle_location_id\":3366073050,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66915434},{\"id\":3365859638,\"siri_snapshot_id\":1065922,\"siri_ride_stop_id\":1602476497,\"recorded_at_time\":\"2024-02-12T11:35:01+00:00\",\"lon\":34.782421,\"lat\":31.79752,\"bearing\":36,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":37,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/38\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62085440,\"siri_ride__journey_ref\":\"2024-02-12-2899890\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365845986,\"siri_ride__last_vehicle_location_id\":3366073050,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66915434},{\"id\":3365852826,\"siri_snapshot_id\":1065921,\"siri_ride_stop_id\":1602476497,\"recorded_at_time\":\"2024-02-12T11:35:01+00:00\",\"lon\":34.782421,\"lat\":31.79752,\"bearing\":36,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":37,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/37\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62085440,\"siri_ride__journey_ref\":\"2024-02-12-2899890\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365845986,\"siri_ride__last_vehicle_location_id\":3366073050,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66915434},{\"id\":3365845986,\"siri_snapshot_id\":1065920,\"siri_ride_stop_id\":1602476497,\"recorded_at_time\":\"2024-02-12T11:35:01+00:00\",\"lon\":34.782421,\"lat\":31.79752,\"bearing\":36,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":37,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/36\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62085440,\"siri_ride__journey_ref\":\"2024-02-12-2899890\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365845986,\"siri_ride__last_vehicle_location_id\":3366073050,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66915434},{\"id\":3367036148,\"siri_snapshot_id\":1066077,\"siri_ride_stop_id\":1602985140,\"recorded_at_time\":\"2024-02-12T15:40:02+00:00\",\"lon\":34.782444,\"lat\":31.798153,\"bearing\":356,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":36,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/41\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62114011,\"siri_ride__journey_ref\":\"2024-02-12-56650711\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366998711,\"siri_ride__last_vehicle_location_id\":3367236416,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915467},{\"id\":3367976520,\"siri_snapshot_id\":1066226,\"siri_ride_stop_id\":1603429545,\"recorded_at_time\":\"2024-02-12T18:42:11+00:00\",\"lon\":34.78627,\"lat\":31.804686,\"bearing\":303,\"velocity\":40,\"distance_from_journey_start\":1329,\"distance_from_siri_ride_stop_meters\":35,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/42\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62132363,\"siri_ride__journey_ref\":\"2024-02-12-30446956\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3367951825,\"siri_ride__last_vehicle_location_id\":3368092063,\"siri_ride__duration_minutes\":31,\"siri_ride__gtfs_ride_id\":66913926},{\"id\":3368845994,\"siri_snapshot_id\":1066506,\"siri_ride_stop_id\":1603834077,\"recorded_at_time\":\"2024-02-12T16:21:06+00:00\",\"lon\":34.78286,\"lat\":31.798941,\"bearing\":8,\"velocity\":18,\"distance_from_journey_start\":166,\"distance_from_siri_ride_stop_meters\":34,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/21\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62118844,\"siri_ride__journey_ref\":\"2024-02-12-56650713\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367236418,\"siri_ride__last_vehicle_location_id\":3368801057,\"siri_ride__duration_minutes\":46,\"siri_ride__gtfs_ride_id\":66865756},{\"id\":3368057927,\"siri_snapshot_id\":1066243,\"siri_ride_stop_id\":1603460030,\"recorded_at_time\":\"2024-02-12T18:55:01+00:00\",\"lon\":34.7822,\"lat\":31.797808,\"bearing\":30,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":33,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/59\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62133916,\"siri_ride__journey_ref\":\"2024-02-12-56650721\",\"siri_ride__scheduled_start_time\":\"2024-02-12T19:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3368038247,\"siri_ride__last_vehicle_location_id\":3368208112,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865753},{\"id\":3368053059,\"siri_snapshot_id\":1066242,\"siri_ride_stop_id\":1603460030,\"recorded_at_time\":\"2024-02-12T18:55:01+00:00\",\"lon\":34.7822,\"lat\":31.797808,\"bearing\":30,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":33,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/58\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62133916,\"siri_ride__journey_ref\":\"2024-02-12-56650721\",\"siri_ride__scheduled_start_time\":\"2024-02-12T19:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3368038247,\"siri_ride__last_vehicle_location_id\":3368208112,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865753},{\"id\":3368048148,\"siri_snapshot_id\":1066241,\"siri_ride_stop_id\":1603460030,\"recorded_at_time\":\"2024-02-12T18:55:01+00:00\",\"lon\":34.7822,\"lat\":31.797808,\"bearing\":30,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":33,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/57\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62133916,\"siri_ride__journey_ref\":\"2024-02-12-56650721\",\"siri_ride__scheduled_start_time\":\"2024-02-12T19:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3368038247,\"siri_ride__last_vehicle_location_id\":3368208112,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865753},{\"id\":3368043231,\"siri_snapshot_id\":1066240,\"siri_ride_stop_id\":1603460030,\"recorded_at_time\":\"2024-02-12T18:55:01+00:00\",\"lon\":34.7822,\"lat\":31.797808,\"bearing\":30,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":33,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/56\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62133916,\"siri_ride__journey_ref\":\"2024-02-12-56650721\",\"siri_ride__scheduled_start_time\":\"2024-02-12T19:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3368038247,\"siri_ride__last_vehicle_location_id\":3368208112,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865753},{\"id\":3368038247,\"siri_snapshot_id\":1066239,\"siri_ride_stop_id\":1603460030,\"recorded_at_time\":\"2024-02-12T18:55:01+00:00\",\"lon\":34.7822,\"lat\":31.797808,\"bearing\":30,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":33,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/55\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62133916,\"siri_ride__journey_ref\":\"2024-02-12-56650721\",\"siri_ride__scheduled_start_time\":\"2024-02-12T19:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3368038247,\"siri_ride__last_vehicle_location_id\":3368208112,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865753},{\"id\":3367354252,\"siri_snapshot_id\":1066121,\"siri_ride_stop_id\":1603145560,\"recorded_at_time\":\"2024-02-12T16:43:28+00:00\",\"lon\":34.786861,\"lat\":31.802595,\"bearing\":4,\"velocity\":0,\"distance_from_journey_start\":1016,\"distance_from_siri_ride_stop_meters\":33,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/43\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62121032,\"siri_ride__journey_ref\":\"2024-02-12-34054266\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:40:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367320317,\"siri_ride__last_vehicle_location_id\":3368786847,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66908338},{\"id\":3369478545,\"siri_snapshot_id\":1066289,\"siri_ride_stop_id\":1602614920,\"recorded_at_time\":\"2024-02-12T12:35:31+00:00\",\"lon\":34.782307,\"lat\":31.804363,\"bearing\":102,\"velocity\":0,\"distance_from_journey_start\":10566,\"distance_from_siri_ride_stop_meters\":32,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/36\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62088183,\"siri_ride__journey_ref\":\"2024-02-12-43644425\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3365955898,\"siri_ride__last_vehicle_location_id\":3366143786,\"siri_ride__duration_minutes\":40,\"siri_ride__gtfs_ride_id\":66908335},{\"id\":3369252489,\"siri_snapshot_id\":1066364,\"siri_ride_stop_id\":1602789096,\"recorded_at_time\":\"2024-02-12T14:00:01+00:00\",\"lon\":34.782623,\"lat\":31.798111,\"bearing\":22,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":31,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/01\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62102598,\"siri_ride__journey_ref\":\"2024-02-12-43644428\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366542194,\"siri_ride__last_vehicle_location_id\":3366726163,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66914344},{\"id\":3368898146,\"siri_snapshot_id\":1066496,\"siri_ride_stop_id\":1603851806,\"recorded_at_time\":\"2024-02-12T16:03:29+00:00\",\"lon\":34.786896,\"lat\":31.802567,\"bearing\":3,\"velocity\":29,\"distance_from_journey_start\":1016,\"distance_from_siri_ride_stop_meters\":31,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/04\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62116498,\"siri_ride__journey_ref\":\"2024-02-12-43644431\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367109256,\"siri_ride__last_vehicle_location_id\":3367347477,\"siri_ride__duration_minutes\":47,\"siri_ride__gtfs_ride_id\":66915466},{\"id\":3369420600,\"siri_snapshot_id\":1066326,\"siri_ride_stop_id\":1602656676,\"recorded_at_time\":\"2024-02-12T12:55:01+00:00\",\"lon\":34.782314,\"lat\":31.798008,\"bearing\":0,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":29,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/55\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62095384,\"siri_ride__journey_ref\":\"2024-02-12-56650703\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366231072,\"siri_ride__last_vehicle_location_id\":3366466956,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66865755},{\"id\":3369413717,\"siri_snapshot_id\":1066315,\"siri_ride_stop_id\":1602656676,\"recorded_at_time\":\"2024-02-12T12:55:01+00:00\",\"lon\":34.782314,\"lat\":31.798008,\"bearing\":0,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":29,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/56\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62095384,\"siri_ride__journey_ref\":\"2024-02-12-56650703\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366231072,\"siri_ride__last_vehicle_location_id\":3366466956,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66865755},{\"id\":3367058563,\"siri_snapshot_id\":1066080,\"siri_ride_stop_id\":1603012362,\"recorded_at_time\":\"2024-02-12T15:43:37+00:00\",\"lon\":34.786499,\"lat\":31.802153,\"bearing\":328,\"velocity\":18,\"distance_from_journey_start\":1016,\"distance_from_siri_ride_stop_meters\":29,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/44\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62114011,\"siri_ride__journey_ref\":\"2024-02-12-56650711\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366998711,\"siri_ride__last_vehicle_location_id\":3367236416,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915467},{\"id\":3366853691,\"siri_snapshot_id\":1066054,\"siri_ride_stop_id\":1602922733,\"recorded_at_time\":\"2024-02-12T15:03:17+00:00\",\"lon\":34.786865,\"lat\":31.802555,\"bearing\":4,\"velocity\":0,\"distance_from_journey_start\":1016,\"distance_from_siri_ride_stop_meters\":29,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/03\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62109786,\"siri_ride__journey_ref\":\"2024-02-12-20251227\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:00:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3366821054,\"siri_ride__last_vehicle_location_id\":3368950129,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66913184},{\"id\":3366466958,\"siri_snapshot_id\":1066005,\"siri_ride_stop_id\":1602740518,\"recorded_at_time\":\"2024-02-12T13:40:16+00:00\",\"lon\":34.782623,\"lat\":31.798088,\"bearing\":16,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":29,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/41\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62100388,\"siri_ride__journey_ref\":\"2024-02-12-34054223\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366429684,\"siri_ride__last_vehicle_location_id\":3366662832,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66914343},{\"id\":3366246072,\"siri_snapshot_id\":1065976,\"siri_ride_stop_id\":1602656676,\"recorded_at_time\":\"2024-02-12T12:55:01+00:00\",\"lon\":34.782314,\"lat\":31.798008,\"bearing\":0,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":29,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/59\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62095384,\"siri_ride__journey_ref\":\"2024-02-12-56650703\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366231072,\"siri_ride__last_vehicle_location_id\":3366466956,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66865755},{\"id\":3366238581,\"siri_snapshot_id\":1065975,\"siri_ride_stop_id\":1602656676,\"recorded_at_time\":\"2024-02-12T12:55:01+00:00\",\"lon\":34.782314,\"lat\":31.798008,\"bearing\":0,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":29,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/58\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62095384,\"siri_ride__journey_ref\":\"2024-02-12-56650703\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366231072,\"siri_ride__last_vehicle_location_id\":3366466956,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66865755},{\"id\":3366231072,\"siri_snapshot_id\":1065974,\"siri_ride_stop_id\":1602656676,\"recorded_at_time\":\"2024-02-12T12:55:01+00:00\",\"lon\":34.782314,\"lat\":31.798008,\"bearing\":0,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":29,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/57\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62095384,\"siri_ride__journey_ref\":\"2024-02-12-56650703\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366231072,\"siri_ride__last_vehicle_location_id\":3366466956,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66865755},{\"id\":3365880005,\"siri_snapshot_id\":1065925,\"siri_ride_stop_id\":1602476497,\"recorded_at_time\":\"2024-02-12T11:40:11+00:00\",\"lon\":34.782452,\"lat\":31.797586,\"bearing\":36,\"velocity\":4,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":29,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/41\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62085440,\"siri_ride__journey_ref\":\"2024-02-12-2899890\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365845986,\"siri_ride__last_vehicle_location_id\":3366073050,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66915434},{\"id\":3368911508,\"siri_snapshot_id\":1066516,\"siri_ride_stop_id\":1603856396,\"recorded_at_time\":\"2024-02-12T15:50:40+00:00\",\"lon\":34.782261,\"lat\":31.80438,\"bearing\":103,\"velocity\":0,\"distance_from_journey_start\":10546,\"distance_from_siri_ride_stop_meters\":28,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/51\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62111816,\"siri_ride__journey_ref\":\"2024-02-12-34054265\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:20:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3366910133,\"siri_ride__last_vehicle_location_id\":3367095004,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66914114},{\"id\":3368811585,\"siri_snapshot_id\":1066510,\"siri_ride_stop_id\":1603180084,\"recorded_at_time\":\"2024-02-12T17:00:06+00:00\",\"lon\":34.782425,\"lat\":31.797606,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":28,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/00\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62122848,\"siri_ride__journey_ref\":\"2024-02-12-56650715\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3367433965,\"siri_ride__last_vehicle_location_id\":3367651364,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66913928},{\"id\":3367725600,\"siri_snapshot_id\":1066180,\"siri_ride_stop_id\":1603315890,\"recorded_at_time\":\"2024-02-12T17:53:48+00:00\",\"lon\":34.783829,\"lat\":31.804193,\"bearing\":126,\"velocity\":0,\"distance_from_journey_start\":10933,\"distance_from_siri_ride_stop_meters\":28,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/54\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62125092,\"siri_ride__journey_ref\":\"2024-02-12-20251298\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367541360,\"siri_ride__last_vehicle_location_id\":3367742721,\"siri_ride__duration_minutes\":42,\"siri_ride__gtfs_ride_id\":66908337},{\"id\":3367139233,\"siri_snapshot_id\":1066091,\"siri_ride_stop_id\":1603036441,\"recorded_at_time\":\"2024-02-12T15:55:00+00:00\",\"lon\":34.782314,\"lat\":31.797688,\"bearing\":194,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":27,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/00\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62116498,\"siri_ride__journey_ref\":\"2024-02-12-43644431\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367109256,\"siri_ride__last_vehicle_location_id\":3367347477,\"siri_ride__duration_minutes\":47,\"siri_ride__gtfs_ride_id\":66915466},{\"id\":3367131795,\"siri_snapshot_id\":1066090,\"siri_ride_stop_id\":1603036441,\"recorded_at_time\":\"2024-02-12T15:55:00+00:00\",\"lon\":34.782314,\"lat\":31.797688,\"bearing\":194,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":27,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/59\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62116498,\"siri_ride__journey_ref\":\"2024-02-12-43644431\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367109256,\"siri_ride__last_vehicle_location_id\":3367347477,\"siri_ride__duration_minutes\":47,\"siri_ride__gtfs_ride_id\":66915466},{\"id\":3367124320,\"siri_snapshot_id\":1066089,\"siri_ride_stop_id\":1603036441,\"recorded_at_time\":\"2024-02-12T15:55:00+00:00\",\"lon\":34.782314,\"lat\":31.797688,\"bearing\":194,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":27,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/58\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62116498,\"siri_ride__journey_ref\":\"2024-02-12-43644431\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367109256,\"siri_ride__last_vehicle_location_id\":3367347477,\"siri_ride__duration_minutes\":47,\"siri_ride__gtfs_ride_id\":66915466},{\"id\":3367116816,\"siri_snapshot_id\":1066088,\"siri_ride_stop_id\":1603036441,\"recorded_at_time\":\"2024-02-12T15:55:00+00:00\",\"lon\":34.782314,\"lat\":31.797688,\"bearing\":194,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":27,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/57\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62116498,\"siri_ride__journey_ref\":\"2024-02-12-43644431\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367109256,\"siri_ride__last_vehicle_location_id\":3367347477,\"siri_ride__duration_minutes\":47,\"siri_ride__gtfs_ride_id\":66915466},{\"id\":3367109256,\"siri_snapshot_id\":1066087,\"siri_ride_stop_id\":1603036441,\"recorded_at_time\":\"2024-02-12T15:55:00+00:00\",\"lon\":34.782314,\"lat\":31.797688,\"bearing\":194,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":27,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/56\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62116498,\"siri_ride__journey_ref\":\"2024-02-12-43644431\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367109256,\"siri_ride__last_vehicle_location_id\":3367347477,\"siri_ride__duration_minutes\":47,\"siri_ride__gtfs_ride_id\":66915466},{\"id\":3366361763,\"siri_snapshot_id\":1065991,\"siri_ride_stop_id\":1602696398,\"recorded_at_time\":\"2024-02-12T13:20:07+00:00\",\"lon\":34.782444,\"lat\":31.798052,\"bearing\":24,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":26,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/20\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62098002,\"siri_ride__journey_ref\":\"2024-02-12-43644427\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366322683,\"siri_ride__last_vehicle_location_id\":3366557956,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66913927},{\"id\":3369552309,\"siri_snapshot_id\":1066382,\"siri_ride_stop_id\":1604072703,\"recorded_at_time\":\"2024-02-12T12:02:50+00:00\",\"lon\":34.787388,\"lat\":31.801022,\"bearing\":18,\"velocity\":0,\"distance_from_journey_start\":845,\"distance_from_siri_ride_stop_meters\":25,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/04\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62088183,\"siri_ride__journey_ref\":\"2024-02-12-43644425\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3365955898,\"siri_ride__last_vehicle_location_id\":3366143786,\"siri_ride__duration_minutes\":40,\"siri_ride__gtfs_ride_id\":66908335},{\"id\":3366459498,\"siri_snapshot_id\":1066004,\"siri_ride_stop_id\":1602740518,\"recorded_at_time\":\"2024-02-12T13:35:00+00:00\",\"lon\":34.782429,\"lat\":31.79804,\"bearing\":16,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":25,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/40\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62100388,\"siri_ride__journey_ref\":\"2024-02-12-34054223\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366429684,\"siri_ride__last_vehicle_location_id\":3366662832,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66914343},{\"id\":3366452113,\"siri_snapshot_id\":1066003,\"siri_ride_stop_id\":1602740518,\"recorded_at_time\":\"2024-02-12T13:35:00+00:00\",\"lon\":34.782429,\"lat\":31.79804,\"bearing\":16,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":25,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/39\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62100388,\"siri_ride__journey_ref\":\"2024-02-12-34054223\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366429684,\"siri_ride__last_vehicle_location_id\":3366662832,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66914343},{\"id\":3366444687,\"siri_snapshot_id\":1066002,\"siri_ride_stop_id\":1602740518,\"recorded_at_time\":\"2024-02-12T13:35:00+00:00\",\"lon\":34.782429,\"lat\":31.79804,\"bearing\":16,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":25,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/38\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62100388,\"siri_ride__journey_ref\":\"2024-02-12-34054223\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366429684,\"siri_ride__last_vehicle_location_id\":3366662832,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66914343},{\"id\":3366437214,\"siri_snapshot_id\":1066001,\"siri_ride_stop_id\":1602740518,\"recorded_at_time\":\"2024-02-12T13:35:00+00:00\",\"lon\":34.782429,\"lat\":31.79804,\"bearing\":16,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":25,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/36\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62100388,\"siri_ride__journey_ref\":\"2024-02-12-34054223\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366429684,\"siri_ride__last_vehicle_location_id\":3366662832,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66914343},{\"id\":3366429684,\"siri_snapshot_id\":1066000,\"siri_ride_stop_id\":1602740518,\"recorded_at_time\":\"2024-02-12T13:35:00+00:00\",\"lon\":34.782429,\"lat\":31.79804,\"bearing\":16,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":25,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/35\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62100388,\"siri_ride__journey_ref\":\"2024-02-12-34054223\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366429684,\"siri_ride__last_vehicle_location_id\":3366662832,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66914343},{\"id\":3369186553,\"siri_snapshot_id\":1066438,\"siri_ride_stop_id\":1603945144,\"recorded_at_time\":\"2024-02-12T14:20:27+00:00\",\"lon\":34.783298,\"lat\":31.80411,\"bearing\":104,\"velocity\":43,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":24,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/21\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62100388,\"siri_ride__journey_ref\":\"2024-02-12-34054223\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366429684,\"siri_ride__last_vehicle_location_id\":3366662832,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66914343},{\"id\":3367840455,\"siri_snapshot_id\":1066200,\"siri_ride_stop_id\":1603365847,\"recorded_at_time\":\"2024-02-12T18:13:51+00:00\",\"lon\":34.783291,\"lat\":31.804169,\"bearing\":104,\"velocity\":40,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":24,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/14\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62126949,\"siri_ride__journey_ref\":\"2024-02-12-56650717\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367622357,\"siri_ride__last_vehicle_location_id\":3367863041,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66914346},{\"id\":3367668824,\"siri_snapshot_id\":1066170,\"siri_ride_stop_id\":1603289579,\"recorded_at_time\":\"2024-02-12T17:43:14+00:00\",\"lon\":34.786518,\"lat\":31.802214,\"bearing\":20,\"velocity\":11,\"distance_from_journey_start\":1016,\"distance_from_siri_ride_stop_meters\":24,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/44\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62126949,\"siri_ride__journey_ref\":\"2024-02-12-56650717\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367622357,\"siri_ride__last_vehicle_location_id\":3367863041,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66914346},{\"id\":3368801060,\"siri_snapshot_id\":1066472,\"siri_ride_stop_id\":1603819318,\"recorded_at_time\":\"2024-02-12T17:01:24+00:00\",\"lon\":34.782967,\"lat\":31.799427,\"bearing\":8,\"velocity\":0,\"distance_from_journey_start\":170,\"distance_from_siri_ride_stop_meters\":23,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/01\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62122848,\"siri_ride__journey_ref\":\"2024-02-12-56650715\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3367433965,\"siri_ride__last_vehicle_location_id\":3367651364,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66913928},{\"id\":3367879654,\"siri_snapshot_id\":1066207,\"siri_ride_stop_id\":1603383228,\"recorded_at_time\":\"2024-02-12T18:21:23+00:00\",\"lon\":34.783848,\"lat\":31.800644,\"bearing\":84,\"velocity\":22,\"distance_from_journey_start\":391,\"distance_from_siri_ride_stop_meters\":23,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/21\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62130650,\"siri_ride__journey_ref\":\"2024-02-12-56650719\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367846067,\"siri_ride__last_vehicle_location_id\":3368033593,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66915627},{\"id\":3367868597,\"siri_snapshot_id\":1066205,\"siri_ride_stop_id\":1603368341,\"recorded_at_time\":\"2024-02-12T18:15:00+00:00\",\"lon\":34.782383,\"lat\":31.79768,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":23,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/19\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62130650,\"siri_ride__journey_ref\":\"2024-02-12-56650719\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367846067,\"siri_ride__last_vehicle_location_id\":3368033593,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66915627},{\"id\":3367863043,\"siri_snapshot_id\":1066204,\"siri_ride_stop_id\":1603368341,\"recorded_at_time\":\"2024-02-12T18:15:00+00:00\",\"lon\":34.782383,\"lat\":31.79768,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":23,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/18\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62130650,\"siri_ride__journey_ref\":\"2024-02-12-56650719\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367846067,\"siri_ride__last_vehicle_location_id\":3368033593,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66915627},{\"id\":3367857445,\"siri_snapshot_id\":1066203,\"siri_ride_stop_id\":1603368341,\"recorded_at_time\":\"2024-02-12T18:15:00+00:00\",\"lon\":34.782383,\"lat\":31.79768,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":23,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/17\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62130650,\"siri_ride__journey_ref\":\"2024-02-12-56650719\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367846067,\"siri_ride__last_vehicle_location_id\":3368033593,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66915627},{\"id\":3367851785,\"siri_snapshot_id\":1066202,\"siri_ride_stop_id\":1603368341,\"recorded_at_time\":\"2024-02-12T18:15:00+00:00\",\"lon\":34.782383,\"lat\":31.79768,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":23,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/16\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62130650,\"siri_ride__journey_ref\":\"2024-02-12-56650719\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367846067,\"siri_ride__last_vehicle_location_id\":3368033593,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66915627},{\"id\":3367846067,\"siri_snapshot_id\":1066201,\"siri_ride_stop_id\":1603368341,\"recorded_at_time\":\"2024-02-12T18:15:00+00:00\",\"lon\":34.782383,\"lat\":31.79768,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":23,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/15\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62130650,\"siri_ride__journey_ref\":\"2024-02-12-56650719\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367846067,\"siri_ride__last_vehicle_location_id\":3368033593,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66915627},{\"id\":3369314454,\"siri_snapshot_id\":1066311,\"siri_ride_stop_id\":1602740518,\"recorded_at_time\":\"2024-02-12T13:40:51+00:00\",\"lon\":34.782635,\"lat\":31.798016,\"bearing\":16,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":22,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/42\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62100388,\"siri_ride__journey_ref\":\"2024-02-12-34054223\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366429684,\"siri_ride__last_vehicle_location_id\":3366662832,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66914343},{\"id\":3367874130,\"siri_snapshot_id\":1066206,\"siri_ride_stop_id\":1603368341,\"recorded_at_time\":\"2024-02-12T18:20:04+00:00\",\"lon\":34.782341,\"lat\":31.797745,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":22,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/20\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62130650,\"siri_ride__journey_ref\":\"2024-02-12-56650719\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367846067,\"siri_ride__last_vehicle_location_id\":3368033593,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66915627},{\"id\":3367720122,\"siri_snapshot_id\":1066179,\"siri_ride_stop_id\":1603313485,\"recorded_at_time\":\"2024-02-12T17:52:52+00:00\",\"lon\":34.782143,\"lat\":31.804466,\"bearing\":104,\"velocity\":32,\"distance_from_journey_start\":10546,\"distance_from_siri_ride_stop_meters\":22,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/53\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62125092,\"siri_ride__journey_ref\":\"2024-02-12-20251298\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367541360,\"siri_ride__last_vehicle_location_id\":3367742721,\"siri_ride__duration_minutes\":42,\"siri_ride__gtfs_ride_id\":66908337},{\"id\":3369113646,\"siri_snapshot_id\":1066469,\"siri_ride_stop_id\":1603926412,\"recorded_at_time\":\"2024-02-12T14:40:00+00:00\",\"lon\":34.782421,\"lat\":31.797998,\"bearing\":40,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":21,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/40\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62107835,\"siri_ride__journey_ref\":\"2024-02-12-43644429\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366734007,\"siri_ride__last_vehicle_location_id\":3366942424,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865754},{\"id\":3369449187,\"siri_snapshot_id\":1066330,\"siri_ride_stop_id\":1602614922,\"recorded_at_time\":\"2024-02-12T12:40:03+00:00\",\"lon\":34.782417,\"lat\":31.797693,\"bearing\":34,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":20,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/40\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62093019,\"siri_ride__journey_ref\":\"2024-02-12-43644426\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366143788,\"siri_ride__last_vehicle_location_id\":3366392873,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66915437},{\"id\":3368015290,\"siri_snapshot_id\":1066234,\"siri_ride_stop_id\":1603448660,\"recorded_at_time\":\"2024-02-12T18:50:20+00:00\",\"lon\":34.782166,\"lat\":31.804384,\"bearing\":104,\"velocity\":0,\"distance_from_journey_start\":10546,\"distance_from_siri_ride_stop_meters\":20,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/50\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62130650,\"siri_ride__journey_ref\":\"2024-02-12-56650719\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367846067,\"siri_ride__last_vehicle_location_id\":3368033593,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66915627},{\"id\":3367340659,\"siri_snapshot_id\":1066119,\"siri_ride_stop_id\":1603139685,\"recorded_at_time\":\"2024-02-12T16:41:24+00:00\",\"lon\":34.78413,\"lat\":31.800713,\"bearing\":104,\"velocity\":0,\"distance_from_journey_start\":391,\"distance_from_siri_ride_stop_meters\":20,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/41\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62121032,\"siri_ride__journey_ref\":\"2024-02-12-34054266\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:40:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367320317,\"siri_ride__last_vehicle_location_id\":3368786847,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66908338},{\"id\":3368868124,\"siri_snapshot_id\":1066502,\"siri_ride_stop_id\":1603081539,\"recorded_at_time\":\"2024-02-12T16:15:00+00:00\",\"lon\":34.782433,\"lat\":31.797699,\"bearing\":24,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":19,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/19\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62118844,\"siri_ride__journey_ref\":\"2024-02-12-56650713\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367236418,\"siri_ride__last_vehicle_location_id\":3368801057,\"siri_ride__duration_minutes\":46,\"siri_ride__gtfs_ride_id\":66865756},{\"id\":3368860645,\"siri_snapshot_id\":1066473,\"siri_ride_stop_id\":1603081539,\"recorded_at_time\":\"2024-02-12T16:15:00+00:00\",\"lon\":34.782433,\"lat\":31.797699,\"bearing\":24,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":19,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/20\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62118844,\"siri_ride__journey_ref\":\"2024-02-12-56650713\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367236418,\"siri_ride__last_vehicle_location_id\":3368801057,\"siri_ride__duration_minutes\":46,\"siri_ride__gtfs_ride_id\":66865756},{\"id\":3368785410,\"siri_snapshot_id\":1066474,\"siri_ride_stop_id\":1603229340,\"recorded_at_time\":\"2024-02-12T17:15:00+00:00\",\"lon\":34.782417,\"lat\":31.797703,\"bearing\":6,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":19,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/16\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62125092,\"siri_ride__journey_ref\":\"2024-02-12-20251298\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367541360,\"siri_ride__last_vehicle_location_id\":3367742721,\"siri_ride__duration_minutes\":42,\"siri_ride__gtfs_ride_id\":66908337},{\"id\":3368774714,\"siri_snapshot_id\":1066515,\"siri_ride_stop_id\":1603229340,\"recorded_at_time\":\"2024-02-12T17:15:00+00:00\",\"lon\":34.782417,\"lat\":31.797703,\"bearing\":6,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":19,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/17\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62125092,\"siri_ride__journey_ref\":\"2024-02-12-20251298\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367541360,\"siri_ride__last_vehicle_location_id\":3367742721,\"siri_ride__duration_minutes\":42,\"siri_ride__gtfs_ride_id\":66908337},{\"id\":3368761183,\"siri_snapshot_id\":1066511,\"siri_ride_stop_id\":1603229340,\"recorded_at_time\":\"2024-02-12T17:15:00+00:00\",\"lon\":34.782417,\"lat\":31.797703,\"bearing\":6,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":19,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/18\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62125092,\"siri_ride__journey_ref\":\"2024-02-12-20251298\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367541360,\"siri_ride__last_vehicle_location_id\":3367742721,\"siri_ride__duration_minutes\":42,\"siri_ride__gtfs_ride_id\":66908337},{\"id\":3367547916,\"siri_snapshot_id\":1066150,\"siri_ride_stop_id\":1603229340,\"recorded_at_time\":\"2024-02-12T17:15:00+00:00\",\"lon\":34.782417,\"lat\":31.797703,\"bearing\":6,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":19,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/20\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62125092,\"siri_ride__journey_ref\":\"2024-02-12-20251298\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367541360,\"siri_ride__last_vehicle_location_id\":3367742721,\"siri_ride__duration_minutes\":42,\"siri_ride__gtfs_ride_id\":66908337},{\"id\":3367541360,\"siri_snapshot_id\":1066149,\"siri_ride_stop_id\":1603229340,\"recorded_at_time\":\"2024-02-12T17:15:00+00:00\",\"lon\":34.782417,\"lat\":31.797703,\"bearing\":6,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":19,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/19\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62125092,\"siri_ride__journey_ref\":\"2024-02-12-20251298\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367541360,\"siri_ride__last_vehicle_location_id\":3367742721,\"siri_ride__duration_minutes\":42,\"siri_ride__gtfs_ride_id\":66908337},{\"id\":3367481422,\"siri_snapshot_id\":1066140,\"siri_ride_stop_id\":1603202515,\"recorded_at_time\":\"2024-02-12T17:05:15+00:00\",\"lon\":34.785278,\"lat\":31.804974,\"bearing\":291,\"velocity\":25,\"distance_from_journey_start\":1484,\"distance_from_siri_ride_stop_meters\":19,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/05\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62122848,\"siri_ride__journey_ref\":\"2024-02-12-56650715\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3367433965,\"siri_ride__last_vehicle_location_id\":3367651364,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66913928},{\"id\":3367236418,\"siri_snapshot_id\":1066104,\"siri_ride_stop_id\":1603081539,\"recorded_at_time\":\"2024-02-12T16:15:00+00:00\",\"lon\":34.782433,\"lat\":31.797699,\"bearing\":24,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":19,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/18\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62118844,\"siri_ride__journey_ref\":\"2024-02-12-56650713\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367236418,\"siri_ride__last_vehicle_location_id\":3368801057,\"siri_ride__duration_minutes\":46,\"siri_ride__gtfs_ride_id\":66865756},{\"id\":3367228945,\"siri_snapshot_id\":1066103,\"siri_ride_stop_id\":1603081539,\"recorded_at_time\":\"2024-02-12T16:15:00+00:00\",\"lon\":34.782433,\"lat\":31.797699,\"bearing\":24,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":19,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/17\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62118844,\"siri_ride__journey_ref\":\"2024-02-12-56650713\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367236418,\"siri_ride__last_vehicle_location_id\":3368801057,\"siri_ride__duration_minutes\":46,\"siri_ride__gtfs_ride_id\":66865756},{\"id\":3367221394,\"siri_snapshot_id\":1066102,\"siri_ride_stop_id\":1603081539,\"recorded_at_time\":\"2024-02-12T16:15:00+00:00\",\"lon\":34.782433,\"lat\":31.797699,\"bearing\":24,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":19,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/16\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62118844,\"siri_ride__journey_ref\":\"2024-02-12-56650713\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367236418,\"siri_ride__last_vehicle_location_id\":3368801057,\"siri_ride__duration_minutes\":46,\"siri_ride__gtfs_ride_id\":66865756},{\"id\":3367213813,\"siri_snapshot_id\":1066101,\"siri_ride_stop_id\":1603081539,\"recorded_at_time\":\"2024-02-12T16:15:00+00:00\",\"lon\":34.782433,\"lat\":31.797699,\"bearing\":24,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":19,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/15\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62118844,\"siri_ride__journey_ref\":\"2024-02-12-56650713\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367236418,\"siri_ride__last_vehicle_location_id\":3368801057,\"siri_ride__duration_minutes\":46,\"siri_ride__gtfs_ride_id\":66865756},{\"id\":3366353945,\"siri_snapshot_id\":1065990,\"siri_ride_stop_id\":1602696398,\"recorded_at_time\":\"2024-02-12T13:15:01+00:00\",\"lon\":34.782421,\"lat\":31.797974,\"bearing\":24,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":19,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/19\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62098002,\"siri_ride__journey_ref\":\"2024-02-12-43644427\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366322683,\"siri_ride__last_vehicle_location_id\":3366557956,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66913927},{\"id\":3366346187,\"siri_snapshot_id\":1065989,\"siri_ride_stop_id\":1602696398,\"recorded_at_time\":\"2024-02-12T13:15:01+00:00\",\"lon\":34.782421,\"lat\":31.797974,\"bearing\":24,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":19,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/18\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62098002,\"siri_ride__journey_ref\":\"2024-02-12-43644427\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366322683,\"siri_ride__last_vehicle_location_id\":3366557956,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66913927},{\"id\":3366338421,\"siri_snapshot_id\":1065988,\"siri_ride_stop_id\":1602696398,\"recorded_at_time\":\"2024-02-12T13:15:01+00:00\",\"lon\":34.782421,\"lat\":31.797974,\"bearing\":24,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":19,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/17\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62098002,\"siri_ride__journey_ref\":\"2024-02-12-43644427\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366322683,\"siri_ride__last_vehicle_location_id\":3366557956,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66913927},{\"id\":3366330597,\"siri_snapshot_id\":1065987,\"siri_ride_stop_id\":1602696398,\"recorded_at_time\":\"2024-02-12T13:15:01+00:00\",\"lon\":34.782421,\"lat\":31.797974,\"bearing\":24,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":19,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/16\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62098002,\"siri_ride__journey_ref\":\"2024-02-12-43644427\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366322683,\"siri_ride__last_vehicle_location_id\":3366557956,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66913927},{\"id\":3366322683,\"siri_snapshot_id\":1065986,\"siri_ride_stop_id\":1602696398,\"recorded_at_time\":\"2024-02-12T13:15:01+00:00\",\"lon\":34.782421,\"lat\":31.797974,\"bearing\":24,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":19,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/15\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62098002,\"siri_ride__journey_ref\":\"2024-02-12-43644427\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366322683,\"siri_ride__last_vehicle_location_id\":3366557956,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66913927},{\"id\":3367628255,\"siri_snapshot_id\":1066163,\"siri_ride_stop_id\":1603271070,\"recorded_at_time\":\"2024-02-12T17:36:15+00:00\",\"lon\":34.783363,\"lat\":31.804115,\"bearing\":103,\"velocity\":43,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":18,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/37\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62122848,\"siri_ride__journey_ref\":\"2024-02-12-56650715\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3367433965,\"siri_ride__last_vehicle_location_id\":3367651364,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66913928},{\"id\":3366837376,\"siri_snapshot_id\":1066052,\"siri_ride_stop_id\":1602916198,\"recorded_at_time\":\"2024-02-12T15:01:27+00:00\",\"lon\":34.78336,\"lat\":31.804127,\"bearing\":105,\"velocity\":7,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":18,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/01\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62105505,\"siri_ride__journey_ref\":\"2024-02-12-56650707\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366646680,\"siri_ride__last_vehicle_location_id\":3366886081,\"siri_ride__duration_minutes\":44,\"siri_ride__gtfs_ride_id\":66913186},{\"id\":3366392873,\"siri_snapshot_id\":1065995,\"siri_ride_stop_id\":1602723974,\"recorded_at_time\":\"2024-02-12T13:24:11+00:00\",\"lon\":34.781143,\"lat\":31.799343,\"bearing\":115,\"velocity\":25,\"distance_from_journey_start\":12615,\"distance_from_siri_ride_stop_meters\":18,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/24\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62093019,\"siri_ride__journey_ref\":\"2024-02-12-43644426\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366143788,\"siri_ride__last_vehicle_location_id\":3366392873,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66915437},{\"id\":3366073052,\"siri_snapshot_id\":1065952,\"siri_ride_stop_id\":1602582864,\"recorded_at_time\":\"2024-02-12T12:25:01+00:00\",\"lon\":34.787323,\"lat\":31.801058,\"bearing\":322,\"velocity\":4,\"distance_from_journey_start\":845,\"distance_from_siri_ride_stop_meters\":18,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/25\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62090708,\"siri_ride__journey_ref\":\"2024-02-12-56650701\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366057999,\"siri_ride__last_vehicle_location_id\":3366284443,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66914345},{\"id\":3369505440,\"siri_snapshot_id\":1066429,\"siri_ride_stop_id\":1602575185,\"recorded_at_time\":\"2024-02-12T12:20:20+00:00\",\"lon\":34.782497,\"lat\":31.797691,\"bearing\":30,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":17,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/21\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62090708,\"siri_ride__journey_ref\":\"2024-02-12-56650701\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366057999,\"siri_ride__last_vehicle_location_id\":3366284443,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66914345},{\"id\":3369449178,\"siri_snapshot_id\":1066330,\"siri_ride_stop_id\":1604037797,\"recorded_at_time\":\"2024-02-12T12:40:11+00:00\",\"lon\":34.781384,\"lat\":31.799257,\"bearing\":112,\"velocity\":0,\"distance_from_journey_start\":12615,\"distance_from_siri_ride_stop_meters\":17,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/40\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62088183,\"siri_ride__journey_ref\":\"2024-02-12-43644425\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3365955898,\"siri_ride__last_vehicle_location_id\":3366143786,\"siri_ride__duration_minutes\":40,\"siri_ride__gtfs_ride_id\":66908335},{\"id\":3369275825,\"siri_snapshot_id\":1066418,\"siri_ride_stop_id\":1602789096,\"recorded_at_time\":\"2024-02-12T13:55:01+00:00\",\"lon\":34.782501,\"lat\":31.797985,\"bearing\":22,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":17,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/58\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62102598,\"siri_ride__journey_ref\":\"2024-02-12-43644428\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366542194,\"siri_ride__last_vehicle_location_id\":3366726163,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66914344},{\"id\":3369268282,\"siri_snapshot_id\":1066435,\"siri_ride_stop_id\":1602789096,\"recorded_at_time\":\"2024-02-12T13:55:01+00:00\",\"lon\":34.782501,\"lat\":31.797985,\"bearing\":22,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":17,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/59\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62102598,\"siri_ride__journey_ref\":\"2024-02-12-43644428\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366542194,\"siri_ride__last_vehicle_location_id\":3366726163,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66914344},{\"id\":3369260462,\"siri_snapshot_id\":1066329,\"siri_ride_stop_id\":1602789096,\"recorded_at_time\":\"2024-02-12T13:55:01+00:00\",\"lon\":34.782501,\"lat\":31.797985,\"bearing\":22,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":17,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/00\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62102598,\"siri_ride__journey_ref\":\"2024-02-12-43644428\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366542194,\"siri_ride__last_vehicle_location_id\":3366726163,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66914344},{\"id\":3367771903,\"siri_snapshot_id\":1066188,\"siri_ride_stop_id\":1603335083,\"recorded_at_time\":\"2024-02-12T18:01:06+00:00\",\"lon\":34.784161,\"lat\":31.800674,\"bearing\":62,\"velocity\":0,\"distance_from_journey_start\":391,\"distance_from_siri_ride_stop_meters\":17,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/02\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62128966,\"siri_ride__journey_ref\":\"2024-02-12-1187857\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319402\",\"siri_ride__first_vehicle_location_id\":3367736806,\"siri_ride__last_vehicle_location_id\":3367932239,\"siri_ride__duration_minutes\":36,\"siri_ride__gtfs_ride_id\":66969323},{\"id\":3366550085,\"siri_snapshot_id\":1066016,\"siri_ride_stop_id\":1602789096,\"recorded_at_time\":\"2024-02-12T13:55:01+00:00\",\"lon\":34.782501,\"lat\":31.797985,\"bearing\":22,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":17,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/57\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62102598,\"siri_ride__journey_ref\":\"2024-02-12-43644428\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366542194,\"siri_ride__last_vehicle_location_id\":3366726163,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66914344},{\"id\":3366542194,\"siri_snapshot_id\":1066015,\"siri_ride_stop_id\":1602789096,\"recorded_at_time\":\"2024-02-12T13:55:01+00:00\",\"lon\":34.782501,\"lat\":31.797985,\"bearing\":22,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":17,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/56\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62102598,\"siri_ride__journey_ref\":\"2024-02-12-43644428\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366542194,\"siri_ride__last_vehicle_location_id\":3366726163,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66914344},{\"id\":3369082736,\"siri_snapshot_id\":1066495,\"siri_ride_stop_id\":1602908103,\"recorded_at_time\":\"2024-02-12T14:55:00+00:00\",\"lon\":34.782482,\"lat\":31.797703,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":16,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/55\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62109786,\"siri_ride__journey_ref\":\"2024-02-12-20251227\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:00:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3366821054,\"siri_ride__last_vehicle_location_id\":3368950129,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66913184},{\"id\":3369075727,\"siri_snapshot_id\":1066520,\"siri_ride_stop_id\":1602908103,\"recorded_at_time\":\"2024-02-12T14:55:00+00:00\",\"lon\":34.782482,\"lat\":31.797703,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":16,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/56\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62109786,\"siri_ride__journey_ref\":\"2024-02-12-20251227\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:00:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3366821054,\"siri_ride__last_vehicle_location_id\":3368950129,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66913184},{\"id\":3369065909,\"siri_snapshot_id\":1066492,\"siri_ride_stop_id\":1602908103,\"recorded_at_time\":\"2024-02-12T14:55:00+00:00\",\"lon\":34.782482,\"lat\":31.797703,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":16,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/57\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62109786,\"siri_ride__journey_ref\":\"2024-02-12-20251227\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:00:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3366821054,\"siri_ride__last_vehicle_location_id\":3368950129,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66913184},{\"id\":3369059418,\"siri_snapshot_id\":1066500,\"siri_ride_stop_id\":1602908103,\"recorded_at_time\":\"2024-02-12T14:55:00+00:00\",\"lon\":34.782482,\"lat\":31.797703,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":16,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/58\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62109786,\"siri_ride__journey_ref\":\"2024-02-12-20251227\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:00:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3366821054,\"siri_ride__last_vehicle_location_id\":3368950129,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66913184},{\"id\":3369010466,\"siri_snapshot_id\":1066494,\"siri_ride_stop_id\":1603891373,\"recorded_at_time\":\"2024-02-12T15:15:22+00:00\",\"lon\":34.782135,\"lat\":31.80435,\"bearing\":102,\"velocity\":0,\"distance_from_journey_start\":10546,\"distance_from_siri_ride_stop_meters\":16,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/15\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62107835,\"siri_ride__journey_ref\":\"2024-02-12-43644429\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366734007,\"siri_ride__last_vehicle_location_id\":3366942424,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865754},{\"id\":3366821054,\"siri_snapshot_id\":1066050,\"siri_ride_stop_id\":1602908103,\"recorded_at_time\":\"2024-02-12T14:55:00+00:00\",\"lon\":34.782482,\"lat\":31.797703,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":16,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/59\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62109786,\"siri_ride__journey_ref\":\"2024-02-12-20251227\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:00:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3366821054,\"siri_ride__last_vehicle_location_id\":3368950129,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66913184},{\"id\":3365893979,\"siri_snapshot_id\":1065927,\"siri_ride_stop_id\":1602499731,\"recorded_at_time\":\"2024-02-12T11:42:07+00:00\",\"lon\":34.783989,\"lat\":31.800667,\"bearing\":100,\"velocity\":0,\"distance_from_journey_start\":391,\"distance_from_siri_ride_stop_meters\":16,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/43\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62085440,\"siri_ride__journey_ref\":\"2024-02-12-2899890\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365845986,\"siri_ride__last_vehicle_location_id\":3366073050,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66915434},{\"id\":3369010468,\"siri_snapshot_id\":1066494,\"siri_ride_stop_id\":1602946793,\"recorded_at_time\":\"2024-02-12T15:15:00+00:00\",\"lon\":34.78244,\"lat\":31.797735,\"bearing\":28,\"velocity\":7,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":15,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/15\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62111816,\"siri_ride__journey_ref\":\"2024-02-12-34054265\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:20:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3366910133,\"siri_ride__last_vehicle_location_id\":3367095004,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66914114},{\"id\":3366934367,\"siri_snapshot_id\":1066064,\"siri_ride_stop_id\":1602946793,\"recorded_at_time\":\"2024-02-12T15:15:00+00:00\",\"lon\":34.78244,\"lat\":31.797735,\"bearing\":28,\"velocity\":7,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":15,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/19\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62111816,\"siri_ride__journey_ref\":\"2024-02-12-34054265\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:20:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3366910133,\"siri_ride__last_vehicle_location_id\":3367095004,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66914114},{\"id\":3366926349,\"siri_snapshot_id\":1066063,\"siri_ride_stop_id\":1602946793,\"recorded_at_time\":\"2024-02-12T15:15:00+00:00\",\"lon\":34.78244,\"lat\":31.797735,\"bearing\":28,\"velocity\":7,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":15,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/18\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62111816,\"siri_ride__journey_ref\":\"2024-02-12-34054265\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:20:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3366910133,\"siri_ride__last_vehicle_location_id\":3367095004,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66914114},{\"id\":3366918270,\"siri_snapshot_id\":1066062,\"siri_ride_stop_id\":1602946793,\"recorded_at_time\":\"2024-02-12T15:15:00+00:00\",\"lon\":34.78244,\"lat\":31.797735,\"bearing\":28,\"velocity\":7,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":15,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/17\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62111816,\"siri_ride__journey_ref\":\"2024-02-12-34054265\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:20:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3366910133,\"siri_ride__last_vehicle_location_id\":3367095004,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66914114},{\"id\":3366910133,\"siri_snapshot_id\":1066061,\"siri_ride_stop_id\":1602946793,\"recorded_at_time\":\"2024-02-12T15:15:00+00:00\",\"lon\":34.78244,\"lat\":31.797735,\"bearing\":28,\"velocity\":7,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":15,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/16\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62111816,\"siri_ride__journey_ref\":\"2024-02-12-34054265\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:20:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3366910133,\"siri_ride__last_vehicle_location_id\":3367095004,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66914114},{\"id\":3366346185,\"siri_snapshot_id\":1065989,\"siri_ride_stop_id\":1602706017,\"recorded_at_time\":\"2024-02-12T13:18:10+00:00\",\"lon\":34.782116,\"lat\":31.804392,\"bearing\":106,\"velocity\":0,\"distance_from_journey_start\":10546,\"distance_from_siri_ride_stop_meters\":15,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/18\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62093019,\"siri_ride__journey_ref\":\"2024-02-12-43644426\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366143788,\"siri_ride__last_vehicle_location_id\":3366392873,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66915437},{\"id\":3365935425,\"siri_snapshot_id\":1065933,\"siri_ride_stop_id\":1602520386,\"recorded_at_time\":\"2024-02-12T11:52:35+00:00\",\"lon\":34.782093,\"lat\":31.80442,\"bearing\":120,\"velocity\":0,\"distance_from_journey_start\":10546,\"distance_from_siri_ride_stop_meters\":15,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/53\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62083192,\"siri_ride__journey_ref\":\"2024-02-12-43644424\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3365769509,\"siri_ride__last_vehicle_location_id\":3365970525,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915436},{\"id\":3369291592,\"siri_snapshot_id\":1066318,\"siri_ride_stop_id\":1603983882,\"recorded_at_time\":\"2024-02-12T13:44:18+00:00\",\"lon\":34.787312,\"lat\":31.801094,\"bearing\":40,\"velocity\":0,\"distance_from_journey_start\":845,\"distance_from_siri_ride_stop_meters\":14,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/45\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62100388,\"siri_ride__journey_ref\":\"2024-02-12-34054223\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3366429684,\"siri_ride__last_vehicle_location_id\":3366662832,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66914343},{\"id\":3369252487,\"siri_snapshot_id\":1066364,\"siri_ride_stop_id\":1603972202,\"recorded_at_time\":\"2024-02-12T14:00:33+00:00\",\"lon\":34.782104,\"lat\":31.804394,\"bearing\":105,\"velocity\":0,\"distance_from_journey_start\":10551,\"distance_from_siri_ride_stop_meters\":14,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/01\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62098002,\"siri_ride__journey_ref\":\"2024-02-12-43644427\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366322683,\"siri_ride__last_vehicle_location_id\":3366557956,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66913927},{\"id\":3368831531,\"siri_snapshot_id\":1066507,\"siri_ride_stop_id\":1603129289,\"recorded_at_time\":\"2024-02-12T16:35:00+00:00\",\"lon\":34.782398,\"lat\":31.797876,\"bearing\":4,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":14,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/35\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62121032,\"siri_ride__journey_ref\":\"2024-02-12-34054266\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:40:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367320317,\"siri_ride__last_vehicle_location_id\":3368786847,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66908338},{\"id\":3368824493,\"siri_snapshot_id\":1066485,\"siri_ride_stop_id\":1603129289,\"recorded_at_time\":\"2024-02-12T16:35:00+00:00\",\"lon\":34.782398,\"lat\":31.797876,\"bearing\":4,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":14,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/36\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62121032,\"siri_ride__journey_ref\":\"2024-02-12-34054266\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:40:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367320317,\"siri_ride__last_vehicle_location_id\":3368786847,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66908338},{\"id\":3368815563,\"siri_snapshot_id\":1066514,\"siri_ride_stop_id\":1603129289,\"recorded_at_time\":\"2024-02-12T16:35:00+00:00\",\"lon\":34.782398,\"lat\":31.797876,\"bearing\":4,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":14,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/37\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62121032,\"siri_ride__journey_ref\":\"2024-02-12-34054266\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:40:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367320317,\"siri_ride__last_vehicle_location_id\":3368786847,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66908338},{\"id\":3367454477,\"siri_snapshot_id\":1066136,\"siri_ride_stop_id\":1603189041,\"recorded_at_time\":\"2024-02-12T16:58:22+00:00\",\"lon\":34.783684,\"lat\":31.804144,\"bearing\":128,\"velocity\":0,\"distance_from_journey_start\":10973,\"distance_from_siri_ride_stop_meters\":14,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/58\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62118844,\"siri_ride__journey_ref\":\"2024-02-12-56650713\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367236418,\"siri_ride__last_vehicle_location_id\":3368801057,\"siri_ride__duration_minutes\":46,\"siri_ride__gtfs_ride_id\":66865756},{\"id\":3367327015,\"siri_snapshot_id\":1066117,\"siri_ride_stop_id\":1603129289,\"recorded_at_time\":\"2024-02-12T16:35:00+00:00\",\"lon\":34.782398,\"lat\":31.797876,\"bearing\":4,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":14,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/39\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62121032,\"siri_ride__journey_ref\":\"2024-02-12-34054266\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:40:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367320317,\"siri_ride__last_vehicle_location_id\":3368786847,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66908338},{\"id\":3367320317,\"siri_snapshot_id\":1066116,\"siri_ride_stop_id\":1603129289,\"recorded_at_time\":\"2024-02-12T16:35:00+00:00\",\"lon\":34.782398,\"lat\":31.797876,\"bearing\":4,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":14,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/38\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62121032,\"siri_ride__journey_ref\":\"2024-02-12-34054266\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:40:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367320317,\"siri_ride__last_vehicle_location_id\":3368786847,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66908338},{\"id\":3366861763,\"siri_snapshot_id\":1066055,\"siri_ride_stop_id\":1602926017,\"recorded_at_time\":\"2024-02-12T15:04:23+00:00\",\"lon\":34.785236,\"lat\":31.804995,\"bearing\":308,\"velocity\":0,\"distance_from_journey_start\":1484,\"distance_from_siri_ride_stop_meters\":14,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/04\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62109786,\"siri_ride__journey_ref\":\"2024-02-12-20251227\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:00:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3366821054,\"siri_ride__last_vehicle_location_id\":3368950129,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66913184},{\"id\":3366284443,\"siri_snapshot_id\":1065981,\"siri_ride_stop_id\":1602679266,\"recorded_at_time\":\"2024-02-12T13:04:17+00:00\",\"lon\":34.781208,\"lat\":31.799324,\"bearing\":114,\"velocity\":18,\"distance_from_journey_start\":12615,\"distance_from_siri_ride_stop_meters\":14,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/04\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62090708,\"siri_ride__journey_ref\":\"2024-02-12-56650701\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366057999,\"siri_ride__last_vehicle_location_id\":3366284443,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66914345},{\"id\":3369219431,\"siri_snapshot_id\":1066446,\"siri_ride_stop_id\":1603948952,\"recorded_at_time\":\"2024-02-12T14:15:01+00:00\",\"lon\":34.782452,\"lat\":31.797745,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":13,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/16\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62105505,\"siri_ride__journey_ref\":\"2024-02-12-56650707\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366646680,\"siri_ride__last_vehicle_location_id\":3366886081,\"siri_ride__duration_minutes\":44,\"siri_ride__gtfs_ride_id\":66913186},{\"id\":3369212063,\"siri_snapshot_id\":1066381,\"siri_ride_stop_id\":1603948952,\"recorded_at_time\":\"2024-02-12T14:15:01+00:00\",\"lon\":34.782452,\"lat\":31.797745,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":13,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/17\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62105505,\"siri_ride__journey_ref\":\"2024-02-12-56650707\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366646680,\"siri_ride__last_vehicle_location_id\":3366886081,\"siri_ride__duration_minutes\":44,\"siri_ride__gtfs_ride_id\":66913186},{\"id\":3369203817,\"siri_snapshot_id\":1066281,\"siri_ride_stop_id\":1603948952,\"recorded_at_time\":\"2024-02-12T14:15:01+00:00\",\"lon\":34.782452,\"lat\":31.797745,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":13,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/18\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62105505,\"siri_ride__journey_ref\":\"2024-02-12-56650707\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366646680,\"siri_ride__last_vehicle_location_id\":3366886081,\"siri_ride__duration_minutes\":44,\"siri_ride__gtfs_ride_id\":66913186},{\"id\":3369195638,\"siri_snapshot_id\":1066423,\"siri_ride_stop_id\":1603948952,\"recorded_at_time\":\"2024-02-12T14:15:01+00:00\",\"lon\":34.782452,\"lat\":31.797745,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":13,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/19\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62105505,\"siri_ride__journey_ref\":\"2024-02-12-56650707\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366646680,\"siri_ride__last_vehicle_location_id\":3366886081,\"siri_ride__duration_minutes\":44,\"siri_ride__gtfs_ride_id\":66913186},{\"id\":3369179304,\"siri_snapshot_id\":1066415,\"siri_ride_stop_id\":1603948952,\"recorded_at_time\":\"2024-02-12T14:15:01+00:00\",\"lon\":34.782452,\"lat\":31.797745,\"bearing\":26,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":13,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/20\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62105505,\"siri_ride__journey_ref\":\"2024-02-12-56650707\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366646680,\"siri_ride__last_vehicle_location_id\":3366886081,\"siri_ride__duration_minutes\":44,\"siri_ride__gtfs_ride_id\":66913186},{\"id\":3367320315,\"siri_snapshot_id\":1066116,\"siri_ride_stop_id\":1603129287,\"recorded_at_time\":\"2024-02-12T16:37:54+00:00\",\"lon\":34.783428,\"lat\":31.804235,\"bearing\":104,\"velocity\":32,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":13,\"siri_snapshot__snapshot_id\":\"2024/02/12/16/38\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62116498,\"siri_ride__journey_ref\":\"2024-02-12-43644431\",\"siri_ride__scheduled_start_time\":\"2024-02-12T16:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3367109256,\"siri_ride__last_vehicle_location_id\":3367347477,\"siri_ride__duration_minutes\":47,\"siri_ride__gtfs_ride_id\":66915466},{\"id\":3365985063,\"siri_snapshot_id\":1065940,\"siri_ride_stop_id\":1602529472,\"recorded_at_time\":\"2024-02-12T11:55:00+00:00\",\"lon\":34.782417,\"lat\":31.797832,\"bearing\":18,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":12,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/00\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62088183,\"siri_ride__journey_ref\":\"2024-02-12-43644425\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3365955898,\"siri_ride__last_vehicle_location_id\":3366143786,\"siri_ride__duration_minutes\":40,\"siri_ride__gtfs_ride_id\":66908335},{\"id\":3365977809,\"siri_snapshot_id\":1065939,\"siri_ride_stop_id\":1602529472,\"recorded_at_time\":\"2024-02-12T11:55:00+00:00\",\"lon\":34.782417,\"lat\":31.797832,\"bearing\":18,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":12,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/59\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62088183,\"siri_ride__journey_ref\":\"2024-02-12-43644425\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3365955898,\"siri_ride__last_vehicle_location_id\":3366143786,\"siri_ride__duration_minutes\":40,\"siri_ride__gtfs_ride_id\":66908335},{\"id\":3365970527,\"siri_snapshot_id\":1065938,\"siri_ride_stop_id\":1602529472,\"recorded_at_time\":\"2024-02-12T11:55:00+00:00\",\"lon\":34.782417,\"lat\":31.797832,\"bearing\":18,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":12,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/58\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62088183,\"siri_ride__journey_ref\":\"2024-02-12-43644425\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3365955898,\"siri_ride__last_vehicle_location_id\":3366143786,\"siri_ride__duration_minutes\":40,\"siri_ride__gtfs_ride_id\":66908335},{\"id\":3365963227,\"siri_snapshot_id\":1065937,\"siri_ride_stop_id\":1602529472,\"recorded_at_time\":\"2024-02-12T11:55:00+00:00\",\"lon\":34.782417,\"lat\":31.797832,\"bearing\":18,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":12,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/57\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62088183,\"siri_ride__journey_ref\":\"2024-02-12-43644425\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3365955898,\"siri_ride__last_vehicle_location_id\":3366143786,\"siri_ride__duration_minutes\":40,\"siri_ride__gtfs_ride_id\":66908335},{\"id\":3365955898,\"siri_snapshot_id\":1065936,\"siri_ride_stop_id\":1602529472,\"recorded_at_time\":\"2024-02-12T11:55:00+00:00\",\"lon\":34.782417,\"lat\":31.797832,\"bearing\":18,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":12,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/56\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62088183,\"siri_ride__journey_ref\":\"2024-02-12-43644425\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3365955898,\"siri_ride__last_vehicle_location_id\":3366143786,\"siri_ride__duration_minutes\":40,\"siri_ride__gtfs_ride_id\":66908335},{\"id\":3365887017,\"siri_snapshot_id\":1065926,\"siri_ride_stop_id\":1602496729,\"recorded_at_time\":\"2024-02-12T11:41:22+00:00\",\"lon\":34.782963,\"lat\":31.799335,\"bearing\":16,\"velocity\":0,\"distance_from_journey_start\":171,\"distance_from_siri_ride_stop_meters\":12,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/42\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62085440,\"siri_ride__journey_ref\":\"2024-02-12-2899890\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365845986,\"siri_ride__last_vehicle_location_id\":3366073050,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66915434},{\"id\":3366958602,\"siri_snapshot_id\":1066067,\"siri_ride_stop_id\":1602967746,\"recorded_at_time\":\"2024-02-12T15:22:25+00:00\",\"lon\":34.7873,\"lat\":31.801138,\"bearing\":310,\"velocity\":0,\"distance_from_journey_start\":845,\"distance_from_siri_ride_stop_meters\":11,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/22\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62111816,\"siri_ride__journey_ref\":\"2024-02-12-34054265\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:20:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3366910133,\"siri_ride__last_vehicle_location_id\":3367095004,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66914114},{\"id\":3366942424,\"siri_snapshot_id\":1066065,\"siri_ride_stop_id\":1602961342,\"recorded_at_time\":\"2024-02-12T15:20:16+00:00\",\"lon\":34.781189,\"lat\":31.799288,\"bearing\":114,\"velocity\":22,\"distance_from_journey_start\":12615,\"distance_from_siri_ride_stop_meters\":11,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/20\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62107835,\"siri_ride__journey_ref\":\"2024-02-12-43644429\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366734007,\"siri_ride__last_vehicle_location_id\":3366942424,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865754},{\"id\":3366662834,\"siri_snapshot_id\":1066030,\"siri_ride_stop_id\":1602840148,\"recorded_at_time\":\"2024-02-12T14:24:38+00:00\",\"lon\":34.785206,\"lat\":31.805008,\"bearing\":294,\"velocity\":25,\"distance_from_journey_start\":1484,\"distance_from_siri_ride_stop_meters\":11,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/25\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62105505,\"siri_ride__journey_ref\":\"2024-02-12-56650707\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366646680,\"siri_ride__last_vehicle_location_id\":3366886081,\"siri_ride__duration_minutes\":44,\"siri_ride__gtfs_ride_id\":66913186},{\"id\":3366466956,\"siri_snapshot_id\":1066005,\"siri_ride_stop_id\":1602755972,\"recorded_at_time\":\"2024-02-12T13:40:14+00:00\",\"lon\":34.781193,\"lat\":31.799288,\"bearing\":118,\"velocity\":4,\"distance_from_journey_start\":12615,\"distance_from_siri_ride_stop_meters\":11,\"siri_snapshot__snapshot_id\":\"2024/02/12/13/41\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62095384,\"siri_ride__journey_ref\":\"2024-02-12-56650703\",\"siri_ride__scheduled_start_time\":\"2024-02-12T13:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23319502\",\"siri_ride__first_vehicle_location_id\":3366231072,\"siri_ride__last_vehicle_location_id\":3366466956,\"siri_ride__duration_minutes\":45,\"siri_ride__gtfs_ride_id\":66865755},{\"id\":3368019978,\"siri_snapshot_id\":1066235,\"siri_ride_stop_id\":1603451021,\"recorded_at_time\":\"2024-02-12T18:51:22+00:00\",\"lon\":34.783642,\"lat\":31.804159,\"bearing\":104,\"velocity\":0,\"distance_from_journey_start\":10938,\"distance_from_siri_ride_stop_meters\":10,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/51\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62130650,\"siri_ride__journey_ref\":\"2024-02-12-56650719\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367846067,\"siri_ride__last_vehicle_location_id\":3368033593,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66915627},{\"id\":3366950546,\"siri_snapshot_id\":1066066,\"siri_ride_stop_id\":1602964629,\"recorded_at_time\":\"2024-02-12T15:21:17+00:00\",\"lon\":34.784046,\"lat\":31.800631,\"bearing\":74,\"velocity\":0,\"distance_from_journey_start\":391,\"distance_from_siri_ride_stop_meters\":10,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/21\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62111816,\"siri_ride__journey_ref\":\"2024-02-12-34054265\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:20:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3366910133,\"siri_ride__last_vehicle_location_id\":3367095004,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66914114},{\"id\":3366845560,\"siri_snapshot_id\":1066053,\"siri_ride_stop_id\":1602919495,\"recorded_at_time\":\"2024-02-12T15:02:23+00:00\",\"lon\":34.787281,\"lat\":31.801125,\"bearing\":312,\"velocity\":0,\"distance_from_journey_start\":845,\"distance_from_siri_ride_stop_meters\":10,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/02\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62109786,\"siri_ride__journey_ref\":\"2024-02-12-20251227\",\"siri_ride__scheduled_start_time\":\"2024-02-12T15:00:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3366821054,\"siri_ride__last_vehicle_location_id\":3368950129,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66913184},{\"id\":3365742346,\"siri_snapshot_id\":1065905,\"siri_ride_stop_id\":1602428707,\"recorded_at_time\":\"2024-02-12T11:06:26+00:00\",\"lon\":34.783443,\"lat\":31.804192,\"bearing\":104,\"velocity\":40,\"distance_from_journey_start\":10878,\"distance_from_siri_ride_stop_meters\":10,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/06\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62079158,\"siri_ride__journey_ref\":\"2024-02-12-43644423\",\"siri_ride__scheduled_start_time\":\"2024-02-12T10:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365593797,\"siri_ride__last_vehicle_location_id\":3365762678,\"siri_ride__duration_minutes\":34,\"siri_ride__gtfs_ride_id\":66913185},{\"id\":3369523029,\"siri_snapshot_id\":1066336,\"siri_ride_stop_id\":1602575185,\"recorded_at_time\":\"2024-02-12T12:15:00+00:00\",\"lon\":34.782562,\"lat\":31.797918,\"bearing\":30,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":9,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/19\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62090708,\"siri_ride__journey_ref\":\"2024-02-12-56650701\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366057999,\"siri_ride__last_vehicle_location_id\":3366284443,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66914345},{\"id\":3369515667,\"siri_snapshot_id\":1066291,\"siri_ride_stop_id\":1602575185,\"recorded_at_time\":\"2024-02-12T12:15:00+00:00\",\"lon\":34.782562,\"lat\":31.797918,\"bearing\":30,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":9,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/20\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62090708,\"siri_ride__journey_ref\":\"2024-02-12-56650701\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366057999,\"siri_ride__last_vehicle_location_id\":3366284443,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66914345},{\"id\":3366065496,\"siri_snapshot_id\":1065951,\"siri_ride_stop_id\":1602575185,\"recorded_at_time\":\"2024-02-12T12:15:00+00:00\",\"lon\":34.782562,\"lat\":31.797918,\"bearing\":30,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":9,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/17\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62090708,\"siri_ride__journey_ref\":\"2024-02-12-56650701\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366057999,\"siri_ride__last_vehicle_location_id\":3366284443,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66914345},{\"id\":3366057999,\"siri_snapshot_id\":1065950,\"siri_ride_stop_id\":1602575185,\"recorded_at_time\":\"2024-02-12T12:15:00+00:00\",\"lon\":34.782562,\"lat\":31.797918,\"bearing\":30,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":9,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/16\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62090708,\"siri_ride__journey_ref\":\"2024-02-12-56650701\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366057999,\"siri_ride__last_vehicle_location_id\":3366284443,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66914345},{\"id\":3369502352,\"siri_snapshot_id\":1066279,\"siri_ride_stop_id\":1602575185,\"recorded_at_time\":\"2024-02-12T12:21:27+00:00\",\"lon\":34.782585,\"lat\":31.79777,\"bearing\":30,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":8,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/22\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62090708,\"siri_ride__journey_ref\":\"2024-02-12-56650701\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366057999,\"siri_ride__last_vehicle_location_id\":3366284443,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66914345},{\"id\":3367573562,\"siri_snapshot_id\":1066154,\"siri_ride_stop_id\":1603244552,\"recorded_at_time\":\"2024-02-12T17:23:34+00:00\",\"lon\":34.787197,\"lat\":31.801109,\"bearing\":316,\"velocity\":0,\"distance_from_journey_start\":850,\"distance_from_siri_ride_stop_meters\":8,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/24\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62125092,\"siri_ride__journey_ref\":\"2024-02-12-20251298\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367541360,\"siri_ride__last_vehicle_location_id\":3367742721,\"siri_ride__duration_minutes\":42,\"siri_ride__gtfs_ride_id\":66908337},{\"id\":3369493522,\"siri_snapshot_id\":1066394,\"siri_ride_stop_id\":1604053474,\"recorded_at_time\":\"2024-02-12T12:22:58+00:00\",\"lon\":34.782936,\"lat\":31.799276,\"bearing\":10,\"velocity\":4,\"distance_from_journey_start\":166,\"distance_from_siri_ride_stop_meters\":7,\"siri_snapshot__snapshot_id\":\"2024/02/12/12/23\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62090708,\"siri_ride__journey_ref\":\"2024-02-12-56650701\",\"siri_ride__scheduled_start_time\":\"2024-02-12T12:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366057999,\"siri_ride__last_vehicle_location_id\":3366284443,\"siri_ride__duration_minutes\":49,\"siri_ride__gtfs_ride_id\":66914345},{\"id\":3367586178,\"siri_snapshot_id\":1066156,\"siri_ride_stop_id\":1603249936,\"recorded_at_time\":\"2024-02-12T17:25:23+00:00\",\"lon\":34.785175,\"lat\":31.805038,\"bearing\":294,\"velocity\":22,\"distance_from_journey_start\":1484,\"distance_from_siri_ride_stop_meters\":7,\"siri_snapshot__snapshot_id\":\"2024/02/12/17/26\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62125092,\"siri_ride__journey_ref\":\"2024-02-12-20251298\",\"siri_ride__scheduled_start_time\":\"2024-02-12T17:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3367541360,\"siri_ride__last_vehicle_location_id\":3367742721,\"siri_ride__duration_minutes\":42,\"siri_ride__gtfs_ride_id\":66908337},{\"id\":3365701505,\"siri_snapshot_id\":1065899,\"siri_ride_stop_id\":1602406495,\"recorded_at_time\":\"2024-02-12T11:00:10+00:00\",\"lon\":34.782478,\"lat\":31.797863,\"bearing\":18,\"velocity\":0,\"distance_from_journey_start\":0,\"distance_from_siri_ride_stop_meters\":7,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/00\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62081159,\"siri_ride__journey_ref\":\"2024-02-12-2899889\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:00:00+00:00\",\"siri_ride__vehicle_ref\":\"23289602\",\"siri_ride__first_vehicle_location_id\":3365694760,\"siri_ride__last_vehicle_location_id\":3365852824,\"siri_ride__duration_minutes\":41,\"siri_ride__gtfs_ride_id\":66915433},{\"id\":3367895881,\"siri_snapshot_id\":1066210,\"siri_ride_stop_id\":1603390688,\"recorded_at_time\":\"2024-02-12T18:24:20+00:00\",\"lon\":34.78516,\"lat\":31.805016,\"bearing\":291,\"velocity\":32,\"distance_from_journey_start\":1484,\"distance_from_siri_ride_stop_meters\":6,\"siri_snapshot__snapshot_id\":\"2024/02/12/18/24\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62130650,\"siri_ride__journey_ref\":\"2024-02-12-56650719\",\"siri_ride__scheduled_start_time\":\"2024-02-12T18:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7787469\",\"siri_ride__first_vehicle_location_id\":3367846067,\"siri_ride__last_vehicle_location_id\":3368033593,\"siri_ride__duration_minutes\":39,\"siri_ride__gtfs_ride_id\":66915627},{\"id\":3366845558,\"siri_snapshot_id\":1066053,\"siri_ride_stop_id\":1602916198,\"recorded_at_time\":\"2024-02-12T15:02:26+00:00\",\"lon\":34.783592,\"lat\":31.804127,\"bearing\":244,\"velocity\":0,\"distance_from_journey_start\":10993,\"distance_from_siri_ride_stop_meters\":6,\"siri_snapshot__snapshot_id\":\"2024/02/12/15/02\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62105505,\"siri_ride__journey_ref\":\"2024-02-12-56650707\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3366646680,\"siri_ride__last_vehicle_location_id\":3366886081,\"siri_ride__duration_minutes\":44,\"siri_ride__gtfs_ride_id\":66913186},{\"id\":3369602570,\"siri_snapshot_id\":1066383,\"siri_ride_stop_id\":1604093521,\"recorded_at_time\":\"2024-02-12T11:45:20+00:00\",\"lon\":34.786667,\"lat\":31.804609,\"bearing\":270,\"velocity\":4,\"distance_from_journey_start\":1329,\"distance_from_siri_ride_stop_meters\":4,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/46\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62085440,\"siri_ride__journey_ref\":\"2024-02-12-2899890\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23321002\",\"siri_ride__first_vehicle_location_id\":3365845986,\"siri_ride__last_vehicle_location_id\":3366073050,\"siri_ride__duration_minutes\":50,\"siri_ride__gtfs_ride_id\":66915434},{\"id\":3366749916,\"siri_snapshot_id\":1066041,\"siri_ride_stop_id\":1602878090,\"recorded_at_time\":\"2024-02-12T14:44:08+00:00\",\"lon\":34.786633,\"lat\":31.804564,\"bearing\":276,\"velocity\":0,\"distance_from_journey_start\":1329,\"distance_from_siri_ride_stop_meters\":4,\"siri_snapshot__snapshot_id\":\"2024/02/12/14/44\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62107835,\"siri_ride__journey_ref\":\"2024-02-12-43644429\",\"siri_ride__scheduled_start_time\":\"2024-02-12T14:40:00+00:00\",\"siri_ride__vehicle_ref\":\"23288002\",\"siri_ride__first_vehicle_location_id\":3366734007,\"siri_ride__last_vehicle_location_id\":3366942424,\"siri_ride__duration_minutes\":38,\"siri_ride__gtfs_ride_id\":66865754},{\"id\":3365824875,\"siri_snapshot_id\":1065917,\"siri_ride_stop_id\":1602466453,\"recorded_at_time\":\"2024-02-12T11:24:19+00:00\",\"lon\":34.786652,\"lat\":31.804626,\"bearing\":286,\"velocity\":4,\"distance_from_journey_start\":1329,\"distance_from_siri_ride_stop_meters\":4,\"siri_snapshot__snapshot_id\":\"2024/02/12/11/24\",\"siri_route__id\":973,\"siri_route__line_ref\":2974,\"siri_route__operator_ref\":3,\"siri_ride__id\":62083192,\"siri_ride__journey_ref\":\"2024-02-12-43644424\",\"siri_ride__scheduled_start_time\":\"2024-02-12T11:20:00+00:00\",\"siri_ride__vehicle_ref\":\"7807869\",\"siri_ride__first_vehicle_location_id\":3365769509,\"siri_ride__last_vehicle_location_id\":3365970525,\"siri_ride__duration_minutes\":43,\"siri_ride__gtfs_ride_id\":66915436}]"
           },
           "headersSize": 0,
-          "bodySize": 229276,
+          "bodySize": 229231,
           "redirectURL": "",
-          "_transferSize": 229276
+          "_transferSize": 229231
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 1502.773, "receive": 37.817 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 36316.077,
+          "receive": 58.393
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:53.076Z",
-        "time": 33.503,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:28:03.538Z",
+        "time": 53.689,
         "request": {
           "method": "GET",
           "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_agencies/list?date_from=2024-02-11",
@@ -3076,18 +3391,19 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
-          "queryString": [
-            {
-              "name": "date_from",
-              "value": "2024-02-11"
-            }
-          ],
-          "headersSize": 395,
+          "queryString": [{ "name": "date_from", "value": "2024-02-11" }],
+          "headersSize": 396,
           "bodySize": 0
         },
         "response": {
@@ -3099,7 +3415,7 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "8145" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:53 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:28:03 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
@@ -3114,24 +3430,31 @@
           "_transferSize": 8303
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 30.538, "receive": 2.965 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 51.309,
+          "receive": 2.38
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:53.708Z",
-        "time": 38.804,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:28:04.155Z",
+        "time": 125.392,
         "request": {
           "method": "GET",
-          "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_routes/list?limit=100&date_from=2024-02-11&date_to=2024-02-12&operator_refs=31&route_short_name=1",
+          "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_routes/list?limit=100&date_from=2024-02-12&date_to=2024-02-12&operator_refs=31&route_short_name=1",
           "httpVersion": "HTTP/2.0",
           "cookies": [],
           "headers": [
@@ -3139,34 +3462,25 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
           "queryString": [
-            {
-              "name": "limit",
-              "value": "100"
-            },
-            {
-              "name": "date_from",
-              "value": "2024-02-11"
-            },
-            {
-              "name": "date_to",
-              "value": "2024-02-12"
-            },
-            {
-              "name": "operator_refs",
-              "value": "31"
-            },
-            {
-              "name": "route_short_name",
-              "value": "1"
-            }
+            { "name": "limit", "value": "100" },
+            { "name": "date_from", "value": "2024-02-12" },
+            { "name": "date_to", "value": "2024-02-12" },
+            { "name": "operator_refs", "value": "31" },
+            { "name": "route_short_name", "value": "1" }
           ],
-          "headersSize": 393,
+          "headersSize": 394,
           "bodySize": 0
         },
         "response": {
@@ -3176,41 +3490,48 @@
           "cookies": [],
           "headers": [
             { "name": "access-control-allow-origin", "value": "*" },
-            { "name": "content-length", "value": "7809" },
+            { "name": "content-length", "value": "3905" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:53 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:28:04 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
           "content": {
-            "size": 7809,
+            "size": 3905,
             "mimeType": "application/json",
             "compression": 0,
-            "text": "[{\"id\":4328515,\"date\":\"2024-02-11\",\"line_ref\":1634,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"מסוף רמז/רציפים-אשקלון<->שד. אליעזר בן יהודה/עולי הגרדום-אשקלון-1#\",\"route_mkt\":\"36001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4328516,\"date\":\"2024-02-11\",\"line_ref\":1636,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"שפירא/התקווה-אשקלון<->מסוף רמז/דוד רמז-אשקלון-2#\",\"route_mkt\":\"36001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4331585,\"date\":\"2024-02-11\",\"line_ref\":16523,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"המעפילים/דניאל-שדרות<->מסוף אזור התעשייה/רומא-שדרות-1#\",\"route_mkt\":\"39001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4331586,\"date\":\"2024-02-11\",\"line_ref\":16524,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"מסוף אזור התעשייה/רומא-שדרות<->המעפילים/דניאל-שדרות-2#\",\"route_mkt\":\"39001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4331598,\"date\":\"2024-02-11\",\"line_ref\":16557,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"מרכז ביג קסטינה-קרית מלאכי<->שדרות אריק שרון-קרית מלאכי-1#\",\"route_mkt\":\"94001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4331599,\"date\":\"2024-02-11\",\"line_ref\":16558,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"שדרות אריק שרון-קרית מלאכי<->מרכז ביג קסטינה-קרית מלאכי-2#\",\"route_mkt\":\"94001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4331600,\"date\":\"2024-02-11\",\"line_ref\":16559,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"שוק עירוני חדש-נתיבות<->ת.רכבת נתיבות/רציפים-נתיבות-1#\",\"route_mkt\":\"95001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4331601,\"date\":\"2024-02-11\",\"line_ref\":16561,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"ת.רכבת נתיבות/רציפים-נתיבות<->שוק עירוני חדש-נתיבות-2#\",\"route_mkt\":\"95001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4331690,\"date\":\"2024-02-11\",\"line_ref\":16688,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"תחנת רכבת קריית גת/יציאה-קרית גת<->מסוף כרמי גת/הורדה-קרית גת-1#\",\"route_mkt\":\"96001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4331691,\"date\":\"2024-02-11\",\"line_ref\":16689,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"מסוף כרמי גת/איסוף-קרית גת<->תחנת רכבת קריית גת/כניסה-קרית גת-2#\",\"route_mkt\":\"96001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4331692,\"date\":\"2024-02-11\",\"line_ref\":16690,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"ת. רכבת אופקים/רציפים-אופקים<->שוק-אופקים-1#\",\"route_mkt\":\"97001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4331693,\"date\":\"2024-02-11\",\"line_ref\":16691,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"שוק-אופקים<->ת. רכבת אופקים/הורדה-אופקים-2#\",\"route_mkt\":\"97001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4335148,\"date\":\"2024-02-12\",\"line_ref\":1634,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"מסוף רמז/רציפים-אשקלון<->שד. אליעזר בן יהודה/עולי הגרדום-אשקלון-1#\",\"route_mkt\":\"36001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4335149,\"date\":\"2024-02-12\",\"line_ref\":1636,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"שפירא/התקווה-אשקלון<->מסוף רמז/דוד רמז-אשקלון-2#\",\"route_mkt\":\"36001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338169,\"date\":\"2024-02-12\",\"line_ref\":16523,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"המעפילים/דניאל-שדרות<->מסוף אזור התעשייה/רומא-שדרות-1#\",\"route_mkt\":\"39001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338170,\"date\":\"2024-02-12\",\"line_ref\":16524,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"מסוף אזור התעשייה/רומא-שדרות<->המעפילים/דניאל-שדרות-2#\",\"route_mkt\":\"39001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338182,\"date\":\"2024-02-12\",\"line_ref\":16557,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"מרכז ביג קסטינה-קרית מלאכי<->שדרות אריק שרון-קרית מלאכי-1#\",\"route_mkt\":\"94001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338183,\"date\":\"2024-02-12\",\"line_ref\":16558,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"שדרות אריק שרון-קרית מלאכי<->מרכז ביג קסטינה-קרית מלאכי-2#\",\"route_mkt\":\"94001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338184,\"date\":\"2024-02-12\",\"line_ref\":16559,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"שוק עירוני חדש-נתיבות<->ת.רכבת נתיבות/רציפים-נתיבות-1#\",\"route_mkt\":\"95001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338185,\"date\":\"2024-02-12\",\"line_ref\":16561,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"ת.רכבת נתיבות/רציפים-נתיבות<->שוק עירוני חדש-נתיבות-2#\",\"route_mkt\":\"95001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338274,\"date\":\"2024-02-12\",\"line_ref\":16688,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"תחנת רכבת קריית גת/יציאה-קרית גת<->מסוף כרמי גת/הורדה-קרית גת-1#\",\"route_mkt\":\"96001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338275,\"date\":\"2024-02-12\",\"line_ref\":16689,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"מסוף כרמי גת/איסוף-קרית גת<->תחנת רכבת קריית גת/כניסה-קרית גת-2#\",\"route_mkt\":\"96001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338276,\"date\":\"2024-02-12\",\"line_ref\":16690,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"ת. רכבת אופקים/רציפים-אופקים<->שוק-אופקים-1#\",\"route_mkt\":\"97001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338277,\"date\":\"2024-02-12\",\"line_ref\":16691,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"שוק-אופקים<->ת. רכבת אופקים/הורדה-אופקים-2#\",\"route_mkt\":\"97001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"}]"
+            "text": "[{\"id\":4335148,\"date\":\"2024-02-12\",\"line_ref\":1634,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"מסוף רמז/רציפים-אשקלון<->שד. אליעזר בן יהודה/עולי הגרדום-אשקלון-1#\",\"route_mkt\":\"36001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4335149,\"date\":\"2024-02-12\",\"line_ref\":1636,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"שפירא/התקווה-אשקלון<->מסוף רמז/דוד רמז-אשקלון-2#\",\"route_mkt\":\"36001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338169,\"date\":\"2024-02-12\",\"line_ref\":16523,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"המעפילים/דניאל-שדרות<->מסוף אזור התעשייה/רומא-שדרות-1#\",\"route_mkt\":\"39001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338170,\"date\":\"2024-02-12\",\"line_ref\":16524,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"מסוף אזור התעשייה/רומא-שדרות<->המעפילים/דניאל-שדרות-2#\",\"route_mkt\":\"39001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338182,\"date\":\"2024-02-12\",\"line_ref\":16557,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"מרכז ביג קסטינה-קרית מלאכי<->שדרות אריק שרון-קרית מלאכי-1#\",\"route_mkt\":\"94001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338183,\"date\":\"2024-02-12\",\"line_ref\":16558,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"שדרות אריק שרון-קרית מלאכי<->מרכז ביג קסטינה-קרית מלאכי-2#\",\"route_mkt\":\"94001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338184,\"date\":\"2024-02-12\",\"line_ref\":16559,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"שוק עירוני חדש-נתיבות<->ת.רכבת נתיבות/רציפים-נתיבות-1#\",\"route_mkt\":\"95001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338185,\"date\":\"2024-02-12\",\"line_ref\":16561,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"ת.רכבת נתיבות/רציפים-נתיבות<->שוק עירוני חדש-נתיבות-2#\",\"route_mkt\":\"95001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338274,\"date\":\"2024-02-12\",\"line_ref\":16688,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"תחנת רכבת קריית גת/יציאה-קרית גת<->מסוף כרמי גת/הורדה-קרית גת-1#\",\"route_mkt\":\"96001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338275,\"date\":\"2024-02-12\",\"line_ref\":16689,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"מסוף כרמי גת/איסוף-קרית גת<->תחנת רכבת קריית גת/כניסה-קרית גת-2#\",\"route_mkt\":\"96001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338276,\"date\":\"2024-02-12\",\"line_ref\":16690,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"ת. רכבת אופקים/רציפים-אופקים<->שוק-אופקים-1#\",\"route_mkt\":\"97001\",\"route_direction\":\"1\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"},{\"id\":4338277,\"date\":\"2024-02-12\",\"line_ref\":16691,\"operator_ref\":31,\"route_short_name\":\"1\",\"route_long_name\":\"שוק-אופקים<->ת. רכבת אופקים/הורדה-אופקים-2#\",\"route_mkt\":\"97001\",\"route_direction\":\"2\",\"route_alternative\":\"#\",\"agency_name\":\"דן בדרום\",\"route_type\":\"3\"}]"
           },
           "headersSize": 0,
-          "bodySize": 7958,
+          "bodySize": 4045,
           "redirectURL": "",
-          "_transferSize": 7958
+          "_transferSize": 4045
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 33.527, "receive": 5.277 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 121.335,
+          "receive": 4.057
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       },
       {
-        "pageref": "page@8e3fdf1fd967def6ccb46271da7b203d",
-        "startedDateTime": "2026-05-29T05:28:54.275Z",
-        "time": 33.034,
+        "pageref": "page@82312af85a77f70a8ed4a1492fbb3e03",
+        "startedDateTime": "2026-06-25T16:28:04.692Z",
+        "time": 77.081,
         "request": {
           "method": "GET",
-          "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_routes/list?limit=100&date_from=2024-02-11&date_to=2024-02-12&operator_refs=31&route_short_name=9999",
+          "url": "https://open-bus-stride-api.hasadna.org.il/gtfs_routes/list?limit=100&date_from=2024-02-12&date_to=2024-02-12&operator_refs=31&route_short_name=9999",
           "httpVersion": "HTTP/2.0",
           "cookies": [],
           "headers": [
@@ -3218,34 +3539,25 @@
             { "name": "Accept-Language", "value": "he-IL" },
             { "name": "Origin", "value": "http://localhost:3000" },
             { "name": "Referer", "value": "http://localhost:3000/" },
-            { "name": "User-Agent", "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.7727.15 Safari/537.36" },
-            { "name": "sec-ch-ua", "value": "\"HeadlessChrome\";v=\"147\", \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"147\"" },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.7778.96 Safari/537.36"
+            },
+            {
+              "name": "sec-ch-ua",
+              "value": "\"Chromium\";v=\"148\", \"HeadlessChrome\";v=\"148\", \"Not/A)Brand\";v=\"99\""
+            },
             { "name": "sec-ch-ua-mobile", "value": "?0" },
             { "name": "sec-ch-ua-platform", "value": "\"Windows\"" }
           ],
           "queryString": [
-            {
-              "name": "limit",
-              "value": "100"
-            },
-            {
-              "name": "date_from",
-              "value": "2024-02-11"
-            },
-            {
-              "name": "date_to",
-              "value": "2024-02-12"
-            },
-            {
-              "name": "operator_refs",
-              "value": "31"
-            },
-            {
-              "name": "route_short_name",
-              "value": "9999"
-            }
+            { "name": "limit", "value": "100" },
+            { "name": "date_from", "value": "2024-02-12" },
+            { "name": "date_to", "value": "2024-02-12" },
+            { "name": "operator_refs", "value": "31" },
+            { "name": "route_short_name", "value": "9999" }
           ],
-          "headersSize": 393,
+          "headersSize": 394,
           "bodySize": 0
         },
         "response": {
@@ -3257,30 +3569,32 @@
             { "name": "access-control-allow-origin", "value": "*" },
             { "name": "content-length", "value": "2" },
             { "name": "content-type", "value": "application/json" },
-            { "name": "date", "value": "Fri, 29 May 2026 05:28:54 GMT" },
+            { "name": "date", "value": "Thu, 25 Jun 2026 16:28:04 GMT" },
             { "name": "strict-transport-security", "value": "max-age=31536000; includeSubDomains" }
           ],
-          "content": {
-            "size": 2,
-            "mimeType": "application/json",
-            "compression": 0,
-            "text": "[]"
-          },
+          "content": { "size": 2, "mimeType": "application/json", "compression": 0, "text": "[]" },
           "headersSize": 0,
           "bodySize": 139,
           "redirectURL": "",
           "_transferSize": 139
         },
         "cache": {},
-        "timings": { "dns": -1, "connect": -1, "ssl": -1, "send": 0, "wait": 30.415, "receive": 2.619 },
-        "serverIPAddress": "83.229.74.225",
+        "timings": {
+          "dns": -1,
+          "connect": -1,
+          "ssl": -1,
+          "send": 0,
+          "wait": 74.441,
+          "receive": 2.64
+        },
+        "serverIPAddress": "83.229.74.240",
         "_serverPort": 443,
         "_securityDetails": {
           "protocol": "TLS 1.2",
           "subjectName": "open-bus-stride-api.hasadna.org.il",
-          "issuer": "R13",
-          "validFrom": 1775355903,
-          "validTo": 1783131902
+          "issuer": "YR2",
+          "validFrom": 1780536423,
+          "validTo": 1788312422
         }
       }
     ]


### PR DESCRIPTION
# Description

API calls that tried to fetch the route list for a specific date but had the `date_from` has taken Israeli midnight and serialized it into UTC time - which is always the previous date.

In `getRoutesAsync` it queried the previous date and the correct date - and the results were filtered client-side.
In `getAllRoutesList` it queried only the previous day - so the operator page was actually showing the routes of a previous day. 

## Fix
* 
* Added regression tests
* re-recorded `timeline.har` (otherwise tests failing)