### PR TITLE
revert: remove PWTEST_CHILD_PROCESS_TIMEOUT workaround (#1759)

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -318,7 +318,6 @@ jobs:
       - name: Run Playwright Visual Tests
         env:
           APPLITOOLS_BATCH_NAME: open-bus-map-search/${{ github.ref }}/${{ env.SHORT_SHA }}/
-          PWTEST_CHILD_PROCESS_TIMEOUT: '1800000' # 30 min; default 300000 force-kills slow UFG result collection → false CI failure
         run: npm run test:e2e:visual
       - name: Prepare Playwright artifact directory
         if: always()


### PR DESCRIPTION
# Description

Closes #1759.

Removed `PWTEST_CHILD_PROCESS_TIMEOUT` environment variable from `validate.yaml` as Playwright has resolved the underlying issue in `microsoft/playwright#42007`.

## screenshots

N/A (CI configuration change only)