### PR TITLE
fix: stop the date picker from resetting while a date is typed

### DIFF
--- a/src/pages/components/DateSelector.tsx
+++ b/src/pages/components/DateSelector.tsx
@@ -40,7 +40,13 @@ export function DateSelector({
   return (
     <DatePicker
       value={time}
-      onChange={onChange}
+      onChange={(value, context) => {
+        // The field fires on every keystroke, so a half-typed date arrives
+        // here as an invalid one, and a date outside minDate/maxDate arrives
+        // as-is. Forwarding those overwrites whatever the user is typing.
+        if (context.validationError) return
+        onChange(value)
+      }}
       format="DD/MM/YYYY"
       label={customLabel || t('choose_date')}
       disableFuture


### PR DESCRIPTION
Fixes #1822: a user reported that the date field cannot be typed into. It
jumps back to the current date or to an unrelated year, with no way to
change it.

## Root cause

`DatePicker` fires `onChange` on every keystroke, so while `21/03/2026` is
being typed the intermediate values are incomplete dates. `DateSelector`
forwarded all of them:

```tsx
<DatePicker value={time} onChange={onChange} ... />
```

The pages then commit whatever arrives. In `singleLineMap`, `vehicle`,
`operator` and `velocityHeatmap` the handler reads
`toIsraelTimezone(time ?? dayjs())`, so a `null` becomes **today** and the
field visibly snaps back to the current date, which is what the report
describes.

The part worth flagging: MUI already knows the value is not acceptable. It
passes a second argument to `onChange` carrying `validationError`, which
covers `invalidDate`, `minDate`, `maxDate` and `disableFuture`. The
component was reading that error in `onError` to render the helper text,
while `onChange` ignored it and forwarded the value anyway.

## Fix

Forward the change only when there is no validation error:

```tsx
onChange={(value, context) => {
  if (context.validationError) return
  onChange(value)
}}
```

One place instead of seven call sites, and it also stops out-of-range and
future dates from being committed, not just half-typed ones.

## Notes

- #1821 is an exact duplicate of #1822, submitted 4ms apart. The bug report
  form appears to double-submit, which may be worth a separate issue.
- `npm run lint` and `npm run test:unit` pass (235 tests).
