### PR TITLE
fix: pin the Applitools app name for both visual test runners

### DIFF
--- a/applitools.config.cjs
+++ b/applitools.config.cjs
@@ -4,6 +4,10 @@
  * @type {import('@applitools/eyes-storybook').ApplitoolsConfig}
  */
 const config = {
+  // Pin the Applitools app explicitly: unset, eyes-storybook falls back to the
+  // package.json name, putting the story baselines in a different app than the
+  // Playwright ones.
+  appName: 'OpenBus',
   testConcurrency: 20,
   dontCloseBatches: true,
   // 'nodiffs': visual diffs don't fail the job (the github integration reports them via a separate

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -44,6 +44,9 @@ export default defineConfig<EyesFixture>({
     serviceWorkers: 'block',
 
     eyesConfig: {
+      // Pin the Applitools app explicitly: unset, the fixture silently defaults to
+      // 'My App', which strands every baseline in a shared junk-drawer app.
+      appName: 'OpenBus',
       type: 'ufg',
       isDisabled: !process.env.APPLITOOLS_API_KEY,
       failTestsOnDiff: false,


### PR DESCRIPTION
# Description

Fix a SUSPECTED root cause of the Applitools Eyes baseline auto-merge failure.

Before #1454 there was the line:
```
        await eyes.open(page, 'OpenBus', testinfo.title)
```
in `tests/visual.spec.ts:35`

Which gave this App Name to both playwright and storybooks tests.

Since #1454 the playwright tests got the SDK fallback "My App" name, and the storybook defaulted to the `package.json` name: "open-bus-map-search".

The github integration on applitools side was maybe tied to the name "OpenBus" so that stopped working once the tests started to report another name.

### Note
Looks like it started to fail on 28/02/2026 when #1454 was merged. Some PRs that was created **before** and started **after** still worked.
The only thing that contradict the theory are #1479 #1472 and #1480 that were opened after the regression and still seem to report "Successfully merged baselines! (0 changes found)".

## screenshots
### The `OpenBus` app last run:
<img width="1855" height="950" alt="image" src="https://github.com/user-attachments/assets/6faffdf2-c661-47e2-9aec-53de11133527" />

### The `My App` app last run today (storybook never goes here):
<img width="1855" height="950" alt="image" src="https://github.com/user-attachments/assets/ee3b3eb2-2e6c-49bc-926f-20ce2681731a" />

### The `My App` app is the SDK fallback for undefined, and every casual test falls there:
<img width="1811" height="818" alt="image" src="https://github.com/user-attachments/assets/7ebf71fb-df09-4e9f-91cd-8d42336e4613" />

### The `open-bus-map-search` app is storybook only:
<img width="1657" height="1027" alt="image" src="https://github.com/user-attachments/assets/8a46160b-f04a-48e5-a256-69a24e0bd385" />
