### PR TITLE
fix: Role of modal buttons

### DIFF
--- a/src/layout/header/ShareButton.tsx
+++ b/src/layout/header/ShareButton.tsx
@@ -43,12 +43,13 @@ export const ShareButton = () => {
 
   return (
     <Tooltip title={tooltipTitle} open={copied || undefined} placement="bottomRight">
-      <div
+      <button
+        type="button"
         className="header-link"
         onClick={handleShare}
         aria-label={copied ? t('link_copied') : t('share_link')}>
         {copied ? <CheckTwoTone fontSize="inherit" /> : <LinkTwoTone fontSize="inherit" />}
-      </div>
+      </button>
     </Tooltip>
   )
 }

--- a/src/pages/components/YotubeModal.scss
+++ b/src/pages/components/YotubeModal.scss
@@ -9,7 +9,6 @@
 
   // the icon is sized with fontSize="inherit" from the surrounding heading
   font: inherit;
-  color: inherit;
 }
 
 .modal-iframe-container {

--- a/src/pages/components/YotubeModal.scss
+++ b/src/pages/components/YotubeModal.scss
@@ -3,6 +3,13 @@
   align-items: center;
   margin: auto 12px;
   cursor: pointer;
+  padding: 0;
+  border: none;
+  background: none;
+
+  // the icon is sized with fontSize="inherit" from the surrounding heading
+  font: inherit;
+  color: inherit;
 }
 
 .modal-iframe-container {

--- a/src/pages/components/YotubeModal.scss
+++ b/src/pages/components/YotubeModal.scss
@@ -9,6 +9,7 @@
 
   // the icon is sized with fontSize="inherit" from the surrounding heading
   font: inherit;
+  color: inherit;
 }
 
 .modal-iframe-container {

--- a/src/pages/components/YoutubeModal.tsx
+++ b/src/pages/components/YoutubeModal.tsx
@@ -15,15 +15,13 @@ const InfoYoutubeModal = ({ videoUrl, label, title }: InfoYoutubeModalProps) => 
 
   return (
     <>
-      {/* span carries the label/click like the old antd icon wrapper, so the
-          aria-labelled element keeps an svg descendant (tests rely on it) */}
-      <span
-        role="img"
+      <button
+        type="button"
         aria-label={label}
         className="modal-info-ico"
         onClick={() => setVisible(true)}>
         <HelpTwoTone fontSize="inherit" />
-      </span>
+      </button>
       <Modal
         width={'1000px'}
         footer={null}

--- a/src/pages/components/YoutubeModal.tsx
+++ b/src/pages/components/YoutubeModal.tsx
@@ -20,7 +20,7 @@ const InfoYoutubeModal = ({ videoUrl, label, title }: InfoYoutubeModalProps) => 
         aria-label={label}
         className="modal-info-ico"
         onClick={() => setVisible(true)}>
-        <HelpTwoTone fontSize="inherit" color="primary" />
+        <HelpTwoTone fontSize="inherit" />
       </button>
       <Modal
         width={'1000px'}

--- a/src/pages/components/YoutubeModal.tsx
+++ b/src/pages/components/YoutubeModal.tsx
@@ -20,7 +20,7 @@ const InfoYoutubeModal = ({ videoUrl, label, title }: InfoYoutubeModalProps) => 
         aria-label={label}
         className="modal-info-ico"
         onClick={() => setVisible(true)}>
-        <HelpTwoTone fontSize="inherit" />
+        <HelpTwoTone fontSize="inherit" color="primary" />
       </button>
       <Modal
         width={'1000px'}


### PR DESCRIPTION
# Description
Convert the element of the video modal button and shareUrl button to `button` to fix the sonarcloud constant error on push commits.