### PR TITLE
test: Trace e2e tests only on-first-retry

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -341,8 +341,8 @@ jobs:
         if: always()
         run: |
           mkdir -p playwright-artifact
-          if [ -d test-results ]; then cp -r test-results/* playwright-artifact/; fi
-          if [ -d playwright-report ]; then cp -r playwright-report/* playwright-artifact/; fi
+          if [ -d test-results ]; then cp -r test-results/. playwright-artifact/; fi
+          if [ -d playwright-report ]; then cp -r playwright-report/. playwright-artifact/; fi
           touch playwright-artifact/.keep
       - name: Upload Playwright test artifact
         if: always()
@@ -385,7 +385,7 @@ jobs:
         with:
           sha: ${{ github.event.pull_request.head.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          description: 'Playwright html report with traces'
+          description: 'Playwright html report'
           status: ${{needs.test.result}}
           context: 'Test results (click to see!)'
           targetUrl: 'https://s3.amazonaws.com/noam-gaash.co.il/${{ github.run_id }}/open-bus/${{ github.event.pull_request.head.sha }}/test-results/index.html'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,7 +35,7 @@ export default defineConfig<EyesFixture>({
     locale: 'he-IL',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: process.env.CI ? 'on' : 'on-all-retries',
+    trace: process.env.CI ? 'on-first-retry' : 'on-all-retries',
 
     timezoneId: 'Asia/Jerusalem',
 


### PR DESCRIPTION
# Description

Set playwright to trace the e2e tests only on-first-retry instead of tracing and uploading artifact of every run.

It is estimated to save ~40% of the time the job takes - but the cost is that any flaky test will need more manual debugging.