### PR TITLE
fix: allow github.com in CSP so about page contributors load

### DIFF
--- a/nginx-default.conf
+++ b/nginx-default.conf
@@ -42,10 +42,11 @@ server {
         # - script-src: no 'unsafe-inline'/'unsafe-eval' (built index.html has no inline scripts); GA/GTM hosts load the analytics scripts.
         # - style-src-elem 'unsafe-inline': MUI/emotion and styled-components inject runtime <style> elements. style-src omits
         #   'unsafe-inline', so inline style="" attributes stay blocked (the app sets none — React style={{}} writes via the CSSOM).
-        # - img-src: openstreetmap tiles, google-analytics beacon pixels.
-        # - connect-src: *.hasadna.org.il for the stride/backend APIs, google-analytics/googletagmanager for analytics.
+        # - img-src: openstreetmap tiles, google-analytics beacon pixels, avatars.githubusercontent.com for the about page's contributor avatars.
+        # - connect-src: *.hasadna.org.il for the stride/backend APIs, google-analytics/googletagmanager for analytics,
+        #   api.github.com for the about page's contributor list.
         # - frame-src: youtube(-nocookie).com instruction videos, docs.google.com hackathon registration form.
         # - frame-ancestors 'self': CSP3 clickjacking control; same effect as the X-Frame-Options SAMEORIGIN above.
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://www.google-analytics.com https://www.googletagmanager.com; style-src 'self'; style-src-elem 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.openstreetmap.fr https://*.openstreetmap.org https://www.google-analytics.com; connect-src 'self' https://*.hasadna.org.il https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://docs.google.com; worker-src 'self' blob:; frame-ancestors 'self';" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://www.google-analytics.com https://www.googletagmanager.com; style-src 'self'; style-src-elem 'self' 'unsafe-inline'; img-src 'self' data: blob: https://*.openstreetmap.fr https://*.openstreetmap.org https://www.google-analytics.com https://avatars.githubusercontent.com; connect-src 'self' https://*.hasadna.org.il https://www.google-analytics.com https://region1.google-analytics.com https://www.googletagmanager.com https://api.github.com; frame-src 'self' https://www.youtube.com https://www.youtube-nocookie.com https://docs.google.com; worker-src 'self' blob:; frame-ancestors 'self';" always;
     }
 }


### PR DESCRIPTION
# Description

Relaxed the nginx CSP to enable the contributors on About page to render:
- img-src: https://avatars.githubusercontent.com
- connect-src: https://api.github.com
