### PR TITLE
fix: stop the date field from rewriting what the user is typing

### DIFF
--- a/src/pages/components/DateSelector.tsx
+++ b/src/pages/components/DateSelector.tsx
@@ -40,7 +40,13 @@ export function DateSelector({
   return (
     <DatePicker
       value={time}
-      onChange={onChange}
+      onChange={(value, context) => {
+        // The field fires on every keystroke, so a half-typed date arrives
+        // here as an invalid one, and a date outside minDate/maxDate arrives
+        // as-is. Forwarding those overwrites whatever the user is typing.
+        if (context.validationError) return
+        onChange(value)
+      }}
       format="DD/MM/YYYY"
       label={customLabel || t('choose_date')}
       disableFuture

--- a/src/pages/components/DateSelector.tsx
+++ b/src/pages/components/DateSelector.tsx
@@ -41,9 +41,9 @@ export function DateSelector({
     <DatePicker
       value={time}
       onChange={(value, context) => {
-        // The field fires on every keystroke, so a half-typed date arrives
-        // here as an invalid one, and a date outside minDate/maxDate arrives
-        // as-is. Forwarding those overwrites whatever the user is typing.
+        // The field fires on every keystroke, so a half-typed date arrives here
+        // as invalid. Forwarding it overwrites the sections the user is still
+        // editing, and on the dashboard it reaches groupByService and throws.
         if (context.validationError) return
         onChange(value)
       }}


### PR DESCRIPTION
Closes #1822. Full investigation in #1839.

`DateSelector` forwarded every `onChange`, including the ones MUI had already
rejected through `context.validationError`, so half-typed dates reached the
pages and overwrote the sections the user was still editing. On `/dashboard`
an `Invalid Date` reached `groupByService` and crashed the page.

Typing `21032026` gave 31/07/2026 before, and gives 21/03/2026 now. Picking
from the calendar is unaffected.

The timezone side of this (the field carrying an instant instead of a calendar
day) is not touched here. It is described in #1839 along with the risk of
changing it.
