### PR TITLE
test: stop storybook visual tests capturing empty charts

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,5 +1,6 @@
 import type { Preview } from '@storybook/react-vite'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { http, HttpResponse } from 'msw'
 import { initialize, mswLoader } from 'msw-storybook-addon'
 import { Suspense, useEffect } from 'react'
 import { BrowserRouter } from 'react-router'
@@ -21,13 +22,27 @@ const queryClient = new QueryClient({
 
 queryClient.setQueryData(['version'], '1.2.3')
 
+/**
+ * Anything that resolves an operator goes through the memoized `getAgencyList()` singleton, and
+ * `fetchGroupBy` drops every row whose operator is missing from it. Left unmocked it reaches the
+ * live API, which the visual-test CI job points at 127.0.0.1 — so the agency list comes back empty
+ * and each chart silently renders nothing. A story may still override this with its own handler.
+ */
+const agencyListHandler = http.get('*/gtfs_agencies/list', async () => {
+  const { agencies } = await import('./mockData')
+  return HttpResponse.json(agencies)
+})
+
 const preview: Preview = {
   beforeAll: () => {
-    initialize({
-      serviceWorker: {
-        url: './mockServiceWorker.js',
+    initialize(
+      {
+        serviceWorker: {
+          url: './mockServiceWorker.js',
+        },
       },
-    })
+      [agencyListHandler],
+    )
   },
   loaders: [mswLoader],
   parameters: {

--- a/applitools.config.cjs
+++ b/applitools.config.cjs
@@ -14,12 +14,15 @@ const config = {
   // commit status), but real errors (stories failed to load/render) still exit non-zero.
   // The value is undocumented (typed as boolean) but supported — see eyes-storybook src/processResults.js.
   exitcode: /** @type {boolean} */ (/** @type {unknown} */ ('nodiffs')),
+  // A story that is meant to stay in its loading state opts out with
+  // `parameters: { eyes: { waitBeforeCapture: <ms> } }`, which takes precedence over this.
   waitBeforeCapture: async () => {
     const startTime = Date.now()
     const timeout = 60 * 1000
     while (
-      document.querySelector('.ant-skeleton-content') ||
-      document.querySelector('.ant-skeleton')
+      document.querySelector(
+        '.ant-skeleton, .ant-skeleton-content, [data-testid="skeleton-loader"]',
+      )
     ) {
       await new Promise((resolve) => setTimeout(resolve, 100))
       const duration = Date.now() - startTime

--- a/applitools.config.cjs
+++ b/applitools.config.cjs
@@ -19,11 +19,7 @@ const config = {
   waitBeforeCapture: async () => {
     const startTime = Date.now()
     const timeout = 60 * 1000
-    while (
-      document.querySelector(
-        '.ant-skeleton, .ant-skeleton-content, [data-testid="skeleton-loader"]',
-      )
-    ) {
+    while (document.querySelector('[data-testid="skeleton-loader"]')) {
       await new Promise((resolve) => setTimeout(resolve, 100))
       const duration = Date.now() - startTime
       const isTimeout = duration > timeout

--- a/src/pages/components/map-related/MapWithLocationsAndPath.stories.tsx
+++ b/src/pages/components/map-related/MapWithLocationsAndPath.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from '@storybook/react-vite'
-import { http, HttpResponse } from 'msw'
 import { plannedRouteStops, positionGroups } from './mapStorybookData'
 import { MapWithLocationsAndPath } from './MapWithLocationsAndPath'
 
@@ -42,19 +41,6 @@ type Story = StoryObj<typeof meta>
 export const Default: Story = {}
 
 export const WhitData: Story = {
-  parameters: {
-    msw: {
-      handlers: [
-        http.get(
-          (info) => new URL(info.request.url).pathname === '/gtfs_agencies/list',
-          async () => {
-            const { agencies } = await import('../../../../.storybook/mockData')
-            return HttpResponse.json(agencies)
-          },
-        ),
-      ],
-    },
-  },
   args: {
     plannedRouteStops: plannedRouteStops,
     positionGroups: positionGroups,

--- a/src/pages/operator/OperatorRoutes.stories.tsx
+++ b/src/pages/operator/OperatorRoutes.stories.tsx
@@ -141,6 +141,8 @@ export const Default: Story = {}
 /** Skeleton placeholder while the routes request is in flight. */
 export const Loading: Story = {
   parameters: {
+    // The skeleton never resolves here, so opt out of the global wait-for-skeletons capture hook.
+    eyes: { waitBeforeCapture: 100 },
     msw: {
       handlers: [
         routesHandler(async () => {

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -89,8 +89,7 @@ export const waitForMapIdle = async (page: Page) => {
 }
 
 export const waitForSkeletonsToHide = async (page: Page) => {
-  // matches both the legacy antd skeleton and the MUI-based SkeletonLoader
-  const skeletons = page.locator('.ant-skeleton-content, [data-testid="skeleton-loader"]')
+  const skeletons = page.locator('[data-testid="skeleton-loader"]')
   while ((await skeletons.count()) > 0) {
     await skeletons.last().waitFor({ state: 'hidden' })
   }


### PR DESCRIPTION
# Description

Several charts were empty in storybook eyes. 

For example:
<img width="1731" height="770" alt="image" src="https://github.com/user-attachments/assets/31e1c432-fe82-4d7d-90c7-a4d45de85222" />
