### PR TITLE
ci: Drop unit-coverage reporting from SonarCloud

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -20,17 +20,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: npm
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run unit tests with coverage
-        run: npx jest --coverage --coverageReporters=lcov
-
       - name: SonarCloud Scan
         if: env.SONAR_TOKEN != ''
         uses: SonarSource/sonarqube-scan-action@v6

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -57,8 +57,7 @@ jobs:
         run: npm run lint
       - name: Check for circular dependencies
         run: npx madge --extensions js,ts --circular .
-      # Jest gates merges here: this is the only required check that runs it.
-      # (sonarcloud.yml also runs jest, for unit coverage, but isn't required.)
+      # Jest gates merges here: this is the only job in CI that runs it.
       - name: Run unit tests
         run: npm run test:unit
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,9 +6,5 @@ sonar.sources=src
 sonar.tests=src
 sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts
 sonar.exclusions=**/node_modules/**,**/*.stories.tsx
-sonar.coverage.exclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.stories.tsx
-
-sonar.javascript.lcov.reportPaths=coverage/lcov.info
-sonar.typescript.lcov.reportPaths=coverage/lcov.info
 
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
# Description
Removed jest coverage from SonarCloud checks.

SonarCloud measured unit-test coverage on PRs - which only checks number of rows covered, not the quality of the testing.

On the other hand, it leaves red status check line on most PRs - so it became a constant noise that don't worth the value it adds.