### PR TITLE
revert: storybook mocking migration to sb.mock()

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,16 +3,9 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { initialize, mswLoader } from 'msw-storybook-addon'
 import { Suspense, useEffect } from 'react'
 import { BrowserRouter } from 'react-router'
-import { sb } from 'storybook/test'
 import { ThemeProvider, useTheme } from 'src/layout/ThemeContext'
 import i18n from 'src/locale/allTranslations'
 import 'src/index.scss'
-
-sb.mock(import('../src/api/groupByService.ts'))
-sb.mock(import('../src/api/gtfsService.ts'))
-sb.mock(import('../src/hooks/useFormQuerys.ts'))
-sb.mock(import('../src/api/agencyList.ts'))
-sb.mock(import('../src/pages/velocityHeatmap/useVelocityAggregationData.ts'))
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/src/pages/components/map-related/MapLayers/BusToolTip.stories.tsx
+++ b/src/pages/components/map-related/MapLayers/BusToolTip.stories.tsx
@@ -1,7 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { mocked } from 'storybook/test'
-import { getRoutesByLineRef } from 'src/api/gtfsService'
+import { http, HttpResponse } from 'msw'
 import Widget from 'src/shared/Widget'
+import {
+  busToolTipMockedRoute,
+  busToolTipMockedSiriRides,
+} from '../../../../../.storybook/mockData'
 import { BusToolTip, BusToolTipProps } from './BusToolTip'
 
 const meta = {
@@ -23,19 +26,37 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
-const mockedRoute = {
-  id: 3753789,
-  date: new Date('2023-11-01'),
-  lineRef: 2974,
-  operatorRef: 3,
-  routeShortName: '1',
-  routeLongName: 'שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#',
-  routeMkt: '33001',
-  routeDirection: '3',
-  routeAlternative: '#',
-  agencyName: 'אגד',
-  routeType: '3',
-}
+const routeHandler = http.get(
+  (info) => new URL(info.request.url).pathname === '/gtfs_routes/list',
+  ({ request }) => {
+    const { searchParams } = new URL(request.url)
+    const matchesLineRef = searchParams.get('line_refs') === '2974'
+    const matchesOperatorRef = searchParams.get('operator_refs') === '3'
+
+    if (!matchesLineRef || !matchesOperatorRef) {
+      return HttpResponse.json()
+    }
+
+    return HttpResponse.json(busToolTipMockedRoute)
+  },
+)
+
+const ridesHandler = http.get(
+  (info) => new URL(info.request.url).pathname === '/siri_rides/list',
+  ({ request }) => {
+    const { searchParams } = new URL(request.url)
+
+    const matchesLineRef = searchParams.get('siri_route__line_refs') === '2974'
+    const matchesRouteRef = searchParams.get('siri_route_ids') === '973'
+    const matchesVehicleRef = searchParams.get('vehicle_refs') === '23321002'
+
+    if (!matchesLineRef || !matchesRouteRef || !matchesVehicleRef) {
+      return HttpResponse.json()
+    }
+
+    return HttpResponse.json(busToolTipMockedSiriRides)
+  },
+)
 
 const defaultArgs: BusToolTipProps = {
   position: {
@@ -73,15 +94,19 @@ const defaultArgs: BusToolTipProps = {
 }
 
 export const Default: Story = {
-  beforeEach: () => {
-    mocked(getRoutesByLineRef).mockResolvedValue([mockedRoute])
+  parameters: {
+    msw: {
+      handlers: [routeHandler, ridesHandler],
+    },
   },
   args: defaultArgs,
 }
 
 export const WithComplaint: Story = {
-  beforeEach: () => {
-    mocked(getRoutesByLineRef).mockResolvedValue([mockedRoute])
+  parameters: {
+    msw: {
+      handlers: [routeHandler, ridesHandler],
+    },
   },
   args: defaultArgs,
   play: async ({ canvasElement, userEvent }) => {

--- a/src/pages/components/map-related/MapLayers/ComplaintModal.stories.tsx
+++ b/src/pages/components/map-related/MapLayers/ComplaintModal.stories.tsx
@@ -1,8 +1,8 @@
 import type { GtfsRoutePydanticModel } from '@hasadna/open-bus-api-client'
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { http, HttpResponse } from 'msw'
 import { useState } from 'react'
-import { mocked } from 'storybook/test'
-import { useBusOperatorQuery, useCitiesQuery } from 'src/hooks/useFormQuerys'
+import { busToolTipMockedSiriRides } from '../../../../../.storybook/mockData'
 import type { BusToolTipProps } from './BusToolTip'
 import ComplaintModal from './ComplaintModal'
 
@@ -63,6 +63,32 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+const siriRidesHandler = http.get(
+  (info) => new URL(info.request.url).pathname === '/siri_rides/list',
+  ({ request }) => {
+    const { searchParams } = new URL(request.url)
+    const matchesRouteId = searchParams.get('siri_route_ids') === '973'
+    const matchesLineRef = searchParams.get('siri_route__line_refs') === '2974'
+    const matchesVehicleRef = searchParams.get('vehicle_refs') === '23321002'
+
+    if (!matchesRouteId || !matchesLineRef || !matchesVehicleRef) {
+      return HttpResponse.json([])
+    }
+
+    return HttpResponse.json(busToolTipMockedSiriRides)
+  },
+)
+
+const operatorsHandler = http.get(
+  (info) => new URL(info.request.url).pathname === '/gov/operators',
+  () => HttpResponse.json({ success: true, data: [{ dataText: 'אגד', dataCode: 3 }] }),
+)
+
+const citiesHandler = http.get(
+  (info) => new URL(info.request.url).pathname === '/gov/cities',
+  () => HttpResponse.json({ success: true, data: [{ dataText: 'גדרה', dataCode: 2550 }] }),
+)
+
 const defaultArgs: BusToolTipProps & { route: GtfsRoutePydanticModel } = {
   position: {
     loc: [31.799982, 34.786926],
@@ -112,19 +138,10 @@ const defaultArgs: BusToolTipProps & { route: GtfsRoutePydanticModel } = {
 }
 
 export const Default: Story = {
-  beforeEach: () => {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- partial UseQueryResult mock
-    mocked(useBusOperatorQuery).mockReturnValue({
-      data: [{ dataText: 'אגד', dataCode: 3 }],
-      isLoading: false,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any)
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument -- partial UseQueryResult mock
-    mocked(useCitiesQuery).mockReturnValue({
-      data: [{ dataText: 'גדרה', dataCode: 2550 }],
-      isLoading: false,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    } as any)
+  parameters: {
+    msw: {
+      handlers: [siriRidesHandler, operatorsHandler, citiesHandler],
+    },
   },
   args: {
     position: defaultArgs.position,

--- a/src/pages/components/map-related/MapWithLocationsAndPath.stories.tsx
+++ b/src/pages/components/map-related/MapWithLocationsAndPath.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { mocked } from 'storybook/test'
-import { getAgencyList } from 'src/api/agencyList'
+import { http, HttpResponse } from 'msw'
 import { plannedRouteStops, positionGroups } from './mapStorybookData'
 import { MapWithLocationsAndPath } from './MapWithLocationsAndPath'
 
@@ -43,12 +42,18 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {}
 
 export const WhitData: Story = {
-  beforeEach: () => {
-    mocked(getAgencyList).mockResolvedValue([
-      { date: new Date('2024-02-11'), operatorRef: 3, agencyName: 'אגד' },
-      { date: new Date('2024-02-11'), operatorRef: 5, agencyName: 'דן' },
-      { date: new Date('2024-02-11'), operatorRef: 18, agencyName: 'קווים' },
-    ])
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(
+          (info) => new URL(info.request.url).pathname === '/gtfs_agencies/list',
+          async () => {
+            const { agencies } = await import('../../../../.storybook/mockData')
+            return HttpResponse.json(agencies)
+          },
+        ),
+      ],
+    },
   },
   args: {
     plannedRouteStops: plannedRouteStops,

--- a/src/pages/dashboard/AllLineschart/AllLinesChart.stories.tsx
+++ b/src/pages/dashboard/AllLineschart/AllLinesChart.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { mocked } from 'storybook/test'
-import { useGroupBy } from 'src/api/groupByService'
+import { http, HttpResponse } from 'msw'
 import dayjs from 'src/dayjs'
 import { getPastDate } from '../../../../.storybook/main'
 import AllLinesChart from './AllLinesChart'
@@ -39,34 +38,19 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+const URL =
+  'https://open-bus-stride-api.hasadna.org.il/gtfs_rides_agg/group_by?date_from=2024-02-05&date_to=2024-02-12&group_by=operator_ref&exclude_hour_from=23&exclude_hour_to=2'
+
 export const Default: Story = {
-  beforeEach: () => {
-    mocked(useGroupBy).mockReturnValue([
-      [
-        {
-          totalRoutes: 20235,
-          totalPlannedRides: 47824,
-          totalActualRides: 46939,
-          operatorRef: {
-            date: new Date('2024-02-11'),
-            operatorRef: 3,
-            agencyName: 'אגד',
-          },
-        },
-        {
-          totalRoutes: 6686,
-          totalPlannedRides: 24970,
-          totalActualRides: 24833,
-          operatorRef: {
-            date: new Date('2024-02-11'),
-            operatorRef: 5,
-            agencyName: 'דן',
-          },
-        },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(URL, async () => {
+          const { allLineMock } = await import('../../../../.storybook/mockData')
+          return HttpResponse.json(allLineMock)
+        }),
       ],
-      false,
-      null,
-    ])
+    },
   },
   args: {
     startDate: dayjs(getPastDate()).subtract(7, 'day'),

--- a/src/pages/dashboard/ArrivalByTimeChart/DayTimeChart.stories.tsx
+++ b/src/pages/dashboard/ArrivalByTimeChart/DayTimeChart.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { mocked } from 'storybook/test'
-import { useGroupBy } from 'src/api/groupByService'
+import { http, HttpResponse } from 'msw'
 import dayjs from 'src/dayjs'
 import { getPastDate } from '../../../../.storybook/main'
 import DayTimeChart from './DayTimeChart'
@@ -46,25 +45,19 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+const URL =
+  'https://open-bus-stride-api.hasadna.org.il/gtfs_rides_agg/group_by?date_from=2024-02-05&date_to=2024-02-12&group_by=operator_ref,gtfs_route_date&exclude_hour_from=23&exclude_hour_to=2'
+
 export const Default: Story = {
-  beforeEach: () => {
-    mocked(useGroupBy).mockReturnValue([
-      [
-        {
-          gtfsRouteDate: new Date('2024-02-11'),
-          totalRoutes: 20235,
-          totalPlannedRides: 47824,
-          totalActualRides: 46939,
-          operatorRef: {
-            date: new Date('2024-02-11'),
-            operatorRef: 3,
-            agencyName: 'אגד',
-          },
-        },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(URL, async () => {
+          const { arrivalByTimeChart } = await import('../../../../.storybook/mockData')
+          return HttpResponse.json(arrivalByTimeChart)
+        }),
       ],
-      false,
-      null,
-    ])
+    },
   },
   args: {
     startDate: dayjs(getPastDate()).subtract(7, 'day'),

--- a/src/pages/dashboard/WorstLinesChart/WorstLinesChart.stories.tsx
+++ b/src/pages/dashboard/WorstLinesChart/WorstLinesChart.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { mocked } from 'storybook/test'
-import { useGroupBy } from 'src/api/groupByService'
+import { http, HttpResponse } from 'msw'
 import dayjs from 'src/dayjs'
 import { getPastDate } from '../../../../.storybook/main'
 import WorstLinesChart from './WorstLinesChart'
@@ -43,27 +42,19 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+const URL =
+  'https://open-bus-stride-api.hasadna.org.il/gtfs_rides_agg/group_by?date_from=2024-02-05&date_to=2024-02-12&group_by=operator_ref,line_ref&exclude_hour_from=23&exclude_hour_to=2'
+
 export const Default: Story = {
-  beforeEach: () => {
-    mocked(useGroupBy).mockReturnValue([
-      [
-        {
-          lineRef: 2974,
-          routeShortName: "['1']",
-          routeLongName: 'שדרות מנחם בגין/כביש 7-גדרה<->שדרות מנחם בגין/כביש 7-גדרה-3#',
-          totalRoutes: 20,
-          totalPlannedRides: 100,
-          totalActualRides: 40,
-          operatorRef: {
-            date: new Date('2024-02-11'),
-            operatorRef: 3,
-            agencyName: 'אגד',
-          },
-        },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(URL, async () => {
+          const { worstLinesChart } = await import('../../../../.storybook/mockData')
+          return HttpResponse.json(worstLinesChart)
+        }),
       ],
-      false,
-      null,
-    ])
+    },
   },
   args: {
     startDate: dayjs(getPastDate()).subtract(7, 'day'),

--- a/src/pages/operator/OperatorGaps.stories.tsx
+++ b/src/pages/operator/OperatorGaps.stories.tsx
@@ -1,6 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { mocked } from 'storybook/test'
-import { useGroupBy } from 'src/api/groupByService'
+import { http, HttpResponse } from 'msw'
 import dayjs from 'src/dayjs'
 import { getPastDate } from '../../../.storybook/main'
 import { OperatorGaps } from './OperatorGaps'
@@ -29,24 +28,19 @@ export default meta
 
 type Story = StoryObj<typeof meta>
 
+const URL =
+  'https://open-bus-stride-api.hasadna.org.il/gtfs_rides_agg/group_by?date_from=2024-02-11&date_to=2024-02-12&group_by=operator_ref&exclude_hour_from=23&exclude_hour_to=2'
+
 export const Default: Story = {
-  beforeEach: () => {
-    mocked(useGroupBy).mockReturnValue([
-      [
-        {
-          totalRoutes: 20235,
-          totalPlannedRides: 47824,
-          totalActualRides: 46939,
-          operatorRef: {
-            date: new Date('2024-02-11'),
-            operatorRef: 3,
-            agencyName: 'Egged',
-          },
-        },
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(URL, async () => {
+          const { operatorGaps } = await import('../../../.storybook/mockData')
+          return HttpResponse.json(operatorGaps)
+        }),
       ],
-      false,
-      null,
-    ])
+    },
   },
   args: {
     operatorId: '3',

--- a/src/pages/operator/OperatorRoutes.stories.tsx
+++ b/src/pages/operator/OperatorRoutes.stories.tsx
@@ -1,7 +1,6 @@
-import { GtfsRoutePydanticModelFromJSON } from '@hasadna/open-bus-api-client'
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { expect, mocked, userEvent, waitFor, within } from 'storybook/test'
-import { getAllRoutesList } from 'src/api/gtfsService'
+import { delay, http, HttpResponse } from 'msw'
+import { expect, userEvent, waitFor, within } from 'storybook/test'
 import dayjs from 'src/dayjs'
 import i18n from 'src/locale/allTranslations'
 import { ISRAEL_TRAIN_ID } from 'src/model/operator'
@@ -10,14 +9,17 @@ import { OperatorRoutes } from './OperatorRoutes'
 
 const DATE = dayjs(getPastDate()).format('YYYY-MM-DD')
 
+// MSW matches by pathname (query params are ignored), so a single wildcard
+// handler serves every operatorId/limit/date the component asks for.
+const routesHandler = (resolver: Parameters<typeof http.get>[1]) =>
+  http.get('*/gtfs_routes/list', resolver)
+
 // The mock dataset is the full אגד route list (1243 routes → 354 line groups),
 // shared with the e2e HAR, so the line/city assertions below stay in sync.
-const mockWithRoutes = async () => {
+const withRoutes = routesHandler(async () => {
   const { operatorRoutes } = await import('../../../.storybook/mockData')
-  mocked(getAllRoutesList).mockResolvedValue(
-    operatorRoutes.map((route) => GtfsRoutePydanticModelFromJSON(route)),
-  )
-}
+  return HttpResponse.json(operatorRoutes)
+})
 
 // Real רכבת ישראל (operator 2) routes, fetched verbatim from the Stride API
 // (gtfs_routes/list?operator_refs=2) for 2024-02-12 — the same date the rest of
@@ -92,11 +94,7 @@ const trainRoutes = [
   },
 ]
 
-const mockWithTrainRoutes = () => {
-  mocked(getAllRoutesList).mockResolvedValue(
-    trainRoutes.map((route) => GtfsRoutePydanticModelFromJSON(route)),
-  )
-}
+const withTrainRoutes = routesHandler(() => HttpResponse.json(trainRoutes))
 
 // Read the line labels rendered in the (collapsed) accordion headers.
 const groupLabels = (canvasElement: HTMLElement) =>
@@ -121,7 +119,9 @@ const meta = {
     operatorId: '3',
     date: DATE,
   },
-  beforeEach: mockWithRoutes,
+  parameters: {
+    msw: { handlers: [withRoutes] },
+  },
   decorators: [
     (Story) => (
       <div style={{ minWidth: 700 }}>
@@ -140,15 +140,22 @@ export const Default: Story = {}
 
 /** Skeleton placeholder while the routes request is in flight. */
 export const Loading: Story = {
-  beforeEach: () => {
-    mocked(getAllRoutesList).mockImplementation(() => new Promise(() => {}))
+  parameters: {
+    msw: {
+      handlers: [
+        routesHandler(async () => {
+          await delay('infinite')
+          return HttpResponse.json([])
+        }),
+      ],
+    },
   },
 }
 
 /** Operator with no routes for the selected date — no search box, no list. */
 export const Empty: Story = {
-  beforeEach: () => {
-    mocked(getAllRoutesList).mockResolvedValue([])
+  parameters: {
+    msw: { handlers: [routesHandler(() => HttpResponse.json([]))] },
   },
 }
 
@@ -212,7 +219,9 @@ export const TrainOperator: Story = {
     operatorId: ISRAEL_TRAIN_ID,
     date: DATE,
   },
-  beforeEach: mockWithTrainRoutes,
+  parameters: {
+    msw: { handlers: [withTrainRoutes] },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     const firstGroup = await waitFor(() =>

--- a/src/pages/velocityHeatmap/components/VelocityHeatmapRectangles.stories.tsx
+++ b/src/pages/velocityHeatmap/components/VelocityHeatmapRectangles.stories.tsx
@@ -1,10 +1,8 @@
-import { SiriVelocityAggregationPydanticModelFromJSON } from '@hasadna/open-bus-api-client'
 import type { Meta, StoryObj } from '@storybook/react-vite'
+import { http, HttpResponse } from 'msw'
 import { TileLayer } from 'react-leaflet'
-import { mocked } from 'storybook/test'
 import { MapShell } from 'src/pages/components/map-related/MapShell'
 import { velocityAggregation } from '../../../../.storybook/mockData'
-import { useVelocityAggregationData } from '../useVelocityAggregationData'
 import { VelocityHeatmapLegend } from './VelocityHeatmapLegend'
 import { VelocityHeatmapRectangles } from './VelocityHeatmapRectangles'
 
@@ -68,31 +66,27 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 const parameters = {
+  msw: {
+    handlers: [
+      http.get(
+        'https://open-bus-stride-api.hasadna.org.il/siri_velocity_aggregation/siri_velocity_aggregation',
+        () => HttpResponse.json(velocityAggregation),
+      ),
+    ],
+  },
   eyes: {
     waitBeforeCapture: '.leaflet-overlay-pane path',
   },
 }
 
-const mockVelocityData = () => {
-  const data = velocityAggregation.map((row) => SiriVelocityAggregationPydanticModelFromJSON(row))
-  mocked(useVelocityAggregationData).mockReturnValue({
-    data,
-    loading: false,
-    error: null,
-    currZoom: 13,
-  })
-}
-
-export const Default: Story = { parameters, beforeEach: mockVelocityData }
+export const Default: Story = { parameters }
 
 export const StdDev: Story = {
   args: { visMode: 'std' },
   parameters,
-  beforeEach: mockVelocityData,
 }
 
 export const CoeffOfVar: Story = {
   args: { visMode: 'cv' },
   parameters,
-  beforeEach: mockVelocityData,
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "allowImportingTsExtensions": true,
     "jsx": "react-jsx",
     "types": ["vite/client", "node", "vitest/globals"]
   },


### PR DESCRIPTION
Reverts #1832. Six storybook stories have rendered nothing on main since it
merged, and Storybook Visual Tests has been red. The mechanism is written up in
https://github.com/hasadna/open-bus-map-search/pull/1832#issuecomment-5501171923

Reverting rather than fixing forward, because the right fix turns on a decision
that is not mine to make: whether the plain automock was deliberate. This puts
the tree back to 59a8b3a exactly.

## Redoing it

#1455 is still worth doing. The trap is that `sb.mock()` lives in `preview.tsx`
and is global by construction, so automocking a module obliges every story that
reaches it to declare its own mock, and nothing today enforces or reveals that.
The PR audited the eight stories it migrated. MapContent.stories.tsx, which it
never touched, broke anyway.

The rule that prevents it is small: every story runs in CI, and a missing mock
fails. That needs no Applitools key, because it never compares against a
baseline. It only asks whether a story runs at all, which is a different
question from whether it still looks the same, and it is the one nothing
currently asks.

Two questions before I write that up as an issue:

1. Was `@storybook/addon-vitest` considered during the v10 upgrade in #1452? It
   would run the stories as tests on every PR, forks included.
2. Is there a supported way to make an automocked export fail loudly instead of
   returning `undefined`? The type in `storybook/test` only exposes
   `{ spy?: boolean }`, so I may be missing the mechanism.

Happy to open the issue and do the work once those are settled.
