### PR TITLE
refactor: persist query cache to idb

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "geolib": "^3.3.4",
         "i18next": "^26.3.6",
         "i18next-fs-backend": "^2.6.5",
+        "idb-keyval": "^6.3.0",
         "leaflet": "^1.9.4",
         "leaflet.markercluster": "^1.5.3",
         "react": "^19.2.4",
@@ -15157,6 +15158,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.3.0.tgz",
+      "integrity": "sha512-um+2dgAWmYsu615EXpWVwSmapJhON0G43t3Ka/EVaohzPQXSMqKEqeDK/oIW3Ow+BXaF2PvSc+oBTFp793A5Ow==",
+      "license": "Apache-2.0"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "geolib": "^3.3.4",
     "i18next": "^26.3.6",
     "i18next-fs-backend": "^2.6.5",
+    "idb-keyval": "^6.3.0",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
     "react": "^19.2.4",

--- a/src/api/gapsService.ts
+++ b/src/api/gapsService.ts
@@ -7,9 +7,9 @@ export type Gap = {
   gtfsRideId?: number
 }
 
-// What actually lives in the (localStorage-persisted) React Query cache: JSON-native
-// only. dayjs times are held as ISO strings and revived at the UI edge (GapsTable),
-// so a rehydrated cache can never hand the table a bare string to call .format() on.
+// What actually lives in the persisted React Query cache. dayjs times are held as ISO
+// strings and revived at the UI edge (GapsTable) — persistence is a structured clone,
+// which would otherwise hand the table a Dayjs-shaped object with no .format() on it.
 export type SerializedGap = {
   plannedStartTime?: string
   actualStartTime?: string

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,11 @@
 import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister'
 import { QueryClient } from '@tanstack/react-query'
-import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
+import {
+  type PersistedClient,
+  PersistQueryClientProvider,
+  removeOldestQuery,
+} from '@tanstack/react-query-persist-client'
+import { createStore, del, get, set } from 'idb-keyval'
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import ReactGAImport from 'react-ga4'
@@ -8,9 +13,30 @@ import App from './App'
 import './locale/allTranslations'
 import './index.scss'
 
+const queryCacheStore = createStore('open-bus-map-search', 'react-query')
+
+/** One dashboard visit persists ~2MB of a ~5MB localStorage budget, and over the quota the
+ *  persister has nowhere to report the failure: it abandons the whole write silently, so the
+ *  app simply stops persisting. IndexedDB's quota is a share of free disk instead. */
 const persister = createAsyncStoragePersister({
-  storage: window.localStorage,
+  storage: {
+    getItem: (key) => get(key, queryCacheStore),
+    setItem: (key, value) => set(key, value, queryCacheStore),
+    removeItem: (key) => del(key, queryCacheStore),
+  },
+  /* IndexedDB stores a structured clone, so the cache goes to disk as an object graph and
+   * comes back as one — skipping a JSON round trip over megabytes, and keeping `Date` fields
+   * as Dates instead of the strings `JSON.parse` would hand back. The persister types the
+   * stored value as a string because most storages can only hold one; nothing between these
+   * two functions ever treats it as such. */
+  serialize: (client) => client as unknown as string,
+  deserialize: (stored) => stored as unknown as PersistedClient,
+  retry: removeOldestQuery,
 })
+
+// Nothing reads the localStorage cache any more, and an abandoned one keeps its megabytes for
+// the life of the browser profile.
+window.localStorage.removeItem('REACT_QUERY_OFFLINE_CACHE')
 
 /** An answer with nothing in it — `[]`, or the `null` a page returns instead of rethrowing.
  *  "There is genuinely nothing" and "this date is not ingested yet" look identical from


### PR DESCRIPTION
# Description

Move react-query persistency from localStorage to IndexedDB.
* It is faster
* More importantly: it has much bigger quota