### PR TITLE
test: fix a flaky storybook test

### DIFF
--- a/applitools.config.cjs
+++ b/applitools.config.cjs
@@ -16,18 +16,66 @@ const config = {
   exitcode: /** @type {boolean} */ (/** @type {unknown} */ ('nodiffs')),
   // A story that is meant to stay in its loading state opts out with
   // `parameters: { eyes: { waitBeforeCapture: <ms> } }`, which takes precedence over this.
+  //
+  // Three waits, in order: the story is on the page, its data has loaded, and it has
+  // stopped moving. Skipping the last one is what put a half-drawn line chart in a
+  // baseline — the skeleton clears when the data lands, ~1.5s before recharts finishes
+  // drawing, so "no skeleton" is not the same as "done rendering".
   waitBeforeCapture: async () => {
-    const startTime = Date.now()
-    const timeout = 60 * 1000
+    const MOUNT_TIMEOUT = 10 * 1000
+    const SKELETON_TIMEOUT = 60 * 1000
+    const SETTLE_TIMEOUT = 10 * 1000
+    // Long enough to bridge a frame at 60fps with room to spare, short enough that it
+    // costs nothing on a story that was already still.
+    const QUIET_MS = 250
+
+    const sleep = (/** @type {number} */ ms) => new Promise((resolve) => setTimeout(resolve, ms))
+    const root = () => document.querySelector('#storybook-root') || document.body
+
+    // 1. The story has to actually be on the page. Run before React has committed
+    //    anything and every check below passes trivially on an empty document.
+    const mountDeadline = Date.now() + MOUNT_TIMEOUT
+    while (root().childElementCount === 0 && Date.now() < mountDeadline) {
+      await sleep(50)
+    }
+
+    // 2. Data still loading.
+    const skeletonDeadline = Date.now() + SKELETON_TIMEOUT
     while (document.querySelector('[data-testid="skeleton-loader"]')) {
-      await new Promise((resolve) => setTimeout(resolve, 100))
-      const duration = Date.now() - startTime
-      const isTimeout = duration > timeout
-      if (isTimeout) {
+      if (Date.now() > skeletonDeadline) {
         console.warn('Waited too long for skeletons to disappear.')
         throw new Error('Skeletons did not disappear in time on ' + window.location.href)
       }
+      await sleep(100)
     }
+
+    // 3. Still animating. recharts draws a chart by rewriting SVG attributes from JS on
+    //    every frame, which `document.getAnimations()` cannot see — a MutationObserver
+    //    going quiet is the signal that it finished. Times out instead of throwing: a
+    //    story that animates forever should still be captured, just not waited on.
+    await new Promise((resolve) => {
+      /** @type {ReturnType<typeof setTimeout>} */ let quietTimer
+      /** @type {ReturnType<typeof setTimeout>} */ let hardTimer
+      function finish() {
+        observer.disconnect()
+        clearTimeout(quietTimer)
+        clearTimeout(hardTimer)
+        resolve(undefined)
+      }
+      const observer = new MutationObserver(() => {
+        clearTimeout(quietTimer)
+        quietTimer = setTimeout(finish, QUIET_MS)
+      })
+      observer.observe(document.documentElement, {
+        subtree: true,
+        childList: true,
+        attributes: true,
+        characterData: true,
+      })
+      quietTimer = setTimeout(finish, QUIET_MS)
+      hardTimer = setTimeout(finish, SETTLE_TIMEOUT)
+    })
+
     return true
   },
   // puppeteerOptions: {headless: false, devtools: true},

--- a/applitools.config.cjs
+++ b/applitools.config.cjs
@@ -17,42 +17,38 @@ const config = {
   // A story that is meant to stay in its loading state opts out with
   // `parameters: { eyes: { waitBeforeCapture: <ms> } }`, which takes precedence over this.
   //
-  // Three waits, in order: the story is on the page, its data has loaded, and it has
-  // stopped moving. Skipping the last one is what put a half-drawn line chart in a
-  // baseline — the skeleton clears when the data lands, ~1.5s before recharts finishes
-  // drawing, so "no skeleton" is not the same as "done rendering".
+  // "No skeleton" is not the same as "done rendering": the skeleton clears when the data
+  // lands, ~1.5s before recharts has finished drawing the chart it hands off to. That gap
+  // is what put a half-drawn line chart in a baseline, so wait for the charts too.
   waitBeforeCapture: async () => {
-    const MOUNT_TIMEOUT = 10 * 1000
-    const SKELETON_TIMEOUT = 60 * 1000
-    const SETTLE_TIMEOUT = 10 * 1000
-    // Long enough to bridge a frame at 60fps with room to spare, short enough that it
-    // costs nothing on a story that was already still.
-    const QUIET_MS = 250
-
-    const sleep = (/** @type {number} */ ms) => new Promise((resolve) => setTimeout(resolve, ms))
-    const root = () => document.querySelector('#storybook-root') || document.body
-
-    // 1. The story has to actually be on the page. Run before React has committed
-    //    anything and every check below passes trivially on an empty document.
-    const mountDeadline = Date.now() + MOUNT_TIMEOUT
-    while (root().childElementCount === 0 && Date.now() < mountDeadline) {
-      await sleep(50)
-    }
-
-    // 2. Data still loading.
-    const skeletonDeadline = Date.now() + SKELETON_TIMEOUT
+    const startTime = Date.now()
+    const timeout = 60 * 1000
     while (document.querySelector('[data-testid="skeleton-loader"]')) {
-      if (Date.now() > skeletonDeadline) {
+      await new Promise((resolve) => setTimeout(resolve, 100))
+      const duration = Date.now() - startTime
+      const isTimeout = duration > timeout
+      if (isTimeout) {
         console.warn('Waited too long for skeletons to disappear.')
         throw new Error('Skeletons did not disappear in time on ' + window.location.href)
       }
-      await sleep(100)
     }
 
-    // 3. Still animating. recharts draws a chart by rewriting SVG attributes from JS on
-    //    every frame, which `document.getAnimations()` cannot see — a MutationObserver
-    //    going quiet is the signal that it finished. Times out instead of throwing: a
-    //    story that animates forever should still be captured, just not waited on.
+    // recharts animates by rewriting SVG attributes from JS on every frame, which
+    // `document.getAnimations()` cannot see — a MutationObserver going quiet is the
+    // signal that it finished. Scoped to the chart subtrees, and skipped entirely when
+    // the story has no chart, so the ~85% of stories that hold none pay nothing. (Waiting
+    // for the whole document to go quiet instead is ~1.4s on every story, which doubled
+    // the visual-test job for one story's benefit.) Times out rather than throwing: a
+    // chart that animates forever should still be captured, just not waited on.
+    const SETTLE_TIMEOUT = 10 * 1000
+    // Long enough to bridge a frame at 60fps with room to spare, short enough that it
+    // costs nothing on a chart that was already still.
+    const QUIET_MS = 250
+    // ResponsiveContainer renders its div on mount, before the chart inside it exists, so
+    // this matches a chart story even while the chart is still being laid out.
+    const charts = document.querySelectorAll('.recharts-responsive-container, .recharts-wrapper')
+    if (charts.length === 0) return true
+
     await new Promise((resolve) => {
       /** @type {ReturnType<typeof setTimeout>} */ let quietTimer
       /** @type {ReturnType<typeof setTimeout>} */ let hardTimer
@@ -66,12 +62,14 @@ const config = {
         clearTimeout(quietTimer)
         quietTimer = setTimeout(finish, QUIET_MS)
       })
-      observer.observe(document.documentElement, {
-        subtree: true,
-        childList: true,
-        attributes: true,
-        characterData: true,
-      })
+      charts.forEach((chart) =>
+        observer.observe(chart, {
+          subtree: true,
+          childList: true,
+          attributes: true,
+          characterData: true,
+        }),
+      )
       quietTimer = setTimeout(finish, QUIET_MS)
       hardTimer = setTimeout(finish, SETTLE_TIMEOUT)
     })


### PR DESCRIPTION
# Description
One chart was captured mid-rendering.

## screenshots
<img width="1739" height="858" alt="image" src="https://github.com/user-attachments/assets/87467a22-2c84-4c11-888b-f0b20d920efc" />