### PR TITLE
chore: drop unused @applitools/eyes-storybook devDependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,16 +74,16 @@ Open [http://localhost:3000](http://localhost:3000).
 
 ## 🧪 Testing
 
-| Command                   | Description                                                 |
-| ------------------------- | ----------------------------------------------------------- |
-| `npm run test`            | Run Vitest + Playwright tests (excluding visual tests)      |
-| `npm run test:unit`       | Run Vitest unit tests                                       |
-| `npm run test:unit:watch` | Run Vitest unit tests in watch mode                         |
-| `npm run test:unit:ci`    | Run Vitest with coverage                                    |
-| `npm run test:e2e`        | Run Playwright end-to-end tests                             |
-| `npm run test:e2e:ui`     | Run Playwright tests with interactive UI                    |
-| `npm run test:e2e:visual` | Run visual regression tests with (Playwright + Applitools ) |
-| `npm run test:storybook`  | Run Storybook visual tests with (Applitools)                |
+| Command                   | Description                                                                                                         |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `npm run test`            | Run Vitest + Playwright tests (excluding visual tests)                                                              |
+| `npm run test:unit`       | Run Vitest unit tests                                                                                               |
+| `npm run test:unit:watch` | Run Vitest unit tests in watch mode                                                                                 |
+| `npm run test:unit:ci`    | Run Vitest with coverage                                                                                            |
+| `npm run test:e2e`        | Run Playwright end-to-end tests                                                                                     |
+| `npm run test:e2e:ui`     | Run Playwright tests with interactive UI                                                                            |
+| `npm run test:e2e:visual` | Run visual regression tests with (Playwright + Applitools ) — needs `APPLITOOLS_API_KEY`                            |
+| `npm run test:storybook`  | Run Storybook visual tests with (Applitools) — needs `APPLITOOLS_API_KEY` and `npm i -g @applitools/eyes-storybook` |
 
 More: [Playwright CLI](https://playwright.dev/docs/test-cli)
 

--- a/applitools.config.cjs
+++ b/applitools.config.cjs
@@ -1,8 +1,5 @@
 // @ts-check
 
-/**
- * @type {import('@applitools/eyes-storybook').ApplitoolsConfig}
- */
 const config = {
   // Pin the Applitools app explicitly: unset, eyes-storybook falls back to the
   // package.json name, putting the story baselines in a different app than the
@@ -12,8 +9,8 @@ const config = {
   dontCloseBatches: true,
   // 'nodiffs': visual diffs don't fail the job (the github integration reports them via a separate
   // commit status), but real errors (stories failed to load/render) still exit non-zero.
-  // The value is undocumented (typed as boolean) but supported — see eyes-storybook src/processResults.js.
-  exitcode: /** @type {boolean} */ (/** @type {unknown} */ ('nodiffs')),
+  // Undocumented — the published types declare boolean — but supported; see eyes-storybook src/processResults.js.
+  exitcode: 'nodiffs',
   waitBeforeCapture: async () => {
     const startTime = Date.now()
     const timeout = 60 * 1000

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,6 @@
       },
       "devDependencies": {
         "@applitools/eyes-playwright": "^1.47.15",
-        "@applitools/eyes-storybook": "^3.68.1",
         "@eslint/eslintrc": "^3.3.6",
         "@eslint/js": "^9.39.4",
         "@nx/eslint-plugin": "^23.1.1",
@@ -310,16 +309,6 @@
         "node": ">=12.13.0"
       }
     },
-    "node_modules/@applitools/dom-shared": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@applitools/dom-shared/-/dom-shared-1.2.3.tgz",
-      "integrity": "sha512-gg3iNsN6Qn94++dN/tirWSSWjXoTtK6JlzsuSOrak67lXFXfp+DJbVEqSpyEDpub4qX6b/NYBvlxmHHor7bC8A==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
     "node_modules/@applitools/dom-snapshot": {
       "version": "4.17.8",
       "resolved": "https://registry.npmjs.org/@applitools/dom-snapshot/-/dom-snapshot-4.17.8.tgz",
@@ -512,406 +501,6 @@
         }
       }
     },
-    "node_modules/@applitools/eyes-storybook": {
-      "version": "3.68.1",
-      "resolved": "https://registry.npmjs.org/@applitools/eyes-storybook/-/eyes-storybook-3.68.1.tgz",
-      "integrity": "sha512-lQTsqMqnxXDRxW2FpPgSy+bYUR/2OGrFwHY+H/NwW342KuX/IwJOcnJ/wkvNEy9LwUjEDyt0e0x4gQEJTzZxoA==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/core": "4.68.1",
-        "@applitools/driver": "1.26.8",
-        "@applitools/eyes": "1.45.1",
-        "@applitools/functional-commons": "1.6.0",
-        "@applitools/logger": "2.3.1",
-        "@applitools/monitoring-commons": "1.0.19",
-        "@applitools/spec-driver-puppeteer": "1.8.8",
-        "@applitools/ufg-client": "1.23.1",
-        "@applitools/utils": "1.15.2",
-        "@inquirer/prompts": "7.0.1",
-        "boxen": "4.2.0",
-        "chalk": "3.0.0",
-        "detect-port": "1.3.0",
-        "lodash": "^4.18.0",
-        "ora": "3.4.0",
-        "puppeteer": "24.11.1",
-        "semver": "7.6.2",
-        "strip-ansi": "6.0.0",
-        "throat": "6.0.2",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "eyes-setup": "bin/eyes-setup.js",
-        "eyes-storybook": "bin/eyes-storybook.js"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/core": {
-      "version": "4.68.1",
-      "resolved": "https://registry.npmjs.org/@applitools/core/-/core-4.68.1.tgz",
-      "integrity": "sha512-afVbcVnDN5iG6so7iLDVgXLvM3YEq8/B8J87l42OmIPVs3NlNW5agwXpbpOVK1l8694xEjXaUwsVuO4hxv4CeA==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/core-base": "1.38.1",
-        "@applitools/dom-capture": "11.8.5",
-        "@applitools/dom-snapshot": "4.17.9",
-        "@applitools/driver": "1.26.8",
-        "@applitools/ec-client": "1.12.42",
-        "@applitools/image": "1.3.1",
-        "@applitools/logger": "2.3.1",
-        "@applitools/nml-client": "1.11.40",
-        "@applitools/req": "1.11.3",
-        "@applitools/screenshoter": "3.12.28",
-        "@applitools/snippets": "2.9.6",
-        "@applitools/socket": "1.3.16",
-        "@applitools/ufg-client": "1.23.1",
-        "@applitools/utils": "1.15.2",
-        "abort-controller": "3.0.0",
-        "chalk": "4.1.2",
-        "node-fetch": "2.6.7",
-        "semver": "7.6.2",
-        "shell-quote": "^1.8.4",
-        "throat": "6.0.2"
-      },
-      "bin": {
-        "eyes-check-network": "dist/troubleshoot/check-network.js"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/core-base": {
-      "version": "1.38.1",
-      "resolved": "https://registry.npmjs.org/@applitools/core-base/-/core-base-1.38.1.tgz",
-      "integrity": "sha512-BRT5Xu0+OXofW/36W1K+2HQ2rRXub32PocqLEOQYwdBQWpTwRddF8T6TT1es4Z/vDvORTfoLVMsNel/B9iZKaQ==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/image": "1.3.1",
-        "@applitools/logger": "2.3.1",
-        "@applitools/req": "1.11.3",
-        "@applitools/utils": "1.15.2",
-        "abort-controller": "3.0.0",
-        "chalk": "^3.0.0",
-        "throat": "6.0.2"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/core/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/dom-capture": {
-      "version": "11.8.5",
-      "resolved": "https://registry.npmjs.org/@applitools/dom-capture/-/dom-capture-11.8.5.tgz",
-      "integrity": "sha512-6DHjuGCMyXLN3DIQh5edPEQvXw/dgGMCEtRrPvENLI5ZKE4qi+qYBMLOrMRDWKx5zILe+lI3tvb41xSu53wEAA==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/dom-shared": "1.2.3",
-        "@applitools/functional-commons": "1.6.0"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/dom-snapshot": {
-      "version": "4.17.9",
-      "resolved": "https://registry.npmjs.org/@applitools/dom-snapshot/-/dom-snapshot-4.17.9.tgz",
-      "integrity": "sha512-F0tH32XTgm2j7Q+gWUqi81vFIVtN2fCNpNZWRw8POo5xeBBkqlIJgfsr6lobYP6tKB+PeazPuMKiufblUBiscA==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/dom-shared": "1.2.3",
-        "@applitools/functional-commons": "1.6.0",
-        "css-tree": "^3.1.0",
-        "pako": "1.0.11",
-        "throat": "6.0.2"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/driver": {
-      "version": "1.26.8",
-      "resolved": "https://registry.npmjs.org/@applitools/driver/-/driver-1.26.8.tgz",
-      "integrity": "sha512-Y0shXOYecKbd/+5bNuBblbFSIYdBkqIcdM3+NnPGMZUqphrC3s34fII6yigJHHj1z7Dke4mLyFsW9N2VA6X0Cw==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/logger": "2.3.1",
-        "@applitools/snippets": "2.9.6",
-        "@applitools/utils": "1.15.2",
-        "semver": "7.6.2"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/ec-client": {
-      "version": "1.12.42",
-      "resolved": "https://registry.npmjs.org/@applitools/ec-client/-/ec-client-1.12.42.tgz",
-      "integrity": "sha512-Z7mbacaGnEHULTP5Na473BKPQBfEzDogvqnSyEwAl7a6pDRFbhE4gyr9E8zTbN+Uaw9Yefws+rU2v0nwlX0tNA==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/core-base": "1.38.1",
-        "@applitools/driver": "1.26.8",
-        "@applitools/logger": "2.3.1",
-        "@applitools/req": "1.11.3",
-        "@applitools/socket": "1.3.16",
-        "@applitools/spec-driver-webdriver": "1.6.8",
-        "@applitools/utils": "1.15.2",
-        "abort-controller": "3.0.0",
-        "yargs": "^17.7.2"
-      },
-      "bin": {
-        "ec-client": "dist/cli/cli.js",
-        "eg-client": "dist/cli/cli.js"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "optionalDependencies": {
-        "@applitools/tunnel-client": ">=1.12.3"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/eyes": {
-      "version": "1.45.1",
-      "resolved": "https://registry.npmjs.org/@applitools/eyes/-/eyes-1.45.1.tgz",
-      "integrity": "sha512-04sjVAceVyDdhkr2AqGvNzF7BYR7Hup1Iqxa9vnquhimgYHXH/AC6lHUTdtu61mH2MBdyEZvoZpWpE+Ykwfv4Q==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/core": "4.68.1",
-        "@applitools/logger": "2.3.1",
-        "@applitools/utils": "1.15.2",
-        "chalk": "4.1.2",
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "eyes": "dist/cli/cli.js"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/eyes/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/image": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@applitools/image/-/image-1.3.1.tgz",
-      "integrity": "sha512-qQYXqRAZOBHB6UQDQyAS1xKE0mQBmYW3aMfbm2O8+hkIE2rzQe83Jd4PG8S1+qnzf1h4BT2n10SoCcLF/VI2fg==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/logger": "2.3.1",
-        "@applitools/utils": "1.15.2",
-        "bmpimagejs": "1.0.4",
-        "jpeg-js": "0.4.4",
-        "omggif": "1.0.10",
-        "png-async": "0.9.4",
-        "sharp": "^0.34.5"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/logger": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@applitools/logger/-/logger-2.3.1.tgz",
-      "integrity": "sha512-/z2TfbvVmMqNoh2CL9KV+BjdYj/ATqTneO9aDQekf6N2Wx2AhAGVp1+bkNqRoodYhPmYVb5LycuCVbkAcGCpqw==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/utils": "1.15.2",
-        "chalk": "4.1.2",
-        "debug": "4.3.4"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/logger/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/nml-client": {
-      "version": "1.11.40",
-      "resolved": "https://registry.npmjs.org/@applitools/nml-client/-/nml-client-1.11.40.tgz",
-      "integrity": "sha512-e6rTbfCfINTAAQ1IV/bh2WQRAbNNLfzpu7lR6xYetbma8uFT7kpPaHcav8TUR+pjZk2TKu2T65c4cPcMSGo+Qw==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/logger": "2.3.1",
-        "@applitools/req": "1.11.3",
-        "@applitools/utils": "1.15.2"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "@applitools/core-base": "1.38.1"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/req": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@applitools/req/-/req-1.11.3.tgz",
-      "integrity": "sha512-DIpMe4DU8zSYTbJjpvJAjN+/GpGQXpItMKV2VPfV/djY9fIhlZUDaarjVrht2Y5Me4lN6eZddSL7Xmyo/o7l/A==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/logger": "2.3.1",
-        "@applitools/utils": "1.15.2",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6"
-      },
-      "engines": {
-        "node": ">=16.13.0"
-      },
-      "optionalDependencies": {
-        "undici": ">=6.23.0 <8.0.0"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/screenshoter": {
-      "version": "3.12.28",
-      "resolved": "https://registry.npmjs.org/@applitools/screenshoter/-/screenshoter-3.12.28.tgz",
-      "integrity": "sha512-QLuxVp03/5vJLd8gHkixvI+MfPp0Flc02hBnTCJzsO9bVx5HEfdHZ26opRNS+yqyvQ7nWep4RB0MDPLYVaoJyw==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/image": "1.3.1",
-        "@applitools/logger": "2.3.1",
-        "@applitools/snippets": "2.9.6",
-        "@applitools/utils": "1.15.2"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/socket": {
-      "version": "1.3.16",
-      "resolved": "https://registry.npmjs.org/@applitools/socket/-/socket-1.3.16.tgz",
-      "integrity": "sha512-G5wqj9yQ6Ki5kaQk7OeTxylMHdmvqWreWZoVxoVcUX/4rzLtXkEbZWm7AX6Ym5DfrcCwCEuP6204Cq4tdHP86g==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/logger": "2.3.1",
-        "@applitools/utils": "1.15.2"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/spec-driver-webdriver": {
-      "version": "1.6.8",
-      "resolved": "https://registry.npmjs.org/@applitools/spec-driver-webdriver/-/spec-driver-webdriver-1.6.8.tgz",
-      "integrity": "sha512-Eupo87gMKfywNPublu2l0WfL1hmUVdhw1EQuMzJ9Y/Jb0mJKUfEYGdInuNPNa5FfACvpzFk5//ScZxzqxOoljQ==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/driver": "1.26.8",
-        "@applitools/utils": "1.15.2",
-        "http-proxy-agent": "^7.0.2",
-        "https-proxy-agent": "^7.0.6"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "webdriver": ">=6.0.0"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/ufg-client": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/@applitools/ufg-client/-/ufg-client-1.23.1.tgz",
-      "integrity": "sha512-BOsT3DtZHZSPKqQqvQt1biu3Yw7GiSVfZ+mWddquME5c7i5triJD8WHit6ewmm6WtMN4bb38j6jYCstVegJmQw==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/image": "1.3.1",
-        "@applitools/logger": "2.3.1",
-        "@applitools/req": "1.11.3",
-        "@applitools/utils": "1.15.2",
-        "@xmldom/xmldom": "^0.8.12",
-        "abort-controller": "3.0.0",
-        "css-tree": "^3.1.0",
-        "throat": "6.0.2"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/@applitools/utils": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@applitools/utils/-/utils-1.15.2.tgz",
-      "integrity": "sha512-LrqHBTuI/e219Ly+Fn4pEREzDVXhrhb0oF1gOAvMhblGFq0AAoSbzobuzlKwufySYfHoKNxnR1vurT4Y7ZRWbQ==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@applitools/eyes-storybook/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@applitools/functional-commons": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@applitools/functional-commons/-/functional-commons-1.6.0.tgz",
@@ -954,19 +543,6 @@
       },
       "engines": {
         "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@applitools/monitoring-commons": {
-      "version": "1.0.19",
-      "resolved": "https://registry.npmjs.org/@applitools/monitoring-commons/-/monitoring-commons-1.0.19.tgz",
-      "integrity": "sha512-rzEOvGoiEF4KnK0PJ9I0btdwnaNlIPLYhjF1vTEG15PoucbbKpix9fYusxWlDG7kMiZya8ZycVPc0woVlNaHRQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "debug": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/@applitools/nml-client": {
@@ -1032,16 +608,6 @@
         "node": ">=12.13.0"
       }
     },
-    "node_modules/@applitools/snippets": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/@applitools/snippets/-/snippets-2.9.6.tgz",
-      "integrity": "sha512-u9TPUxa89vkUDH1S3+k3DAEsZZQHV3CFInT4LSTdELlwW92FWaQmb4sRQeSHwnTLZKDhlzMn5P9t/OF2pR/8+w==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
     "node_modules/@applitools/socket": {
       "version": "1.3.15",
       "resolved": "https://registry.npmjs.org/@applitools/socket/-/socket-1.3.15.tgz",
@@ -1071,64 +637,6 @@
       },
       "peerDependencies": {
         "playwright": ">=1.0.0"
-      }
-    },
-    "node_modules/@applitools/spec-driver-puppeteer": {
-      "version": "1.8.8",
-      "resolved": "https://registry.npmjs.org/@applitools/spec-driver-puppeteer/-/spec-driver-puppeteer-1.8.8.tgz",
-      "integrity": "sha512-29R8mnFrptnGQMGOe55piKLW9bNirPp6BpnyoObt/v+f8UjKts2y2mkphcHlnR2kLZCdIKJMAb5/BvUT2Gr+WA==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/driver": "1.26.8",
-        "@applitools/utils": "1.15.2"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "puppeteer": ">=5.3.0"
-      }
-    },
-    "node_modules/@applitools/spec-driver-puppeteer/node_modules/@applitools/driver": {
-      "version": "1.26.8",
-      "resolved": "https://registry.npmjs.org/@applitools/driver/-/driver-1.26.8.tgz",
-      "integrity": "sha512-Y0shXOYecKbd/+5bNuBblbFSIYdBkqIcdM3+NnPGMZUqphrC3s34fII6yigJHHj1z7Dke4mLyFsW9N2VA6X0Cw==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/logger": "2.3.1",
-        "@applitools/snippets": "2.9.6",
-        "@applitools/utils": "1.15.2",
-        "semver": "7.6.2"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@applitools/spec-driver-puppeteer/node_modules/@applitools/logger": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@applitools/logger/-/logger-2.3.1.tgz",
-      "integrity": "sha512-/z2TfbvVmMqNoh2CL9KV+BjdYj/ATqTneO9aDQekf6N2Wx2AhAGVp1+bkNqRoodYhPmYVb5LycuCVbkAcGCpqw==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@applitools/utils": "1.15.2",
-        "chalk": "4.1.2",
-        "debug": "4.3.4"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      }
-    },
-    "node_modules/@applitools/spec-driver-puppeteer/node_modules/@applitools/utils": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@applitools/utils/-/utils-1.15.2.tgz",
-      "integrity": "sha512-LrqHBTuI/e219Ly+Fn4pEREzDVXhrhb0oF1gOAvMhblGFq0AAoSbzobuzlKwufySYfHoKNxnR1vurT4Y7ZRWbQ==",
-      "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
-      "engines": {
-        "node": ">=12.13.0"
       }
     },
     "node_modules/@applitools/spec-driver-webdriver": {
@@ -7568,6 +7076,7 @@
       "integrity": "sha512-eifa0o+i8dERnngJwKrfp3dEq7ia5XFyoqB17S4gK8GhsQE4/P8nxOfQSE0zQHxzzLo/cmF+7+ywEQ7wK7Fb+w==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.1",
         "extract-zip": "^2.0.1",
@@ -7590,6 +7099,7 @@
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -7607,7 +7117,8 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@puppeteer/browsers/node_modules/semver": {
       "version": "7.8.4",
@@ -7615,6 +7126,7 @@
       "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -9226,7 +8738,8 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@trivago/prettier-plugin-sort-imports": {
       "version": "6.0.2",
@@ -9621,6 +9134,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -10840,16 +10354,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/address": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
-      "integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -10921,16 +10425,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true
-    },
-    "node_modules/ansi-align": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
-      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.1.0"
-      }
     },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
@@ -11374,6 +10868,7 @@
       "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "react-native-b4a": "*"
       },
@@ -11497,6 +10992,7 @@
       "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "bare-abort-controller": "*"
       },
@@ -11512,6 +11008,7 @@
       "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
@@ -11537,6 +11034,7 @@
       "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "bare": ">=1.14.0"
       }
@@ -11547,6 +11045,7 @@
       "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
@@ -11557,6 +11056,7 @@
       "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "b4a": "^1.8.1",
         "streamx": "^2.25.0",
@@ -11585,6 +11085,7 @@
       "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "bare-path": "^3.0.0"
       }
@@ -11628,6 +11129,7 @@
       "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -11683,43 +11185,6 @@
       "integrity": "sha512-21oKU7kbRt2OgOOj7rdiNr/yznDNUQ585plxR00rsmECcZr+6O1oCwB8OIoSHk/bDhbG8mFXIdeQuCPHgZ6QBw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/boxen": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
-      "integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-align": "^3.0.0",
-        "camelcase": "^5.3.1",
-        "chalk": "^3.0.0",
-        "cli-boxes": "^2.2.0",
-        "string-width": "^4.1.0",
-        "term-size": "^2.1.0",
-        "type-fest": "^0.8.1",
-        "widest-line": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/boxen/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.15",
@@ -11809,6 +11274,7 @@
       "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -11929,16 +11395,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/camelize": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
@@ -12049,48 +11505,11 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/chromium-bidi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-5.1.0.tgz",
-      "integrity": "sha512-9MSRhWRVoRPDG0TgzkHrshFSJJNZzfY5UFqUMuksg7zL1yoZIZ3jLB0YAgHclbiAxPI86pBnwDX1tbzoiV8aFw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "mitt": "^3.0.1",
-        "zod": "^3.24.1"
-      },
-      "peerDependencies": {
-        "devtools-protocol": "*"
-      }
-    },
-    "node_modules/chromium-bidi/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
       "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
       "license": "MIT"
-    },
-    "node_modules/cli-boxes": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
-      "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/cli-cursor": {
       "version": "3.1.0",
@@ -12588,6 +12007,7 @@
       "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -12878,48 +12298,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/detect-port": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.3.0.tgz",
-      "integrity": "sha512-E+B1gzkl2gqxt1IhUzwjrxBKRqx1UzC3WLONHinn8S3T6lwV/agVCyitiFOsGJ/eYuEUBvD71MZHy3Pv1G9doQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "address": "^1.0.1",
-        "debug": "^2.6.0"
-      },
-      "bin": {
-        "detect": "bin/detect-port",
-        "detect-port": "bin/detect-port"
-      },
-      "engines": {
-        "node": ">= 4.2.1"
-      }
-    },
-    "node_modules/detect-port/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/detect-port/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/devtools-protocol": {
-      "version": "0.0.1464554",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1464554.tgz",
-      "integrity": "sha512-CAoP3lYfwAGQTaAXYvA6JZR0fjGUb7qec1qf4mToyoH2TZgUFeIqYcjh6f9jNuhHfuZiEdH+PONHYrLhRQX6aw==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -13862,6 +13240,7 @@
       "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "bare-events": "^2.7.0"
       }
@@ -13882,6 +13261,7 @@
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
@@ -13903,6 +13283,7 @@
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -13940,7 +13321,8 @@
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -14215,6 +13597,7 @@
       "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pend": "~1.2.0"
       }
@@ -14656,6 +14039,7 @@
       "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
@@ -15301,6 +14685,7 @@
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -16654,7 +16039,8 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -16957,7 +16343,8 @@
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
       "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/modern-tar": {
       "version": "0.7.6",
@@ -17946,195 +17333,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/ora": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
-      "integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.4.2",
-        "cli-cursor": "^2.1.0",
-        "cli-spinners": "^2.0.0",
-        "log-symbols": "^2.2.0",
-        "strip-ansi": "^5.2.0",
-        "wcwidth": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ora/node_modules/ansi-regex": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
-      "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ora/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ora/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ora/node_modules/cli-cursor": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-      "integrity": "sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ora/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/ora/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ora/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/ora/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ora/node_modules/log-symbols": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
-      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ora/node_modules/mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ora/node_modules/onetime": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-      "integrity": "sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ora/node_modules/restore-cursor": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-      "integrity": "sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^2.0.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ora/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/ora/node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/ora/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/outvariant": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
@@ -18292,6 +17490,7 @@
       "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.1.2",
@@ -18312,6 +17511,7 @@
       "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -18327,6 +17527,7 @@
       "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -18529,7 +17730,8 @@
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -18894,6 +18096,7 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -18921,6 +18124,7 @@
       "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -18941,6 +18145,7 @@
       "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -18950,7 +18155,8 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
@@ -18968,6 +18174,7 @@
       "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -18981,99 +18188,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/puppeteer": {
-      "version": "24.11.1",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.11.1.tgz",
-      "integrity": "sha512-QbccB/LgxX4tSZRzr9KQ1Jajdvu3n35Dlf/Otjz0QfR+6mDoZdMWLcWF94uQoC3OJerCyYm5hlU2Ru4nBoId2A==",
-      "deprecated": "< 24.15.0 is no longer supported",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@puppeteer/browsers": "2.10.5",
-        "chromium-bidi": "5.1.0",
-        "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1464554",
-        "puppeteer-core": "24.11.1",
-        "typed-query-selector": "^2.12.0"
-      },
-      "bin": {
-        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/puppeteer-core": {
-      "version": "24.11.1",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.11.1.tgz",
-      "integrity": "sha512-I0Gv3jWBRY9E3NTBElp7br7Gaid5RbFTxCRRMHym1kCf0ompO0Pel4REGsGDwMWkg3uwFzIH7t7qXs3T4DKRWA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@puppeteer/browsers": "2.10.5",
-        "chromium-bidi": "5.1.0",
-        "debug": "^4.4.1",
-        "devtools-protocol": "0.0.1464554",
-        "typed-query-selector": "^2.12.0",
-        "ws": "^8.18.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/puppeteer-core/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/puppeteer/node_modules/cosmiconfig": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.2.tgz",
-      "integrity": "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/qified": {
@@ -20302,6 +19416,7 @@
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
@@ -20326,6 +19441,7 @@
       "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "^10.1.1",
         "smart-buffer": "^4.2.0"
@@ -20341,6 +19457,7 @@
       "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -20554,6 +19671,7 @@
       "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
@@ -21382,6 +20500,7 @@
       "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
@@ -21397,6 +20516,7 @@
       "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "b4a": "^1.6.4",
         "bare-fs": "^4.5.5",
@@ -21446,21 +20566,9 @@
       "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "streamx": "^2.12.5"
-      }
-    },
-    "node_modules/term-size": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/term-size/-/term-size-2.2.1.tgz",
-      "integrity": "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/text-decoder": {
@@ -21469,6 +20577,7 @@
       "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "b4a": "^1.6.4"
       }
@@ -21720,16 +20829,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -21807,13 +20906,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/typed-query-selector": {
-      "version": "2.12.2",
-      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
-      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "6.0.3",
@@ -22931,19 +22023,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/widest-line": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-3.1.0.tgz",
-      "integrity": "sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -23151,6 +22230,7 @@
       "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
         "fd-slicer": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
   },
   "devDependencies": {
     "@applitools/eyes-playwright": "^1.47.15",
-    "@applitools/eyes-storybook": "^3.68.1",
     "@eslint/eslintrc": "^3.3.6",
     "@eslint/js": "^9.39.4",
     "@nx/eslint-plugin": "^23.1.1",


### PR DESCRIPTION
# Description

Remove dependency `@applitools/eyes-storybook` from `package.json` because nothing uses it.

The CI workflow install it globaly in `validate.yaml:266`
```
      - run: npm i -g @applitools/eyes-storybook
```